### PR TITLE
Spot Diagram Refactor & Reference Strategies

### DIFF
--- a/optiland/analysis/__init__.py
+++ b/optiland/analysis/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
 from .angle_vs_height import PupilIncidentAngleVsHeight, FieldIncidentAngleVsHeight
-from .spot_diagram import SpotDiagram
+from .spot_diagram import SpotDiagram, SpotReferenceType
 from .encircled_energy import EncircledEnergy
 from .ray_fan import RayFan, BestFitRayFan
 from .y_ybar import YYbar

--- a/optiland/analysis/rms_vs_field.py
+++ b/optiland/analysis/rms_vs_field.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 
 import optiland.backend as be
-from optiland.analysis import SpotDiagram
+from optiland.analysis.spot_diagram import SpotDiagram
 from optiland.wavefront import Wavefront
 
 if TYPE_CHECKING:

--- a/optiland/analysis/spot_diagram/__init__.py
+++ b/optiland/analysis/spot_diagram/__init__.py
@@ -1,0 +1,12 @@
+"""Spot Diagram Analysis Package
+
+This package provides spot diagram analysis for optical systems, including
+configurable reference centering strategies.
+"""
+
+from __future__ import annotations
+
+from .core import SpotData, SpotDiagram
+from .reference import SpotReferenceType
+
+__all__ = ["SpotData", "SpotDiagram", "SpotReferenceType"]

--- a/optiland/analysis/spot_diagram/core.py
+++ b/optiland/analysis/spot_diagram/core.py
@@ -1,6 +1,7 @@
 """Spot Diagram Analysis
 
-This module provides a spot diagram analysis for optical systems.
+This module provides the core spot diagram analysis for optical systems,
+including data generation, centering, and metrics calculation.
 
 Kramer Harrison, 2024
 """
@@ -10,20 +11,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib import patches
-
 import optiland.backend as be
 from optiland.utils import resolve_fields
 from optiland.visualization.system.utils import transform
 
-from .base import BaseAnalysis
+from ..base import BaseAnalysis
+from .plotting import (
+    calculate_axis_limits,
+    finalize_plot,
+    handle_no_fields,
+    plot_field,
+    setup_plot_layout,
+)
+from .reference import SpotReferenceType, create_reference_strategy
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
-    from numpy.typing import NDArray
 
     from optiland._types import BEArray, DistributionType
 
@@ -46,8 +50,8 @@ class SpotData:
 class SpotDiagram(BaseAnalysis):
     """Generates and plots real ray intersection data on the image surface.
 
-    This class creates spot diagrams, which are purely geometric plots that give an
-    indication of the blur produced by aberrations in an optical system.
+    This class creates spot diagrams, which are purely geometric plots that give
+    an indication of the blur produced by aberrations in an optical system.
 
     Attributes:
         optic: Instance of the optic object to be assessed.
@@ -59,6 +63,7 @@ class SpotDiagram(BaseAnalysis):
             wavelength.
         coordinates: The coordinate system ('global' or 'local') for data and
             plotting.
+        reference: The reference point type used for centering spots.
     """
 
     def __init__(
@@ -69,6 +74,7 @@ class SpotDiagram(BaseAnalysis):
         num_rings: int = 6,
         distribution: DistributionType = "hexapolar",
         coordinates: Literal["global", "local"] = "local",
+        reference: str | SpotReferenceType = SpotReferenceType.CHIEF_RAY,
     ):
         """Initializes the SpotDiagram analysis.
 
@@ -87,9 +93,12 @@ class SpotDiagram(BaseAnalysis):
                 Defaults to "hexapolar".
             coordinates: Coordinate system for data generation and plotting.
                 Defaults to "local".
+            reference: Reference point type for centering spots. Can be
+                "chief_ray" or "centroid". Defaults to "chief_ray".
 
         Raises:
             ValueError: If `coordinates` is not 'global' or 'local'.
+            ValueError: If `reference` is not a valid SpotReferenceType.
         """
         self.fields = resolve_fields(optic, fields)
 
@@ -99,16 +108,15 @@ class SpotDiagram(BaseAnalysis):
 
         self.num_rings = num_rings
         self.distribution: DistributionType = distribution
+        self._reference_strategy = create_reference_strategy(reference)
 
         super().__init__(optic, wavelengths)
         primary_wl_value = self.optic.primary_wavelength
         if primary_wl_value in self.wavelengths:
-            # Use the system's primary wavelength as the reference if available.
             self._analysis_ref_wavelength_index = self.wavelengths.index(
                 primary_wl_value
             )
         else:
