### PR TITLE
Fix normalized fields computation

### DIFF
--- a/optiland/fields.py
+++ b/optiland/fields.py
@@ -181,7 +181,10 @@ class FieldGroup:
         if self.max_field == 0:
             return [(0, 0)]
         return [
-            (float(x / self.max_x_field), float(y / self.max_y_field))
+            (
+                float(x / self.max_x_field) if self.max_x_field != 0 else 0.0,
+                float(y / self.max_y_field) if self.max_y_field != 0 else 0.0,
+            )
             for x, y in zip(self.x_fields, self.y_fields, strict=False)
         ]
 


### PR DESCRIPTION
Hi! The current implementation of the normalized fields computation done in `get_field_coords()` seems to not return 1 when fields are defined in x and y directions. I believe this is due to `x` and `y` being divided by `max_field` instead of the max field in their respective directions.

Example:

```python
lens.add_field(x=0, y=0) 
lens.add_field(x=1, y=1)
lens.add_field(x=2, y=2)

for field in lens.fields.get_field_coords():
    print(field)
```
gives:
```python
(0.0, 0.0)
(0.35, 0.35)
(0.70, 0.70)
```
when it should be:
```python
(0.0, 0.0)
(0.5, 0.5)
(1.0, 1.0)
```
This small fix should solve this.
Best, DrPaprika