### PR TITLE
Re-enable negative image plane locations

### DIFF
--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -263,9 +263,11 @@ class OpticUpdater:
         ya, ua = self.optic.paraxial.marginal_ray()
         offset = float(ya[-1, 0] / ua[-1, 0])
         surfaces = self.optic.surface_group.surfaces
-        if (new_z := surfaces[-1].geometry.cs.z - offset) > 0:
-            surfaces[-1].geometry.cs.z = new_z
-            surfaces[-2].thickness = new_z - surfaces[-2].geometry.cs.z
+        self.optic.surface_group.surfaces[-1].geometry.cs.z -= offset
+        surfaces[-2].thickness = (
+            self.optic.surface_group.surfaces[-1].geometry.cs.z
+            - surfaces[-2].geometry.cs.z
+        )
 
     def flip(self):
         """Flips the optical system, reversing the order of surfaces (excluding


### PR DESCRIPTION
Undo part of #369 : allow the image plane to be on the left side of the last surface. The last surface will have a negative thickness.