### PR TITLE
fix: add comment to to_dict

### DIFF
--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -310,6 +310,7 @@ class Surface:
             "material_post": self.material_post.to_dict(),
             "is_stop": self.is_stop,
             "aperture": self.aperture.to_dict() if self.aperture else None,
+            "comment": self.comment,
             "interaction_model": self.interaction_model.to_dict(),
         }
 


### PR DESCRIPTION
Adds the `comment` field back to `to_dict` in the `Surface` class.