### PR TITLE
Remove implicit array to scalar conversions

### DIFF
--- a/optiland/_types.py
+++ b/optiland/_types.py
@@ -41,7 +41,7 @@ __all__ = [
 
 BEArrayT = TypeVar("BEArrayT", NDArray, "Tensor", Union[NDArray, "Tensor"])
 ScalarOrArrayT = TypeVar(
-    "ScalarOrArray", float, NDArray, "Tensor", Union[NDArray, "Tensor"]
+    "ScalarOrArrayT", float, NDArray, "Tensor", Union[NDArray, "Tensor"]
 )
 
 DistributionType = Literal[

--- a/optiland/rays/ray_aiming/initialization.py
+++ b/optiland/rays/ray_aiming/initialization.py
@@ -65,7 +65,7 @@ class ParaxialReferenceStrategy(StopSizeStrategy):
 
         # Determine marginal ray height at the stop surface
         y_marginal, _ = para.marginal_ray()
-        return be.abs(y_marginal[stop_index].item())
+        return float(be.abs(y_marginal[stop_index].item()))
 
 
 class RealReferenceStrategy(StopSizeStrategy):

--- a/optiland/rays/ray_aiming/initialization.py
+++ b/optiland/rays/ray_aiming/initialization.py
@@ -65,7 +65,7 @@ class ParaxialReferenceStrategy(StopSizeStrategy):
 
         # Determine marginal ray height at the stop surface
         y_marginal, _ = para.marginal_ray()
-        return be.abs(float(y_marginal[stop_index]))
+        return be.abs(y_marginal[stop_index].item())
 
 
 class RealReferenceStrategy(StopSizeStrategy):

--- a/optiland/solves/curvature.py
+++ b/optiland/solves/curvature.py
@@ -132,7 +132,7 @@ class MarginalRayAngleCurvatureSolve(CurvatureSolve):
 
         num = (n_pre * u_in) - (n_post * u_out_target)
         den = y_surf * delta_n
-        c = float(num / den)
+        c = (num / den).item()
 
         # Update curvature
         if hasattr(self.optic.surface_group.surfaces[self.surface_idx].geometry, "c"):
@@ -237,7 +237,7 @@ class ChiefRayAngleCurvatureSolve(CurvatureSolve):
             # c = (nu - n'u') / (y * delta_n)
             num = (n_pre * u_in) - (n_post * u_out_target)
             den = y_surf * delta_n
-            c_target = float(num / den)
+            c_target = (num / den).item()
 
             # Get current curvature
             if hasattr(

--- a/optiland/visualization/system/system.py
+++ b/optiland/visualization/system/system.py
@@ -175,7 +175,7 @@ class OpticalSystem:
                 r = 0.5 * self.optic.aperture.value
                 x_min, x_max, y_min, y_max = -r, r, -r, r
             elif surface.is_stop and self.rays is not None:
-                r = float(be.to_numpy(self.rays.r_extent[idx]))
+                r = be.to_numpy(self.rays.r_extent[idx]).item()
                 if r <= 0:
                     continue
                 x_min, x_max, y_min, y_max = -r, r, -r, r

--- a/optiland/wavefront/strategy.py
+++ b/optiland/wavefront/strategy.py
@@ -233,7 +233,7 @@ class ChiefRayStrategy(ReferenceStrategy):
             SphericalReference: The spherical reference geometry.
         """
         R = be.sqrt(x**2 + y**2 + (z - self.pupil_z) ** 2)
-        return SphericalReference((float(x), float(y), float(z)), R.item())
+        return SphericalReference((x.item(), y.item(), z.item()), R.item())
 
     def _calculate_sphere_from_chief_ray(
         self, chief_ray: RealRays
@@ -267,7 +267,7 @@ class ChiefRayStrategy(ReferenceStrategy):
             PlanarReference: The planar reference geometry.
         """
         return PlanarReference(
-            (float(x), float(y), float(z)), (float(L), float(M), float(N))
+            (x.item(), y.item(), z.item()), (L.item(), M.item(), N.item())
         )
 
 

--- a/tests/test_extended_sources.py
+++ b/tests/test_extended_sources.py
@@ -446,7 +446,7 @@ class TestExtendedSourceOptic:
 
     def test_set_thickness_through_wrapper(self, optic, ext_optic):
         ext_optic.set_thickness(99.0, surface_number=1)
-        assert float(optic.surface_group.get_thickness(1)) == (
+        assert optic.surface_group.get_thickness(1).item() == (
             pytest.approx(99.0)
         )
 


### PR DESCRIPTION
Numpy 2.4.0 dropped support for implicit array-to-scalar conversions. 0-dimensional arrays can still be converted implicitly:

```python
arr = np.array(0)
number = float(arr)  # -> 0
```

but for a dimensionality > 0, this conversion fails:

```python
arr = np.array([0])
number = float(arr)  # -> TypeError: only 0-dimensional arrays can be converted to Python scalars
```

Optiland sometimes still implicitly converts 1-dimensional single-element arrays to scalars, which is incompatible with the latest versions of Numpy. I replaced these conversions with calls so `array.item()`.