### PR TITLE
Fix Surface initialization in Tutorial_10a example notebook

### DIFF
--- a/docs/examples/Tutorial_10a_Custom_Surface_Types.ipynb
+++ b/docs/examples/Tutorial_10a_Custom_Surface_Types.ipynb
@@ -257,13 +257,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "new_surface = Surface(\n",
     "    geometry=new_geo,\n",
-    "    material_pre=material_pre,\n",
+    "    previous_surface=None,\n",
     "    material_post=material_post,\n",
     "    is_stop=True,\n",
     ")"


### PR DESCRIPTION
### Summary
This PR fixes a runtime error in the example notebook
`Tutorial_10a_Custom_Surface_Types.ipynb`.

The notebook still uses the deprecated `material_pre` argument when
constructing a `Surface`, which raises a `TypeError` with the current
Surface API.

### What changed
- Updated the Surface constructor call in the tutorial notebook
- Removed the invalid `material_pre` argument
- Explicitly set `previous_surface=None` to match the current API

### Why this is needed
Running the tutorial as-is fails with:
TypeError: Surface.__init__() got an unexpected keyword argument 'material_pre'

This fix ensures the example notebook runs correctly and stays in sync
with the current Surface interface.

### Scope
- Documentation / example fix only
- No changes to core library behavior

### Testing
- Ran `Tutorial_10a_Custom_Surface_Types.ipynb` locally
- Verified the notebook executes without errors
