### PR TITLE
docs: clarify plt.show() requirement for draw()

### DIFF
--- a/docs/examples/Tutorial_1a_Optiland_for_Beginners.ipynb
+++ b/docs/examples/Tutorial_1a_Optiland_for_Beginners.ipynb
@@ -110,6 +110,17 @@
    ]
   },
   {
+  "cell_type": "markdown",
+  "metadata": {},
+  "source": [
+    "> **Note:**  \n",
+    "The `draw()` method returns the matplotlib figure and axes.  \n",
+    "When running Optiland in a script, you must explicitly call `plt.show()` or `fig.show()` to display the plot.  \n",
+    "\n",
+    "In Jupyter notebooks, figures are displayed automatically."
+  ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "vscode": {


### PR DESCRIPTION
This PR adds a short documentation note to the introductory notebook explaining that `draw()` returns the matplotlib figure and axes, and that `plt.show()` (or `fig.show()`) is required when running Optiland in scripts. This aligns the docs with current behavior and helps avoid confusion for new users.

Fixes #321