### PR TITLE
Allow testing for equality of materials with `__eq__`

### DIFF
--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -67,6 +67,9 @@ class BaseMaterial(ABC):
         super().__init_subclass__(**kwargs)
         BaseMaterial._registry[cls.__name__] = cls
 
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, type(self)) and value.to_dict() == self.to_dict()
+
     def _create_cache_key(self, wavelength: float | be.ndarray, **kwargs) -> tuple:
         """Creates a hashable cache key from wavelength and kwargs."""
         if be.is_array_like(wavelength):

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -512,3 +512,13 @@ def test_plot_nk():
     assert isinstance(fig, Figure)
     assert isinstance(axes, tuple)
     assert len(axes) == 2
+
+def test___eq__():
+    ideal1 = materials.IdealMaterial(1.0, 0.0)
+    ideal2 = materials.IdealMaterial(1.0, 0.0)
+    ideal3 = materials.IdealMaterial(1.0, 0.1)
+    abbe = materials.AbbeMaterial(1.5, 60.0)
+    assert ideal1 == ideal2
+    assert ideal1 != ideal3
+    assert abbe != ideal1
+


### PR DESCRIPTION
A small PR implementing the `__eq__` dunder method for `BaseMaterial`, that allows doing `IdealMaterial(1.0, 0) == IdealMaterial(1.5, 0)`. Comparison is via `to_dict()`, so there might be a better way