### PR TITLE
Fix Optic.plot_surface_sag kwargs forwarding

### DIFF
--- a/optiland/optic/optic.py
+++ b/optiland/optic/optic.py
@@ -658,12 +658,12 @@ class Optic:
         return self.ray_tracer.trace_generic(Hx, Hy, Px, Py, wavelength)
 
     def plot_surface_sag(
-        self, 
-        surface_index: int, 
-        y_cross_section: float = 0, 
+        self,
+        surface_index: int,
+        y_cross_section: float = 0,
         x_cross_section: float = 0,
-        fig_to_plot_on: Figure | None= None,
-        max_extent: float | None  = None,
+        fig_to_plot_on: Figure | None = None,
+        max_extent: float | None = None,
         num_points_grid: int = 50,
         buffer_factor: float = 1.1,
     ):
@@ -677,13 +677,15 @@ class Optic:
                 y-sag plot. Defaults to 0.
         """
         viewer = SurfaceSagViewer(self)
-        viewer.view(surface_index=surface_index, 
-                    y_cross_section=y_cross_section, 
-                    x_cross_section=x_cross_section,
-                    fig_to_plot_on=fig_to_plot_on,
-                    max_extent=max_extent,
-                    num_points_grid=num_points_grid,
-                    buffer_factor=buffer_factor)
+        viewer.view(
+            surface_index=surface_index,
+            y_cross_section=y_cross_section,
+            x_cross_section=x_cross_section,
+            fig_to_plot_on=fig_to_plot_on,
+            max_extent=max_extent,
+            num_points_grid=num_points_grid,
+            buffer_factor=buffer_factor,
+        )
 
     def to_dict(self) -> dict:
         """Convert the optical system to a dictionary.

--- a/tests/test_optic.py
+++ b/tests/test_optic.py
@@ -532,7 +532,15 @@ class TestOptic:
         )
         mock_viewer.assert_called_once_with(lens)
         viewer_instance = mock_viewer.return_value
-        viewer_instance.view.assert_called_once_with(1, 2.0, -2.0)
+        viewer_instance.view.assert_called_once_with(
+            surface_index=1,
+            y_cross_section=2.0,
+            x_cross_section=-2.0,
+            fig_to_plot_on=None,
+            max_extent=None,
+            num_points_grid=50,
+            buffer_factor=1.1,
+        )
 
 
 def test_flip_updates_thickness_attribute(set_test_backend):


### PR DESCRIPTION
Accept and forward fig_to_plot_on, max_extent, num_points_grid, and buffer_factor to SurfaceSagViewer.

This restores compatibility with gallery notebooks that call plot_surface_sag(..., max_extent=..., num_points_grid=...).

Fixes #423 