-            # Otherwise, use the first wavelength in the analysis list.
             self._analysis_ref_wavelength_index = 0
 
     def view(
@@ -131,27 +139,29 @@ class SpotDiagram(BaseAnalysis):
             A tuple containing the Matplotlib figure and a list of its axes.
         """
         if not self.fields:
-            return self._handle_no_fields(fig_to_plot_on)
+            return handle_no_fields(fig_to_plot_on)
 
-        # 1. Prepare data for plotting
         centered_data = self._center_spots(self.data)
         airy_disk_data = self._prepare_airy_disk_data() if add_airy_disk else None
 
-        # 2. Set up the figure and calculate plot limits
-        fig, axs = self._setup_plot_layout(fig_to_plot_on, figsize)
-        axis_lim = self._calculate_axis_limits(centered_data, airy_disk_data)
+        fig, axs = setup_plot_layout(len(self.fields), fig_to_plot_on, figsize)
+        axis_lim = calculate_axis_limits(centered_data, self.fields, airy_disk_data)
 
-        # 3. Plot each field on its corresponding subplot
         for i, field_data in enumerate(centered_data):
             if i >= len(axs):
                 break
-            self._plot_field(
-                axs[i], field_data, self.fields[i], axis_lim, i, airy_disk_data
+            plot_field(
+                axs[i],
+                field_data,
+                self.wavelengths,
+                self.fields[i],
+                axis_lim,
+                i,
+                self.optic.image_surface,
+                airy_disk_data,
             )
 
-        # 4. Finalize the plot (legend, layout, etc.)
-        self._finalize_plot(fig, axs, len(self.fields))
-
+        finalize_plot(fig, axs, len(self.fields), self.wavelengths)
         return fig, fig.get_axes()
 
     # --- Calculation Methods ---
@@ -233,7 +243,8 @@ class SpotDiagram(BaseAnalysis):
             wavelength: The wavelength for the rays.
 
         Returns:
-            A tuple of direction cosine vectors for north, south, east, and west rays.
+            A tuple of direction cosine vectors for north, south, east, and
+            west rays.
         """
         rays = self.generate_marginal_rays(H_x, H_y, wavelength)
         return tuple(be.array([ray.L, ray.M, ray.N]).ravel() for ray in rays)
@@ -259,13 +270,14 @@ class SpotDiagram(BaseAnalysis):
         return be.stack(cosines, axis=0)
 
     def generate_chief_rays_centers(self, wavelength: float) -> BEArray:
-        """Generates the (x, y) intersection points for the chief ray of each field.
+        """Generates the (x, y) intersection points for the chief ray of each
+        field.
 
         Args:
             wavelength: The wavelength for the rays.
 
         Returns:
-            An array of shape (num_fields, 2) containing the (x, y) coordinates.
+            An array of shape (num_fields, 2) with (x, y) coordinates.
         """
         centers = [
             [ray.x.item(), ray.y.item()]
@@ -285,7 +297,7 @@ class SpotDiagram(BaseAnalysis):
             wavelength: The wavelength for the calculation.
 
         Returns:
-            A tuple containing two lists: x-axis radii and y-axis radii for each field.
+            A tuple of two lists: x-axis radii and y-axis radii per field.
         """
         chief_cosines = self.generate_chief_rays_cosines(wavelength)
         airy_rad_x_list, airy_rad_y_list = [], []
@@ -315,7 +327,8 @@ class SpotDiagram(BaseAnalysis):
         return airy_rad_x_list, airy_rad_y_list
 
     def centroid(self) -> list[tuple[BEArray, BEArray]]:
-        """Calculates the geometric centroid of each spot for the reference wavelength.
+        """Calculates the geometric centroid of each spot for the reference
+        wavelength.
 
         Returns:
             A list of (x, y) centroid coordinates for each field.
@@ -356,23 +369,48 @@ class SpotDiagram(BaseAnalysis):
             for field_data in centered_data
         ]
 
-    # --- Internal Data Generation and Plotting Helpers ---
+    # --- Internal Data Generation Helpers ---
+
+    def _get_reference_centers(
+        self, data: list[list[SpotData]]
+    ) -> list[tuple[BEArray, BEArray]]:
+        """Computes the reference centers using the configured strategy.
+
+        Args:
+            data: The spot data to compute centers for.
+
+        Returns:
+            A list of (x, y) center tuples, one per field.
+        """
+        ref_wl = self.wavelengths[self._analysis_ref_wavelength_index]
+        return self._reference_strategy.get_centers(
+            data,
+            self._analysis_ref_wavelength_index,
+            self.optic,
+            self.fields,
+            ref_wl,
+            self.coordinates,
+        )
 
     def _center_spots(self, data: list[list[SpotData]]) -> list[list[SpotData]]:
-        """Centers spot data around the centroid of the reference wavelength.
+        """Centers spot data around the configured reference point.
 
         Args:
             data: The original, uncentered spot data.
 
         Returns:
