### PR TITLE
Fix/surface removal material setting

### DIFF
--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -317,7 +317,12 @@ class SurfaceGroup:
         if index < len(self.surfaces):
             surface_before = self.surfaces[index - 1]
             surface_after = self.surfaces[index]
-            surface_after.material_pre = surface_before.material_post
+            new_pre_material = surface_before.material_post
+
+            # TODO: Refactor the Surface class with a property setter to handle this
+            #       internal sync automatically.
+            surface_after.material_pre = new_pre_material
+            surface_after.interaction_model.material_pre = new_pre_material
 
         if not self.surface_factory.use_absolute_cs:
             was_not_last_surface = index < num_surfaces_before_removal - 1


### PR DESCRIPTION
Fixes #363 

- Fixes bug in which materials are not properly updates after removal of a surface in a `SurfaceGroup` instance