### PR TITLE
add draw3D inside jupyter functionality

### DIFF
--- a/optiland/optic.py
+++ b/optiland/optic.py
@@ -97,7 +97,7 @@ class Optic:
             return self.polarization
 
     def add_surface(self, new_surface=None, surface_type='standard',
-                    comment='', index=None, is_stop=False, material='air', **kwargs):
+                    index=None, is_stop=False, material='air', **kwargs):
         """
         Adds a new surface to the optic.
 
@@ -119,8 +119,8 @@ class Optic:
             ValueError: If index is not provided when defining a new surface.
         """
         self.surface_group.add_surface(
-            new_surface=new_surface, surface_type=surface_type, comment=comment,
-            index=index, is_stop=is_stop, material=material, **kwargs
+            new_surface=new_surface, surface_type=surface_type, index=index,
+            is_stop=is_stop, material=material, **kwargs
             )
 
     def add_field(self, y, x=0.0, vx=0.0, vy=0.0):
@@ -324,7 +324,7 @@ class Optic:
 
     def draw3D(self, fields='all', wavelengths='primary', num_rays=24,
                distribution='ring', figsize=(1200, 800), dark_mode=False,
-               reference=None):
+               reference=None, is_jupyter=False):
         """
         Draw a 3D representation of the optical system.
 
@@ -343,11 +343,23 @@ class Optic:
                 False.
             reference (str, optional): The reference rays to plot. Options
                 include "chief" and "marginal". Defaults to None.
+            is_jupyter (bool, optional): If the plot is required to be plotted 
+                inside the jupyter notebook/lab.
         """
-        viewer = OpticViewer3D(self)
-        viewer.view(fields, wavelengths, num_rays,
-                    distribution=distribution, figsize=figsize,
-                    dark_mode=dark_mode, reference=reference)
+        if is_jupyter:
+            viewer = OpticViewer3D(self)
+            widget = viewer.view(fields, wavelengths, num_rays,
+                        distribution=distribution, figsize=figsize,
+                        dark_mode=dark_mode, reference=reference,
+                        is_jupyter=is_jupyter)
+            return widget  # This will display the interactive visualization
+        
+        elif not is_jupyter:
+            viewer = OpticViewer3D(self)
+            viewer.view(fields, wavelengths, num_rays,
+                        distribution=distribution, figsize=figsize,
+                        dark_mode=dark_mode, reference=reference,
+                        is_jupyter=is_jupyter)
 
     def info(self):
         """Display the optical system information."""

--- a/optiland/visualization/visualization.py
+++ b/optiland/visualization/visualization.py
@@ -16,6 +16,7 @@ import vtk
 from optiland import materials
 from optiland.visualization.rays import Rays2D, Rays3D
 from optiland.visualization.system import OpticalSystem
+from ipyvtklink.viewer import ViewInteractiveWidget
 
 plt.rcParams.update({'font.size': 12, 'font.family': 'cambria'})
 
@@ -122,7 +123,7 @@ class OpticViewer3D:
 
     def view(self, fields='all', wavelengths='primary', num_rays=24,
              distribution='ring', figsize=(1200, 800), dark_mode=False,
-             reference=None):
+             reference=None, is_jupyter=False):
         """
         Visualizes the optical system in 3D.
 
@@ -141,6 +142,8 @@ class OpticViewer3D:
                 Defaults to False.
             reference (str, optional): The reference rays to plot. Options
                 include "chief" and "marginal". Defaults to None.
+            is_jupyter (bool, optional): If the plot is required to be plotted 
+                inside the jupyter notebook/lab.
         """
         renderer = vtk.vtkRenderer()
         self.ren_win.AddRenderer(renderer)
@@ -178,8 +181,13 @@ class OpticViewer3D:
         renderer.GetActiveCamera().Elevation(0)
         renderer.GetActiveCamera().Azimuth(150)
 
-        self.ren_win.Render()
-        self.iren.Start()
+        if is_jupyter:
+            print("Jupyter branch entered")
+            widget = ViewInteractiveWidget(self.ren_win)
+            return widget
+        else:
+            self.ren_win.Render()
+            self.iren.Start()
 
 
 class LensInfoViewer:
@@ -221,7 +229,6 @@ class LensInfoViewer:
             if surf.is_stop:
                 surf_type[-1] = 'Stop - ' + surf_type[-1]
 
-        comments = [surf.comment for surf in self.optic.surface_group.surfaces]
         radii = self.optic.surface_group.radii
         thicknesses = np.diff(self.optic.surface_group.positions.ravel(),
                               append=np.nan)
@@ -251,7 +258,6 @@ class LensInfoViewer:
 
         df = pd.DataFrame({
             'Type': surf_type,
-            'Comment': comments,
             'Radius': radii,
             'Thickness': thicknesses,
             'Material': mat,


### PR DESCRIPTION
Achieved drawing inside Jupyter, preventing the next code blocks from interruption. Used ipyvtklink, but I am not satisfied with its performance. Currently, the algorithm is controlled by a boolean input `is_jupyter` by the user, automatic detection of jupyter is straightforward but I kept it as a boolean for reproducibility for now. I don't know if we should move on from this sample, or just find a way to prevent 3D viewer interruption, or check if the default 3D viewing still interrupts in a QT environment.


Here are two examples to run, one static (I expected it to be interactive), and one interactive:

Starting with the imports and defining the lens system.
```python
from optiland.samples.objectives import CookeTriplet
from optiland.visualization.visualization import OpticViewer3D

lens = CookeTriplet()
```

This creates a static 3D visualization 
```python
drawer = lens.draw3D(is_jupyter=True)
drawer  # This will display the static visualization
```

and this creates an interactive but laggy 3D visualization

```python
viewer_3d = OpticViewer3D(lens)
widget = viewer_3d.view(is_jupyter=True)
widget  # This will display the interactive visualization
```

You can check if other codes are interrupted by adding and running another line:

```python
print("x")
```