-            A deep copy of the data, centered around the respective centroids.
+            A deep copy of the data, centered around the reference points.
         """
-        centroids = self.centroid()
+        centers = self._get_reference_centers(data)
         centered_data = []
         for i, field_list in enumerate(data):
-            cx, cy = centroids[i]
+            cx, cy = centers[i]
             centered_field = [
-                SpotData(x=sd.x - cx, y=sd.y - cy, intensity=be.copy(sd.intensity))
+                SpotData(
+                    x=sd.x - cx,
+                    y=sd.y - cy,
+                    intensity=be.copy(sd.intensity),
+                )
                 for sd in field_list
             ]
             centered_data.append(centered_field)
@@ -387,7 +425,11 @@ class SpotDiagram(BaseAnalysis):
         return [
             [
                 self._generate_field_data(
-                    field, wl, self.num_rings, self.distribution, self.coordinates
+                    field,
+                    wl,
+                    self.num_rings,
+                    self.distribution,
+                    self.coordinates,
                 )
                 for wl in self.wavelengths
             ]
@@ -407,8 +449,8 @@ class SpotDiagram(BaseAnalysis):
         Args:
             field: The (Hx, Hy) field coordinates.
             wavelength: The wavelength for tracing.
-            num_rays: The number of rays to generate, or number of rings if distribution
-                is hexapolar.
+            num_rays: The number of rays to generate, or number of rings if
+                distribution is hexapolar.
             distribution: The ray distribution pattern.
             coordinates: The coordinate system ('local' or 'global').
 
@@ -437,213 +479,33 @@ class SpotDiagram(BaseAnalysis):
 
         return SpotData(x=x_plot, y=y_plot, intensity=i_g)
 
-    def _handle_no_fields(self, fig: Figure) -> tuple[None, None]:
-        """Handles the case where there are no fields to plot.
-
-        Args:
-            fig: An optional existing figure to draw a message on.
-        """
-        print("Warning (SpotDiagram.view): No fields to plot.")
-        if fig and hasattr(fig, "canvas") and fig.canvas:
-            fig.text(
-                0.5, 0.5, "No fields to plot Spot Diagram", ha="center", va="center"
-            )
-            fig.canvas.draw_idle()
-        return None, None
-
-    def _setup_plot_layout(
-        self, fig_to_plot_on: Figure, figsize: tuple
-    ) -> tuple[Figure, NDArray[np.object_]]:
-        """Sets up the Matplotlib figure and axes grid.
-
-        Args:
-            fig_to_plot_on: An existing figure to use, or None to create one.
-            figsize: The size for the figure.
-
-        Returns:
-            A tuple of the figure and a flattened array of its axes.
-        """
-        num_fields = len(self.fields)
-        num_cols = 3
-        num_rows = (num_fields + num_cols - 1) // num_cols
-
-        if fig_to_plot_on:
-            fig = fig_to_plot_on
-            fig.clear()
-        else:
-            fig = plt.figure(figsize=(figsize[0], num_rows * figsize[1]))
-
-        axs = fig.subplots(num_rows, num_cols, sharex=True, sharey=True).flatten()
-        return fig, axs
-
     def _prepare_airy_disk_data(self) -> dict:
         """Prepares all necessary data for plotting the Airy disk.
 
+        The Airy disk position is determined by the configured reference
+        strategy: when using chief ray centering, the Airy disk sits at (0,0);
+        when using centroid centering, it is offset by the difference between
+        the chief ray and centroid positions.
+
         Returns:
