### PR TITLE
Fix Forbes surface tutorial notebook

### DIFF
--- a/docs/gallery/freeform/forbes_surface.ipynb
+++ b/docs/gallery/freeform/forbes_surface.ipynb
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -104,14 +104,15 @@
     "optic = Optic(name=\"Forbes Q2D Singlet Example\")\n",
     "optic.set_aperture(aperture_type=\"EPD\", value=20.0)\n",
     "optic.add_wavelength(value=0.55, is_primary=True, unit=\"um\")\n",
+    "optic.set_field_type(field_type=\"angle\")\n",
     "optic.add_field(y=0.0)\n",
     "\n",
     "# 2. Define the Forbes surface parameters\n",
     "norm_radius = 10.0\n",
     "freeform_coeffs = {\n",
-    "    (4, 0): -0.01,           # Represents a_4^0 (symmetric term)\n",
-    "    (2, 2): 0.35,             # Represents a_2^2 (astigmatic cosine term)\n",
-    "    (3, 1, 'sin'): 0.02,     # Represents b_3^1 (comatic sine term)\n",
+    "    (\"a\", 4, 0): -0.01,           # Represents a_4^0 (symmetric term)\n",
+    "    (\"a\", 2, 2): 0.35,             # Represents a_2^2 (astigmatic cosine term)\n",
+    "    (\"b\", 3, 1): 0.02,     # Represents b_3^1 (comatic sine term)\n",
     "}\n",
     "\n",
     "# 3. Add the surfaces\n",
@@ -214,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -303,7 +304,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".sci-1",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -317,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Use implemented freeform_coeffs key format for forbes_q2d ("a"/"b" tuple keys).
- Set field type before drawing to avoid field_definition=None.