### PR TITLE
fix computation of focal length (f2) when paraxial elements are present

### DIFF
--- a/optiland/raytrace/paraxial_ray_tracer.py
+++ b/optiland/raytrace/paraxial_ray_tracer.py
@@ -96,13 +96,13 @@ class ParaxialRayTracer:
 
             # reflect or refract
             if surfs[k].is_reflective:
-                if surfs[k].surface_type == 'paraxial':
-                    f = surfs[k].f 
+                if surfs[k].surface_type == "paraxial":
+                    f = surfs[k].f
                     u = -u - y / f
                 else:
                     u = -u - 2 * y / R[k]
             else:
-                if surfs[k].surface_type == 'paraxial':
+                if surfs[k].surface_type == "paraxial":
                     f = surfs[k].f
                     u = u - y / f
                 else:


### PR DESCRIPTION
The current implementation consider paraxial lens as flat surfaces (no power)
Therefore the computation of focal length is not correct.
A potential fix is proposed (but maybe different solutions can be used)