-            A dictionary containing Airy disk radii, chief ray centers, and
-            real centroid coordinates.
+            A dictionary containing Airy disk radii and center coordinates
+            relative to the reference point.
         """
         primary_wl_obj = self.optic.wavelengths.primary_wavelength
         wl_val = primary_wl_obj.value if primary_wl_obj else self.wavelengths[0]
 
         airy_rad_x, airy_rad_y = self.airy_disc_x_y(wavelength=wl_val)
         chief_centers = self.generate_chief_rays_centers(wavelength=wl_val)
-        geom_centroids = self.centroid()
+        reference_centers = self._get_reference_centers(self.data)
 
-        real_centroids = be.to_numpy(chief_centers) - be.to_numpy(
-            be.stack(geom_centroids)
+        # Airy disk is physically at the chief ray position. Compute its
+        # offset relative to whichever reference was used for centering.
+        airy_centers = be.to_numpy(chief_centers) - be.to_numpy(
+            be.stack(reference_centers)
         )
 
         return {
             "radii_x": be.to_numpy(airy_rad_x),
             "radii_y": be.to_numpy(airy_rad_y),
-            "real_centroids": real_centroids,
+            "airy_centers": airy_centers,
         }
-
-    def _calculate_axis_limits(
-        self,
-        centered_data: list,
-        airy_disk_data: dict | None = None,
-        buffer: float = 1.05,
-    ) -> float:
-        """Calculates the axis limits to encompass all spots and Airy disks.
-
-        Args:
-            centered_data: The centered spot data.
-            airy_disk_data: The prepared Airy disk data, if any.
-            buffer: A multiplicative buffer to apply to the final limit.
-
-        Returns:
-            A float representing the symmetric axis limit (+/- limit).
-        """
-        max_radii = [
-            be.to_numpy(be.max(be.sqrt(sd.x**2 + sd.y**2)))
-            for field in centered_data
-            for sd in field
-        ]
-        max_geom_radius = max(max_radii) if max_radii else 0.01
-
-        if not airy_disk_data:
-            return max_geom_radius * buffer
-
-        # If Airy disk is present, consider its size and offset
-        rad_x = airy_disk_data["radii_x"]
-        rad_y = airy_disk_data["radii_y"]
-        centroids = airy_disk_data["real_centroids"]
-
-        max_extent = 0
-        for i in range(len(self.fields)):
-            offset = np.max(np.abs(centroids[i]))
-            radius = max(rad_x[i], rad_y[i], max_geom_radius)
-            max_extent = max(max_extent, offset + radius)
-
-        return max_extent * buffer if max_extent > 0 else max_geom_radius * buffer
-
-    def _plot_field(
-        self,
-        ax: Axes,
-        field_data: list[SpotData],
-        field_coords: tuple[float, float],
-        axis_lim: float,
-        field_index: int,
-        airy_disk_data: dict | None = None,
-    ):
-        """Plots the data for a single field on a given axis.
-
-        Args:
-            ax: The Matplotlib axis to plot on.
-            field_data: A list of SpotData for the current field.
-            field_coords: The (Hx, Hy) coordinates of the field.
-            axis_lim: The symmetric axis limit for x and y axes.
-            field_index: The index of the current field.
-            airy_disk_data: Optional dictionary with Airy disk data.
-        """
-        markers = ["o", "s", "^"]
-        for i, points in enumerate(field_data):
-            x, y, intensity = (
-                be.to_numpy(points.x),
-                be.to_numpy(points.y),
-                be.to_numpy(points.intensity),
-            )
-            mask = intensity != 0
-            ax.scatter(
-                x[mask],
-                y[mask],
-                s=10,
-                label=f"{self.wavelengths[i]:.4f} µm",
-                marker=markers[i % 3],
-                alpha=0.7,
-            )
-
-        if airy_disk_data:
-            cx, cy = airy_disk_data["real_centroids"][field_index]
-            width = 2 * airy_disk_data["radii_y"][field_index]
-            height = 2 * airy_disk_data["radii_x"][field_index]
-            ellipse = patches.Ellipse(
-                (cx, cy),
-                width,
-                height,
-                linestyle="--",
-                edgecolor="black",
-                fill=False,
-                lw=2,
-            )
-            ax.add_patch(ellipse)
-
-        # Determine axis labels based on image surface orientation
-        cs = self.optic.image_surface.geometry.cs
-        if np.any(np.abs(cs.get_effective_rotation_euler())[:2] > 0.01):
-            x_label, y_label = "U (mm)", "V (mm)"
-        else:
-            x_label, y_label = "X (mm)", "Y (mm)"
-
-        ax.axis("square")
-        ax.set_xlabel(x_label)
-        ax.set_ylabel(y_label)
-        ax.set_xlim(-axis_lim, axis_lim)
-        ax.set_ylim(-axis_lim, axis_lim)
-        ax.set_title(f"Hx: {field_coords[0]:.3f}, Hy: {field_coords[1]:.3f}")
-        ax.grid(True, alpha=0.25)
-
-    def _finalize_plot(self, fig: Figure, axs: NDArray[np.object_], num_fields: int):
-        """Applies final touches to the plot, including a dynamic shared legend.
-
-        Args:
-            fig: The Matplotlib figure.
-            axs: The array of axes.
-            num_fields: The number of fields that were plotted.
-        """
-        # Remove empty subplot axes
-        for i in range(num_fields, len(axs)):
-            fig.delaxes(axs[i])
-
-        if num_fields == 0:
-            if hasattr(fig, "canvas") and fig.canvas:
-                fig.canvas.draw_idle()
-            return
-
-        handles, labels = axs[0].get_legend_handles_labels()
-        if not handles:
-            fig.tight_layout()
-            if hasattr(fig, "canvas") and fig.canvas:
-                fig.canvas.draw_idle()
-            return
-
-        fig.canvas.draw()
-        pos_left = axs[0].get_position()
-        num_cols = 3
-
-        rightmost_ax_idx = min(num_fields - 1, num_cols - 1)
-        pos_right = axs[rightmost_ax_idx].get_position()
-
-        x_center = (pos_left.x0 + pos_right.x1) / 2.0
-
-        fig.legend(
-            handles,
-            labels,
-            loc="upper center",
-            bbox_to_anchor=(x_center, 0.05),
-            ncol=len(self.wavelengths),
-        )
-
-        fig.subplots_adjust(bottom=0.2)

--- a/optiland/analysis/spot_diagram/plotting.py
+++ b/optiland/analysis/spot_diagram/plotting.py
@@ -1,0 +1,228 @@
+"""Spot Diagram Plotting Utilities
+
+This module provides standalone plotting helper functions for spot diagrams.
+These are extracted from the SpotDiagram class to keep the core analysis
+class focused on data generation and metrics.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib import patches
+
+import optiland.backend as be
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from numpy.typing import NDArray
+
+    from .core import SpotData
+
+
+def handle_no_fields(fig: Figure | None) -> tuple[None, None]:
+    """Handles the case where there are no fields to plot.
+
+    Args:
+        fig: An optional existing figure to draw a message on.
+
+    Returns:
+        A tuple of (None, None).
+    """
+    print("Warning (SpotDiagram.view): No fields to plot.")
+    if fig and hasattr(fig, "canvas") and fig.canvas:
+        fig.text(0.5, 0.5, "No fields to plot Spot Diagram", ha="center", va="center")
+        fig.canvas.draw_idle()
+    return None, None
+
+
+def setup_plot_layout(
+    num_fields: int,
+    fig_to_plot_on: Figure | None,
+    figsize: tuple[float, float],
+) -> tuple[Figure, NDArray[np.object_]]:
+    """Sets up the Matplotlib figure and axes grid.
+
+    Args:
+        num_fields: Number of field points to plot.
+        fig_to_plot_on: An existing figure to use, or None to create one.
+        figsize: The size for the figure.
+
+    Returns:
+        A tuple of the figure and a flattened array of its axes.
+    """
+    num_cols = 3
+    num_rows = (num_fields + num_cols - 1) // num_cols
+
+    if fig_to_plot_on:
+        fig = fig_to_plot_on
+        fig.clear()
+    else:
+        fig = plt.figure(figsize=(figsize[0], num_rows * figsize[1]))
+
+    axs = fig.subplots(num_rows, num_cols, sharex=True, sharey=True).flatten()
+    return fig, axs
+
+
+def calculate_axis_limits(
+    centered_data: list[list[SpotData]],
+    fields: list[tuple[float, float]],
+    airy_disk_data: dict | None = None,
+    buffer: float = 1.05,
+) -> float:
+    """Calculates the axis limits to encompass all spots and Airy disks.
+
+    Args:
+        centered_data: The centered spot data.
+        fields: List of field coordinates.
+        airy_disk_data: The prepared Airy disk data, if any.
+        buffer: A multiplicative buffer to apply to the final limit.
+
+    Returns:
+        A float representing the symmetric axis limit (+/- limit).
+    """
+    max_radii = [
+        be.to_numpy(be.max(be.sqrt(sd.x**2 + sd.y**2)))
+        for field in centered_data
+        for sd in field
+    ]
+    max_geom_radius = max(max_radii) if max_radii else 0.01
+
+    if not airy_disk_data:
+        return max_geom_radius * buffer
+
+    rad_x = airy_disk_data["radii_x"]
+    rad_y = airy_disk_data["radii_y"]
+    centroids = airy_disk_data["airy_centers"]
+
+    max_extent = 0
+    for i in range(len(fields)):
+        offset = np.max(np.abs(centroids[i]))
+        radius = max(rad_x[i], rad_y[i], max_geom_radius)
+        max_extent = max(max_extent, offset + radius)
+
+    return max_extent * buffer if max_extent > 0 else max_geom_radius * buffer
+
+
+def plot_field(
+    ax: Axes,
+    field_data: list[SpotData],
+    wavelengths: list[float],
+    field_coords: tuple[float, float],
+    axis_lim: float,
+    field_index: int,
+    image_surface,
+    airy_disk_data: dict | None = None,
+) -> None:
+    """Plots the data for a single field on a given axis.
+
+    Args:
+        ax: The Matplotlib axis to plot on.
+        field_data: A list of SpotData for the current field.
+        wavelengths: List of wavelength values.
+        field_coords: The (Hx, Hy) coordinates of the field.
+        axis_lim: The symmetric axis limit for x and y axes.
+        field_index: The index of the current field.
+        image_surface: The image surface of the optic.
+        airy_disk_data: Optional dictionary with Airy disk data.
+    """
+    markers = ["o", "s", "^"]
+    for i, points in enumerate(field_data):
+        x, y, intensity = (
+            be.to_numpy(points.x),
+            be.to_numpy(points.y),
+            be.to_numpy(points.intensity),
+        )
+        mask = intensity != 0
+        ax.scatter(
+            x[mask],
+            y[mask],
+            s=10,
+            label=f"{wavelengths[i]:.4f} µm",
+            marker=markers[i % 3],
+            alpha=0.7,
+        )
+
+    if airy_disk_data:
+        cx, cy = airy_disk_data["airy_centers"][field_index]
+        width = 2 * airy_disk_data["radii_y"][field_index]
+        height = 2 * airy_disk_data["radii_x"][field_index]
+        ellipse = patches.Ellipse(
+            (cx, cy),
+            width,
+            height,
+            linestyle="--",
+            edgecolor="black",
+            fill=False,
+            lw=2,
+        )
+        ax.add_patch(ellipse)
+
+    # Determine axis labels based on image surface orientation
+    cs = image_surface.geometry.cs
+    if np.any(np.abs(cs.get_effective_rotation_euler())[:2] > 0.01):
+        x_label, y_label = "U (mm)", "V (mm)"
+    else:
+        x_label, y_label = "X (mm)", "Y (mm)"
+
+    ax.axis("square")
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+    ax.set_xlim(-axis_lim, axis_lim)
+    ax.set_ylim(-axis_lim, axis_lim)
+    ax.set_title(f"Hx: {field_coords[0]:.3f}, Hy: {field_coords[1]:.3f}")
+    ax.grid(True, alpha=0.25)
+
+
+def finalize_plot(
+    fig: Figure,
+    axs: NDArray[np.object_],
+    num_fields: int,
+    wavelengths: list[float],
+) -> None:
+    """Applies final touches to the plot, including a dynamic shared legend.
+
+    Args:
+        fig: The Matplotlib figure.
+        axs: The array of axes.
+        num_fields: The number of fields that were plotted.
+        wavelengths: The list of wavelengths used in the analysis.
+    """
+    for i in range(num_fields, len(axs)):
+        fig.delaxes(axs[i])
+
+    if num_fields == 0:
+        if hasattr(fig, "canvas") and fig.canvas:
+            fig.canvas.draw_idle()
+        return
+
+    handles, labels = axs[0].get_legend_handles_labels()
+    if not handles:
+        fig.tight_layout()
+        if hasattr(fig, "canvas") and fig.canvas:
+            fig.canvas.draw_idle()
+        return
+
+    fig.canvas.draw()
+    pos_left = axs[0].get_position()
+    num_cols = 3
+
+    rightmost_ax_idx = min(num_fields - 1, num_cols - 1)
+    pos_right = axs[rightmost_ax_idx].get_position()
+
+    x_center = (pos_left.x0 + pos_right.x1) / 2.0
+
+    fig.legend(
+        handles,
+        labels,
+        loc="upper center",
+        bbox_to_anchor=(x_center, 0.05),
+        ncol=len(wavelengths),
+    )
+
+    fig.subplots_adjust(bottom=0.2)

