### PR TITLE
feat: ignore zero intensity points in the spot diagram calculation

### DIFF
--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -419,6 +419,10 @@ class SpotDiagram(BaseAnalysis):
             surf_group.intensity[-1, :],
         )
 
+        # Ignore rays with zero intensity
+        mask = i_g > 0
+        x_g, y_g, z_g, i_g = x_g[mask], y_g[mask], z_g[mask], i_g[mask]
+
         if coordinates == "local":
             x_plot, y_plot, _ = transform(
                 x_g, y_g, z_g, self.optic.image_surface, is_global=True


### PR DESCRIPTION
- This PR updates `SpotDiagram` to ignore invalid (zero intensity) points on the image plane