### PR TITLE
feat: Add OptilandEncoder to handle tensor/array serialization across backends

### DIFF
--- a/optiland/fileio/optiland_handler.py
+++ b/optiland/fileio/optiland_handler.py
@@ -42,6 +42,17 @@ def load_obj_from_json(cls, filepath):
     return cls.from_dict(data)
 
 
+class OptilandEncoder(json.JSONEncoder):
+    """Custom JSON encoder to handle tensor/array serialization across backends."""
+
+    def default(self, obj):
+        if hasattr(obj, "tolist") and callable(obj.tolist):
+            return obj.tolist()
+        elif hasattr(obj, "item") and callable(obj.item):
+            return obj.item()
+        return super().default(obj)
+
+
 def save_obj_to_json(obj, filepath):
     """Save an object to a JSON file.
 
@@ -56,7 +67,7 @@ def save_obj_to_json(obj, filepath):
 
     """
     with open(filepath, "w") as f:
-        json.dump(obj.to_dict(), f, indent=4)
+        json.dump(obj.to_dict(), f, indent=4, cls=OptilandEncoder)
 
 
 def load_optiland_file(filepath):

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -231,6 +231,62 @@ def test_load_legacy_optiland_file_with_field_type():
     os.remove(filepath)
 
 
+def test_save_load_optiland_file_with_tensor(set_test_backend):
+    """Test saving and loading an Optiland file when the backend uses tensors."""
+    import optiland.backend as be
+    import numpy as np
+    
+    try:
+        import torch
+        tensor_val = torch.tensor(1.23)
+        tensor_array = torch.tensor([1.23, 4.56])
+        has_torch = True
+    except ImportError:
+        has_torch = False
+        tensor_val = float(1.23)
+        tensor_array = [1.23, 4.56]
+        
+    lens = HeliarLens()
+    lens.add_surface(index=2, surface_type="even_asphere", radius=10.0, conic=-1.0, coefficients=[1.23, 1.23])
+
+    # Manually insert a tensor after creation to simulate a backend mismatch or torch active state
+    if has_torch:
+        lens.surface_group.surfaces[1].thickness = tensor_val
+        lens.surface_group.surfaces[1].geometry.radius = tensor_val
+        lens.surface_group.surfaces[2].geometry.coefficients = [tensor_val, tensor_val]
+    else:
+        # We need a custom mock class to simulate a PyTorch Tensor
+        class MockTensor:
+            def __init__(self, val):
+                self.val = val
+            def tolist(self):
+                return self.val if isinstance(self.val, list) else [self.val]
+            def item(self):
+                return self.val
+        
+        lens.surface_group.surfaces[1].thickness = MockTensor(1.23)
+        lens.surface_group.surfaces[1].geometry.radius = MockTensor(1.23)
+        lens.surface_group.surfaces[2].geometry.coefficients = [MockTensor(1.23), MockTensor(1.23)]
+
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w", suffix=".json"
+    ) as temp_file:
+        from optiland.fileio import save_optiland_file, load_optiland_file
+
+        # This should successfully serialize and not crash
+        save_optiland_file(lens, temp_file.name)
+        
+        # Reloading should read the json file which stores floats
+        lens2 = load_optiland_file(temp_file.name)
+    
+    # Assert values loaded properly
+    assert abs(lens2.surface_group.surfaces[1].thickness - 1.23) < 1e-6
+    assert abs(lens2.surface_group.surfaces[1].geometry.radius - 1.23) < 1e-6
+    assert abs(lens2.surface_group.surfaces[2].geometry.coefficients[0] - 1.23) < 1e-6
+    
+    os.remove(temp_file.name)
+
+
 def test_remove_surface_after_load(set_test_backend, tmp_path):
     """
     Test that removing a surface after loading from a file works correctly.


### PR DESCRIPTION
Adds `OptilandEncoder` to handle tensor/array serialization for any generic backend. This enables saving an `Optic` instance regardless of the backend used.

Example:
```python
import numpy as np
import optiland.backend as be
from optiland.fileio import save_optiland_file, load_optiland_file

be.set_backend("torch")  # set torch backend - this used to fail

lens = optic.Optic()

lens.add_surface(index=0, radius=np.inf, thickness=np.inf)
lens.add_surface(index=1, radius=22.01359, thickness=3.25896, material="SK16")
lens.add_surface(index=2, radius=-435.76044, thickness=6.00755)
lens.add_surface(
    index=3,
    radius=-22.21328,
    thickness=0.99997,
    material=("F2", "schott"),
)
lens.add_surface(index=4, radius=20.29192, thickness=4.75041, is_stop=True)
lens.add_surface(index=5, radius=79.68360, thickness=2.95208, material="SK16")
lens.add_surface(index=6, radius=-18.39533, thickness=42.20778)
lens.add_surface(index=7)

# add aperture
lens.set_aperture(aperture_type="EPD", value=10)

# add field
lens.set_field_type(field_type="angle")
lens.add_field(y=0)
lens.add_field(y=14)
lens.add_field(y=20)

# add wavelength
lens.add_wavelength(value=0.48)
lens.add_wavelength(value=0.55, is_primary=True)
lens.add_wavelength(value=0.65)

# save and load now works
save_optiland_file(lens, "test.json")
lens_new = load_optiland_file("test.json")
```

Fixes #491 