--- a/optiland/analysis/spot_diagram/reference.py
+++ b/optiland/analysis/spot_diagram/reference.py
@@ -10,7 +10,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import abc
-from enum import StrEnum
+from enum import Enum
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
     from .core import SpotData
 
 
-class SpotReferenceType(StrEnum):
+# TODO: Update to StrEnum when Python 3.10 support is dropped
+class SpotReferenceType(str, Enum):
     """Defines the available reference point types for spot centering."""
 
     CHIEF_RAY = "chief_ray"

--- a/optiland/analysis/spot_diagram/reference.py
+++ b/optiland/analysis/spot_diagram/reference.py
@@ -1,0 +1,132 @@
+"""Spot Diagram Reference Strategies
+
+This module provides configurable reference point strategies for centering
+spot diagram data. The center of calculation can be either the chief ray
+intersection or the geometric centroid of the traced rays.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+import abc
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import optiland.backend as be
+
+if TYPE_CHECKING:
+    from optiland._types import BEArray
+    from optiland.optic import Optic
+
+    from .core import SpotData
+
+
+class SpotReferenceType(StrEnum):
+    """Defines the available reference point types for spot centering."""
+
+    CHIEF_RAY = "chief_ray"
+    CENTROID = "centroid"
+
+
+class SpotReferenceStrategy(abc.ABC):
+    """Abstract base class for spot diagram reference strategies."""
+
+    @abc.abstractmethod
+    def get_centers(
+        self,
+        data: list[list[SpotData]],
+        ref_wavelength_index: int,
+        optic: Optic,
+        fields: list[tuple[float, float]],
+        wavelength: float,
+        coordinates: str,
+    ) -> list[tuple[BEArray, BEArray]]:
+        """Computes the (x, y) center for each field.
+
+        Args:
+            data: Nested list of spot data, ordered [field][wavelength].
+            ref_wavelength_index: Index of the reference wavelength.
+            optic: The optical system being analyzed.
+            fields: List of (Hx, Hy) field coordinates.
+            wavelength: Reference wavelength value in micrometers.
+            coordinates: Coordinate system ('global' or 'local').
+
+        Returns:
+            A list of (x, y) center tuples, one per field.
+        """
+
+
+class CentroidReference(SpotReferenceStrategy):
+    """Centers spots using the geometric centroid of rays at the reference
+    wavelength."""
+
+    def get_centers(
+        self,
+        data: list[list[SpotData]],
+        ref_wavelength_index: int,
+        optic: Optic,
+        fields: list[tuple[float, float]],
+        wavelength: float,
+        coordinates: str,
+    ) -> list[tuple[BEArray, BEArray]]:
+        """Computes centroids from the mean of ray intersections."""
+        return [
+            (
+                be.mean(field_data[ref_wavelength_index].x),
+                be.mean(field_data[ref_wavelength_index].y),
+            )
+            for field_data in data
+        ]
+
+
+class ChiefRayReference(SpotReferenceStrategy):
+    """Centers spots using the chief ray intersection at the reference
+    wavelength."""
+
+    def get_centers(
+        self,
+        data: list[list[SpotData]],
+        ref_wavelength_index: int,
+        optic: Optic,
+        fields: list[tuple[float, float]],
+        wavelength: float,
+        coordinates: str,
+    ) -> list[tuple[BEArray, BEArray]]:
+        """Computes centers from chief ray (Px=0, Py=0) intersections."""
+        from optiland.visualization.system.utils import transform
+
+        centers = []
+        for H_x, H_y in fields:
+            ray = optic.trace_generic(Hx=H_x, Hy=H_y, Px=0, Py=0, wavelength=wavelength)
+            if coordinates == "local":
+                x, y, _ = transform(
+                    ray.x, ray.y, ray.z, optic.image_surface, is_global=True
+                )
+                centers.append((x.ravel()[0], y.ravel()[0]))
+            else:
+                centers.append((ray.x.ravel()[0], ray.y.ravel()[0]))
+        return centers
+
+
+def create_reference_strategy(
+    reference: str | SpotReferenceType,
+) -> SpotReferenceStrategy:
+    """Factory function to create a reference strategy from a type string.
+
+    Args:
+        reference: The reference type, either a SpotReferenceType enum value
+            or a string ('chief_ray' or 'centroid').
+
+    Returns:
+        The corresponding SpotReferenceStrategy instance.
+
+    Raises:
+        ValueError: If the reference type is not recognized.
+    """
+    ref = SpotReferenceType(reference)
+    strategies = {
+        SpotReferenceType.CHIEF_RAY: ChiefRayReference,
+        SpotReferenceType.CENTROID: CentroidReference,
+    }
+    return strategies[ref]()

--- a/tests/analysis/test_spot_reference.py
+++ b/tests/analysis/test_spot_reference.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+
+import optiland.backend as be
+from optiland.optic import Optic
+from optiland.analysis.spot_diagram import SpotDiagram, SpotReferenceType
+from optiland.analysis.spot_diagram.reference import ChiefRayReference, CentroidReference
+from optiland.samples.objectives import CookeTriplet
+
+
+@pytest.fixture
+def cooke_triplet():
+    return CookeTriplet()
+
+
+class TestSpotReference:
+    def test_default_reference(self, set_test_backend, cooke_triplet):
+        """SpotDiagram should default to ChiefRayReference."""
+        spot = SpotDiagram(cooke_triplet)
+        assert isinstance(spot._reference_strategy, ChiefRayReference)
+
+    def test_centroid_reference(self, set_test_backend, cooke_triplet):
+        """SpotDiagram with centroid reference should use CentroidReference."""
+        spot = SpotDiagram(cooke_triplet, reference="centroid")
+        assert isinstance(spot._reference_strategy, CentroidReference)
+
+    def test_invalid_reference(self, cooke_triplet):
+        """SpotDiagram with invalid reference should raise ValueError."""
+        with pytest.raises(ValueError):
+            SpotDiagram(cooke_triplet, reference="invalid_ref")
+
+    def test_centroid_centering_logic(self, set_test_backend, cooke_triplet):
+        """When using centroid reference, the mean of the centered rays at the ref wavelength should be ~zero."""
+        spot = SpotDiagram(cooke_triplet, reference="centroid")
+        centered_data = spot._center_spots(spot.data)
+        
+        ref_idx = spot._analysis_ref_wavelength_index
+        for field_data in centered_data:
+            ref_spot = field_data[ref_idx]
+            mean_x = be.to_numpy(be.mean(ref_spot.x)).item()
+            mean_y = be.to_numpy(be.mean(ref_spot.y)).item()
+            
+            # The centered spots should have a centroid of (0, 0)
+            assert np.isclose(mean_x, 0.0, atol=1e-7)
+            assert np.isclose(mean_y, 0.0, atol=1e-7)
+
+    def test_chief_ray_centering_logic(self, set_test_backend, cooke_triplet):
+        """When using chief ray reference, the chief ray coordinates should be (0, 0) in the centered data."""
+        spot = SpotDiagram(cooke_triplet, reference="chief_ray")
+        
+        ref_idx = spot._analysis_ref_wavelength_index
+        ref_wl = spot.wavelengths[ref_idx]
+        
+        # Center the data using the chief ray
+        centered_data = spot._center_spots(spot.data)
+        
+        # Also compute the uncentered chief ray centers
+        chief_centers = spot.generate_chief_rays_centers(ref_wl)
+        chief_centers_np = be.to_numpy(chief_centers)
+        
+        # Original centroid of the data (not centered on chief ray yet)
+        raw_centroid = spot.centroid()
+        
+        for i, field_data in enumerate(centered_data):
+            # The chief ray should be at (0, 0) in the centered data plot.
+            # But the spots are just dots. The difference between the uncentered chief ray
+            # and the uncentered centroid should match the centered centroid.
+            
+            ref_spot = field_data[ref_idx]
+            centered_mean_x = be.to_numpy(be.mean(ref_spot.x)).item()
+            centered_mean_y = be.to_numpy(be.mean(ref_spot.y)).item()
+            
+            raw_cx, raw_cy = raw_centroid[i]
+            chief_x, chief_y = chief_centers_np[i]
+            
+            # The centered data centroid should equal (raw centroid - chief ray)
+            expected_mean_x = be.to_numpy(raw_cx).item() - chief_x
+            expected_mean_y = be.to_numpy(raw_cy).item() - chief_y
+            
+            assert np.isclose(centered_mean_x, expected_mean_x, atol=1e-7)
+            assert np.isclose(centered_mean_y, expected_mean_y, atol=1e-7)
+
+    def test_different_radii(self, set_test_backend, cooke_triplet):
+        """The RMS radii should generally be different under different reference choices for off-axis fields."""
+        spot_chief = SpotDiagram(cooke_triplet, reference="chief_ray")
+        spot_centroid = SpotDiagram(cooke_triplet, reference="centroid")
+        
+        rms_chief = spot_chief.rms_spot_radius()
+        rms_centroid = spot_centroid.rms_spot_radius()
+        
+        # Field 1 and 2 are off-axis (Cooke triplet has fields at Y=0, Y=10, Y=20 roughly)
+        # Check that field 1 or 2 at reference wavelength are different
+        
+        f1_chief = be.to_numpy(rms_chief[1][1]).item()
+        f1_centroid = be.to_numpy(rms_centroid[1][1]).item()
+        
+        assert not np.isclose(f1_chief, f1_centroid, atol=1e-5), "RMS should differ between chief ray and centroid for off-axis fields."

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -76,13 +76,13 @@ class TestCookeTripetSpotDiagram:
         assert_allclose(geo_radius[0][1], 0.00628645771124)
         assert_allclose(geo_radius[0][2], 0.00931911440064)
 
-        assert_allclose(geo_radius[1][0], 0.03717783072826)
-        assert_allclose(geo_radius[1][1], 0.03864613392848)
-        assert_allclose(geo_radius[1][2], 0.04561512437816)
+        assert_allclose(geo_radius[1][0], 0.03928464835617618)
+        assert_allclose(geo_radius[1][1], 0.04075295155639047)
+        assert_allclose(geo_radius[1][2], 0.04772194200606705)
 
-        assert_allclose(geo_radius[2][0], 0.01951655430245)
-        assert_allclose(geo_radius[2][1], 0.02342659090311)
-        assert_allclose(geo_radius[2][2], 0.03747033587405)
+        assert_allclose(geo_radius[2][0], 0.018909146395329878)
+        assert_allclose(geo_radius[2][1], 0.022501847359635008)
+        assert_allclose(geo_radius[2][2], 0.036545592330568866)
 
     def test_spot_rms_radius(self, set_test_backend, cooke_triplet):
         spot = analysis.SpotDiagram(cooke_triplet)
@@ -92,13 +92,13 @@ class TestCookeTripetSpotDiagram:
         assert_allclose(rms_radius[0][1], 0.004293689564257)
         assert_allclose(rms_radius[0][2], 0.006195618755672)
 
-        assert_allclose(rms_radius[1][0], 0.015694600107671)
-        assert_allclose(rms_radius[1][1], 0.016786721284464)
-        assert_allclose(rms_radius[1][2], 0.019109151416248)
+        assert_allclose(rms_radius[1][0], 0.01582480029344623)
+        assert_allclose(rms_radius[1][1], 0.016918412809703662)
+        assert_allclose(rms_radius[1][2], 0.019221165873836682)
 
-        assert_allclose(rms_radius[2][0], 0.013229165357157)
-        assert_allclose(rms_radius[2][1], 0.012081348897953)
-        assert_allclose(rms_radius[2][2], 0.013596802321537)
+        assert_allclose(rms_radius[2][0], 0.013236232767092956)
+        assert_allclose(rms_radius[2][1], 0.012116688566406967)
+        assert_allclose(rms_radius[2][2], 0.013648684944411313)
 
     def test_airy_disc(self, set_test_backend, cooke_triplet):
         spot = analysis.SpotDiagram(cooke_triplet)


### PR DESCRIPTION
# Spot Diagram Refactor & Reference Strategies

This PR refactors the spot diagram module into a dedicated subpackage and introduces a strategy pattern for configuration of the spot centering reference point.

## Key Changes

- **Module Refactor**: Split the monolithic `spot_diagram.py` into a clean, SOLID-compliant `spot_diagram/` subpackage (`core.py`, `reference.py`, `plotting.py`).
- **Reference Strategies**: Added `SpotReferenceType` to allow users to choose the origin for spot calculations and Airy disk positioning.
- **New Default Reference**: Changed the default centering logic from the geometric centroid to the **true chief ray intersection**. This aligns Optiland with industry standards (e.g., Zemax, Code V) and slightly updates downstream expectations for off-axis RMS radii metrics.
- **Plotting Extraction**: Moved matplotlib logic out of `SpotDiagram` into standalone, stateless plotting helper functions.

## Usage Example

```python
from optiland.samples.objectives import CookeTriplet
from optiland.analysis import SpotDiagram

optic = CookeTriplet()

# Default behavior (uses the chief ray intersection as the origin)
spot_chief = SpotDiagram(optic, reference="chief_ray")
print(spot_chief.rms_spot_radius())

# Legacy behavior (uses the geometric centroid of the reference wavelength spots)
spot_centroid = SpotDiagram(optic, reference="centroid")
print(spot_centroid.rms_spot_radius())
```