### PR TITLE
`flip()`: don't flip sign of paraxial surfaces

### DIFF
--- a/optiland/interactions/thin_lens_interaction_model.py
+++ b/optiland/interactions/thin_lens_interaction_model.py
@@ -48,7 +48,7 @@ class ThinLensInteractionModel(BaseInteractionModel):
 
     def flip(self):
         """Flip the interaction model."""
-        self.f = -self.f
+        pass
 
     def interact_real_rays(self, rays):
         """Interacts the rays with the surface by either reflecting or refracting

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -111,7 +111,7 @@ class TestThinLensInteractionModel:
     def test_flip(self, surface):
         f_initial = be.copy(surface.interaction_model.f)
         surface.interaction_model.flip()
-        assert_allclose(surface.interaction_model.f, -f_initial)
+        assert_allclose(surface.interaction_model.f, f_initial)
 
     def test_to_dict(self, surface):
         data = surface.interaction_model.to_dict()


### PR DESCRIPTION
As discussed [here](github.com/HarrisonKramer/optiland/discussions/378): do not flip the sign (type) of a thin lens, such that positive lenses remain positive and negative lenses remain negative after flipping. The only pytests that failed were those explicitly checking for a sign change. I updated those to check that the sign has not changed.