### PR TITLE
Fix GeometricMTF diffraction scale when max_freq is used

### DIFF
--- a/optiland/mtf/geometric.py
+++ b/optiland/mtf/geometric.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
+
 import optiland.backend as be
 from optiland.analysis import SpotDiagram
 from optiland.utils import resolve_wavelength
@@ -18,6 +19,7 @@ from optiland.utils import resolve_wavelength
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
+
     from optiland._types import BEArray, DistributionType, ScalarOrArray
     from optiland.optic import Optic
 


### PR DESCRIPTION
Fixing the diffraction scale for GeometricMTF when using max_freq parameter.

It was using max_freq instead of the cuttoff frequency for the diffraction scaling. The result was that MTF values corresponding to a certain frequency were changing depending on the max_freq parameter, which should not be the case.

Closes #452