### PR TITLE
Paraxial surfaces: fixes for tracing and rendering

### DIFF
--- a/optiland/interactions/thin_lens_interaction_model.py
+++ b/optiland/interactions/thin_lens_interaction_model.py
@@ -71,17 +71,25 @@ class ThinLensInteractionModel(BaseInteractionModel):
         rays.opd = rays.opd - (rays.x**2 + rays.y**2) / (2 * self.f)
 
         n1 = self.material_pre.n(rays.w)
+        n2 = n1 if self.is_reflective else self.material_post.n(rays.w)
+        L, M, N = [component / be.abs(rays.N) for component in (rays.L, rays.M, rays.N)]
+        if not be.isinf(self.f):
+            if self.is_reflective:
+                f1 = f2 = -self.f * be.copysign(be.ones_like(rays.N), rays.N)
+            else:
+                f = self.f * be.copysign(be.ones_like(rays.N), rays.N)
+                f1 = f * n1
+                f2 = f * n2
+            L = L * f1 - rays.x
+            M = M * f1 - rays.y
+            N = be.where(rays.N > 0, f2, -f2)
+            if self.f < 0:
+                L = -L
+                M = -M
+                N = -N
 
-        n2 = -n1 if self.is_reflective else self.material_post.n(rays.w)
-
-        ux1 = rays.L / rays.N
-        uy1 = rays.M / rays.N
-
-        ux2 = 1 / n2 * (n1 * ux1 - rays.x / self.f)
-        uy2 = 1 / n2 * (n1 * uy1 - rays.y / self.f)
-
-        L = ux2
-        M = uy2
+        else:
+            N *= n2 / n1
 
         # only normalize if required
         if self.bsdf or self.coating or isinstance(rays, PolarizedRays):
@@ -104,11 +112,13 @@ class ThinLensInteractionModel(BaseInteractionModel):
             # update polarization matrices, if PolarizedRays
             rays.update()
 
-        # paraxial approximation -> direction is not necessarily unit vector
+        if self.is_reflective:
+            N = -N
         rays.L = L
         rays.M = M
-        rays.N = be.copysign(be.ones_like(rays.N), rays.N)
-        rays.is_normalized = False
+        rays.N = N
+
+        rays.normalize()
 
         return rays
 

--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -67,7 +67,7 @@ class Paraxial:
         """
         z_start = -1
         wavelength = self.optic.primary_wavelength
-        y, u = self._trace_generic(1.0, 0.0, z_start, wavelength, reverse=True, skip=1)
+        y, u = self.trace_generic(1.0, 0.0, z_start, wavelength, reverse=True, skip=1)
         f1 = y[0] / u[-1]
         return f1[0]
 

--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -67,7 +67,7 @@ class Paraxial:
         """
         z_start = -1
         wavelength = self.optic.primary_wavelength
-        y, u = self.trace_generic(1.0, 0.0, z_start, wavelength, reverse=True)
+        y, u = self._trace_generic(1.0, 0.0, z_start, wavelength, reverse=True, skip=1)
         f1 = y[0] / u[-1]
         return f1[0]
 

--- a/optiland/raytrace/paraxial_ray_tracer.py
+++ b/optiland/raytrace/paraxial_ray_tracer.py
@@ -116,7 +116,11 @@ class ParaxialRayTracer:
             # reflect or refract
             if surfs[k].interaction_model.is_reflective:
                 if surfs[k].surface_type == "paraxial":
-                    f = surfs[k].interaction_model.f
+                    f = (
+                        -surfs[k].interaction_model.f
+                        if reverse
+                        else surfs[k].interaction_model.f
+                    )
                     u_ = -u_ - y_ / f
                 else:
                     u_ = -u_ - 2 * y_ / R[k]

--- a/tests/test_paraxial.py
+++ b/tests/test_paraxial.py
@@ -35,6 +35,148 @@ from .utils import assert_allclose
 # TODO: add tests for non-air object and image spaces
 
 
+class Lens:
+    """Base class to calculate paraxial properties. Formulas from Fundamentals Of
+    Optics, Jenkins & White, 4th ed, Ch. 5.6. Note that a Gaussian coordinate system is
+    used in the source. Variables n1, n2 and n3 are n, n' and n'' in the source, and
+    stand for the refractive index in the object, lens, and image media, respectively.
+    P, P1 and P2 are powers, not principal planes, as per source."""
+
+    n1: float
+    n2: float
+    n3: float
+    d: float
+
+    @property
+    def P1(self):
+        raise NotImplementedError
+
+    @property
+    def P2(self):
+        raise NotImplementedError
+
+    @property
+    def P(self) -> float:
+        return self.P1 + self.P2 - self.d / self.n2 * self.P1 * self.P2
+
+    @property
+    def F1(self) -> float:
+        return -self.n1 / self.P * (1 - self.d / self.n2 * self.P2)
+
+    @property
+    def F2(self) -> float:
+        return self.n3 / self.P * (1 - self.d / self.n2 * self.P1)
+
+    @property
+    def f1(self) -> float:
+        return (
+            -self.n1 / self.P
+        )  # Swapped sign wrt source. Reason: use cartesian coordinates
+
+    @property
+    def f2(self) -> float:
+        return self.n3 / self.P
+
+    @property
+    def PP1(self) -> float:
+        """Principal plane. IN J&W defined wrt first lens surface"""
+        return self.n1 / self.P * self.d / self.n2 * self.P2
+
+    @property
+    def PP2(self) -> float:
+        """Principal plane. IN J&W defined wrt last lens surface"""
+        return -self.n3 / self.P * self.d / self.n2 * self.P1
+
+
+class ThickLens(Lens):
+    """Calculate the properties of an immersed thick lens made of two spherical surfaces with radii
+    r1 and r2, a distance d apart."""
+
+    r1: float
+    r2: float
+
+    def __init__(
+        self, n1: float, n2: float, n3: float, r1: float, r2: float, d: float
+    ) -> None:
+        self.n1, self.n2, self.n3 = n1, n2, n3
+        self.r1, self.r2 = r1, r2
+        self.d = d
+
+    @property
+    def P1(self) -> float:
+        return (self.n2 - self.n1) / self.r1
+
+    @property
+    def P2(self) -> float:
+        return (self.n3 - self.n2) / self.r2
+
+
+class CompoundLens(Lens):
+    """Calculate the properties of a system of two immersed thin lenses with focal lengths
+    f1 and f2, a distance d apart. The focal lengths are the equivalent in air, and the
+    actual focal lengths will be adjusted according to immersion."""
+
+    _f1: float
+    _f2: float
+
+    def __init__(
+        self, n1: float, n2: float, n3: float, f1: float, f2: float, d: float
+    ) -> None:
+        self.n1, self.n2, self.n3 = n1, n2, n3
+        self._f1, self._f2 = f1, f2
+        self.d = d
+
+    @property
+    def P1(self) -> float:
+        return 1 / self._f1
+
+    @property
+    def P2(self) -> float:
+        return 1 / self._f2
+
+
+class Mirror:
+    """Simple class to describe a mirror, uses sign convention as in JAMES P. C.
+    SOUTHALL, MIRRORS, PRISMS AND LENSES, THE MACMILLAN COMPANY, 1918"""
+
+    r: float
+
+    def __init__(self, r: float, n: float) -> None:
+        self.r = r
+        self.n = n
+
+    @property
+    def P(self) -> float:
+        # Sign convention as in source
+        return -2 * self.n / self.r
+
+
+class ThickMirror:
+    """Class to describe a 'Thick Mirror', a mirror with a lens in front of it. The
+    light passes back and forth through the lens after reflecting in the mirror. The
+    formula for the effective power of the system is described in JAMES P. C. SOUTHALL,
+    MIRRORS, PRISMS AND LENSES, THE MACMILLAN COMPANY, 1918, p. 379."""
+
+    lens: ThickLens
+    mirror: Mirror
+
+    def __init__(self, lens: ThickLens, mirror: Mirror, d: float) -> None:
+        self.lens = lens
+        self.mirror = mirror
+        self.d = d
+
+    @property
+    def _c(self) -> float:
+        return (self.d - self.lens.PP2) / self.lens.n3
+
+    @property
+    def P(self) -> float:
+        c = self._c
+        P1 = self.lens.P
+        P2 = self.mirror.P
+        return (1 - c * P1) * (2 * P1 + P2 - c * P1 * P2)
+
+
 def get_optic_data():
     return [
         (
@@ -696,105 +838,6 @@ def test_negative_lens():
     )
 
 
-class Lens:
-    """Base class to calculate paraxial properties. Formulas from Fundamentals Of
-    Optics, Jenkins & White, 4th ed, Ch. 5.6. Note that a Gaussian coordinate system is
-    used in the source. Variables n1, n2 and n3 are n, n' and n'' in the source, and
-    stand for the refractive index in the object, lens, and image media, respectively.
-    P, P1 and P2 are powers, not principal planes, as per source."""
-
-    n1: float
-    n2: float
-    n3: float
-    d: float
-
-    @property
-    def P1(self):
-        raise NotImplementedError
-
-    @property
-    def P2(self):
-        raise NotImplementedError
-
-    @property
-    def P(self) -> float:
-        return self.P1 + self.P2 - self.d / self.n2 * self.P1 * self.P2
-
-    @property
-    def F1(self) -> float:
-        return -self.n1 / self.P * (1 - self.d / self.n2 * self.P2)
-
-    @property
-    def F2(self) -> float:
-        return self.n3 / self.P * (1 - self.d / self.n2 * self.P1)
-
-    @property
-    def f1(self) -> float:
-        return (
-            -self.n1 / self.P
-        )  # Swapped sign wrt source. Reason: use cartesian coordinates
-
-    @property
-    def f2(self) -> float:
-        return self.n3 / self.P
-
-    @property
-    def PP1(self) -> float:
-        """Principal plane. IN J&W defined wrt first lens surface"""
-        return self.n1 / self.P * self.d / self.n2 * self.P2
-
-    @property
-    def PP2(self) -> float:
-        """Principal plane. IN J&W defined wrt last lens surface"""
-        return -self.n3 / self.P * self.d / self.n2 * self.P1
-
-
-class ThickLens(Lens):
-    """Calculate the properties of an immersed thick lens made of two spherical surfaces with radii
-    r1 and r2, a distance d apart."""
-
-    r1: float
-    r2: float
-
-    def __init__(
-        self, n1: float, n2: float, n3: float, r1: float, r2: float, d: float
-    ) -> None:
-        self.n1, self.n2, self.n3 = n1, n2, n3
-        self.r1, self.r2 = r1, r2
-        self.d = d
-
-    @property
-    def P1(self) -> float:
-        return (self.n2 - self.n1) / self.r1
-
-    @property
-    def P2(self) -> float:
-        return (self.n3 - self.n2) / self.r2
-
-
-class CompoundLens(Lens):
-    """Calculate the properties of a system of two immersed thin lenses with focal lengths
-    f1 and f2, a distance d apart."""
-
-    _f1: float
-    _f2: float
-
-    def __init__(
-        self, n1: float, n2: float, n3: float, f1: float, f2: float, d: float
-    ) -> None:
-        self.n1, self.n2, self.n3 = n1, n2, n3
-        self._f1, self._f2 = f1, f2
-        self.d = d
-
-    @property
-    def P1(self) -> float:
-        return self.n1 / self._f1
-
-    @property
-    def P2(self) -> float:
-        return self.n3 / self._f2
-
-
 @pytest.mark.parametrize("n1", [1.0, 1.33])
 @pytest.mark.parametrize("n2", [1.5, 1.8])
 @pytest.mark.parametrize("n3", [1.33, 1.5, 1.0])
@@ -840,7 +883,7 @@ def test_compound_lens(n1, n2, n3, f1, f2, d, set_test_backend):
     lens.surfaces.add(
         index=1,
         surface_type="paraxial",
-        f=f1 / n1,
+        f=f1,
         thickness=d,
         material=IdealMaterial(n2),
         is_stop=True,
@@ -848,7 +891,7 @@ def test_compound_lens(n1, n2, n3, f1, f2, d, set_test_backend):
     lens.surfaces.add(
         index=2,
         surface_type="paraxial",
-        f=f2 / n3,
+        f=f2,
         thickness=0.0,
         material=IdealMaterial(n3),
         is_stop=False,
@@ -862,4 +905,373 @@ def test_compound_lens(n1, n2, n3, f1, f2, d, set_test_backend):
     assert_allclose(
         [cl.F1, cl.F2, cl.f1, cl.f2, cl.PP1, cl.PP2],
         [px.F1(), px.F2(), px.f1(), px.f2(), px.P1(), px.P2()],
+    )
+
+
+@pytest.mark.parametrize("n1", [1.0, 1.33])
+@pytest.mark.parametrize("n2", [1.5, 2.0])
+@pytest.mark.parametrize("n3", [1.0, 1.33])
+@pytest.mark.parametrize("r1", [100, -50])
+@pytest.mark.parametrize("r2", [50, -100])
+@pytest.mark.parametrize("rm", [250, -100])
+@pytest.mark.parametrize("d1", [1.0, 5.0])
+@pytest.mark.parametrize("d2", [5.0, 10])
+def test_thick_mirror(n1, n2, n3, r1, r2, rm, d1, d2):
+    thick_lens = ThickLens(n1, n2, n3, r1, r2, d1)
+    mirror = Mirror(rm, n3)
+    thick_mirror = ThickMirror(thick_lens, mirror, d2)
+    lens = Optic()
+
+    lens.add_surface(
+        index=0, radius=be.inf, thickness=be.inf, material=IdealMaterial(n1)
+    )
+    lens.add_surface(
+        index=1, radius=r1, thickness=d1, is_stop=True, material=IdealMaterial(n2)
+    )
+    lens.add_surface(
+        index=2, radius=r2, thickness=d2, is_stop=False, material=IdealMaterial(n3)
+    )
+    lens.add_surface(
+        index=3, radius=rm, thickness=-d2, is_stop=False, material="mirror"
+    )
+    lens.add_surface(
+        index=4, radius=r2, thickness=-d1, is_stop=False, material=IdealMaterial(n2)
+    )
+    lens.add_surface(
+        index=5, radius=r1, thickness=0.0, is_stop=False, material=IdealMaterial(n1)
+    )
+    lens.add_surface(index=lens.surface_group.num_surfaces, material=IdealMaterial(n1))
+    lens.set_aperture(aperture_type="float_by_stop_size", value=5)
+    lens.add_field(0.0)
+    lens.set_field_type("angle")
+    lens.add_wavelength(value=0.55, is_primary=True)
+
+    # Adjust sign to account for sign convention in source:
+    assert -n1 / thick_mirror.P == pytest.approx(lens.paraxial.f2())
+
+
+@pytest.mark.parametrize("n1", [1.0, 1.33])
+@pytest.mark.parametrize("n2", [1.0, 1.2])
+@pytest.mark.parametrize("f", [50.0, -75.0, -100.0, 225.0])
+@pytest.mark.parametrize("d", [0.0, 1.0, 2.0, 5.0, 10.0, 100.0])
+def test_mirrored_lens(n1, n2, f, d, set_test_backend):
+    """Test to ensure that a lens system consisting of a paraxial lens and mirror yield
+    the same results as an unfolded lens system, with the exception of sign swaps"""
+    cl = CompoundLens(n1, n2, n1, f, f, 2 * d)
+    lens = Optic()
+    lens.add_surface(
+        index=0, radius=be.inf, thickness=be.inf, material=IdealMaterial(n1)
+    )
+    lens.add_surface(
+        index=1,
+        surface_type="paraxial",
+        f=f,
+        thickness=d,
+        material=IdealMaterial(n2),
+        is_stop=True,
+    )
+    lens.add_surface(
+        index=2,
+        surface_type="paraxial",
+        material="mirror",
+        f=be.inf,
+        thickness=-d,
+        is_stop=False,
+    )
+    lens.add_surface(
+        index=3,
+        surface_type="paraxial",
+        f=-f,
+        thickness=0.0,
+        material=IdealMaterial(n1),
+        is_stop=False,
+    )
+
+    lens.add_surface(index=4, material=IdealMaterial(n1))
+    lens.add_wavelength(value=0.55, is_primary=True)
+    lens.add_field(y=0)
+    lens.set_field_type(field_type="angle")
+    lens.set_aperture(aperture_type="float_by_stop_size", value=5)
+    px = lens.paraxial
+    assert_allclose(
+        [cl.f1, cl.F1, cl.PP1, cl.f2, cl.F2, cl.PP2],
+        [px.f1(), px.F1(), px.P1(), -px.f2(), -px.F2(), -px.P2()],
+    )
+
+
+def _get_paraxial_items(paraxial: Paraxial):
+    return [getattr(paraxial, item)() for item in ("f1", "f2", "F1", "F2", "P1", "P2")]
+
+
+@pytest.mark.parametrize(
+    "paraxial_surfaces, real_surfaces",
+    [
+        (
+            (  # Case 1: single mirror
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": -50,
+                    "is_stop": True,
+                    "thickness": 0.0,
+                    "material": "mirror",
+                },
+                {"material": IdealMaterial(2.0)},
+            ),
+            (
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "radius": -100.0,
+                    "is_stop": True,
+                    "thickness": 0.0,
+                    "material": "mirror",
+                },
+                {"material": IdealMaterial(2.0)},
+            ),
+        ),
+        (
+            (  # Case 2: Backward propagation through paraxial surface
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": 50,
+                    "is_stop": True,
+                    "thickness": 10.0,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": be.inf,
+                    "is_stop": False,
+                    "thickness": -10.0,
+                    "material": "mirror",
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": -50,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {"material": IdealMaterial(1.5)},
+            ),
+            (
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "radius": 100,
+                    "is_stop": True,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(2.5),
+                },
+                {
+                    "radius": -50,
+                    "is_stop": True,
+                    "thickness": 10.0,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "radius": be.inf,
+                    "is_stop": False,
+                    "thickness": -10.0,
+                    "material": "mirror",
+                },
+                {
+                    "radius": -50,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(2.5),
+                },
+                {
+                    "radius": 100,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {"material": IdealMaterial(1.5)},
+            ),
+        ),
+        (
+            (  # Case 3: Case 2 with opposite focal lengths
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": -50,
+                    "is_stop": True,
+                    "thickness": 10.0,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": be.inf,
+                    "is_stop": False,
+                    "thickness": -10.0,
+                    "material": "mirror",
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": 50,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {"material": IdealMaterial(1.5)},
+            ),
+            (
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "radius": -100,
+                    "is_stop": True,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(2.5),
+                },
+                {
+                    "radius": 50,
+                    "is_stop": True,
+                    "thickness": 10.0,
+                    "material": IdealMaterial(2.0),
+                },
+                {
+                    "radius": be.inf,
+                    "is_stop": False,
+                    "thickness": -10.0,
+                    "material": "mirror",
+                },
+                {
+                    "radius": 50,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(2.5),
+                },
+                {
+                    "radius": -100,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {"material": IdealMaterial(1.5)},
+            ),
+        ),
+        (
+            (  # Case 3: Double paraxial mirror, one with glass substrate
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.0),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": -50,
+                    "is_stop": True,
+                    "thickness": -20.0,
+                    "material": "mirror",
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": be.inf,
+                    "is_stop": False,
+                    "thickness": -4.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": 50.0,
+                    "is_stop": False,
+                    "thickness": 4,
+                    "material": "mirror",
+                },
+                {
+                    "surface_type": "paraxial",
+                    "f": be.inf,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.0),
+                },
+                {"material": IdealMaterial(1.0)},
+            ),
+            (
+                {
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "material": IdealMaterial(1.0),
+                },
+                {
+                    "radius": -100,
+                    "is_stop": True,
+                    "thickness": -20.0,
+                    "material": "mirror",
+                },
+                {
+                    "radius": be.inf,
+                    "is_stop": False,
+                    "thickness": -4.0,
+                    "material": IdealMaterial(1.5),
+                },
+                {
+                    "radius": 100.0,
+                    "is_stop": False,
+                    "thickness": 4,
+                    "material": "mirror",
+                },
+                {
+                    "radius": be.inf,
+                    "is_stop": False,
+                    "thickness": 0.0,
+                    "material": IdealMaterial(1.0),
+                },
+                {"material": IdealMaterial(1.0)},
+            ),
+        ),
+    ],
+)
+def test_equivalence(paraxial_surfaces, real_surfaces, set_test_backend):
+    paraxial_lens = Optic()
+
+    for surface_args in paraxial_surfaces:
+        paraxial_lens.add_surface(
+            index=paraxial_lens.surface_group.num_surfaces, **surface_args
+        )
+
+    paraxial_lens.add_wavelength(value=0.55, is_primary=True)
+    paraxial_lens.add_field(y=0)
+    paraxial_lens.set_field_type(field_type="angle")
+    paraxial_lens.set_aperture(aperture_type="float_by_stop_size", value=5)
+
+    real_lens = Optic()
+    for surface_args in real_surfaces:
+        real_lens.add_surface(
+            index=real_lens.surface_group.num_surfaces, **surface_args
+        )
+
+    real_lens.add_wavelength(value=0.55, is_primary=True)
+    real_lens.add_field(y=0)
+    real_lens.set_field_type(field_type="angle")
+    real_lens.set_aperture(aperture_type="float_by_stop_size", value=5)
+
+    assert_allclose(
+        _get_paraxial_items(paraxial_lens.paraxial),
+        _get_paraxial_items(real_lens.paraxial),
     )

--- a/tests/test_paraxial.py
+++ b/tests/test_paraxial.py
@@ -922,29 +922,29 @@ def test_thick_mirror(n1, n2, n3, r1, r2, rm, d1, d2):
     thick_mirror = ThickMirror(thick_lens, mirror, d2)
     lens = Optic()
 
-    lens.add_surface(
+    lens.surfaces.add(
         index=0, radius=be.inf, thickness=be.inf, material=IdealMaterial(n1)
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=1, radius=r1, thickness=d1, is_stop=True, material=IdealMaterial(n2)
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=2, radius=r2, thickness=d2, is_stop=False, material=IdealMaterial(n3)
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=3, radius=rm, thickness=-d2, is_stop=False, material="mirror"
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=4, radius=r2, thickness=-d1, is_stop=False, material=IdealMaterial(n2)
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=5, radius=r1, thickness=0.0, is_stop=False, material=IdealMaterial(n1)
     )
-    lens.add_surface(index=lens.surface_group.num_surfaces, material=IdealMaterial(n1))
+    lens.surfaces.add(index=lens.surfaces.num_surfaces, material=IdealMaterial(n1))
     lens.set_aperture(aperture_type="float_by_stop_size", value=5)
-    lens.add_field(0.0)
-    lens.set_field_type("angle")
-    lens.add_wavelength(value=0.55, is_primary=True)
+    lens.fields.add(0.0)
+    lens.fields.set_type("angle")
+    lens.wavelengths.add(value=0.55, is_primary=True)
 
     # Adjust sign to account for sign convention in source:
     assert -n1 / thick_mirror.P == pytest.approx(lens.paraxial.f2())
@@ -959,10 +959,10 @@ def test_mirrored_lens(n1, n2, f, d, set_test_backend):
     the same results as an unfolded lens system, with the exception of sign swaps"""
     cl = CompoundLens(n1, n2, n1, f, f, 2 * d)
     lens = Optic()
-    lens.add_surface(
+    lens.surfaces.add(
         index=0, radius=be.inf, thickness=be.inf, material=IdealMaterial(n1)
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=1,
         surface_type="paraxial",
         f=f,
@@ -970,7 +970,7 @@ def test_mirrored_lens(n1, n2, f, d, set_test_backend):
         material=IdealMaterial(n2),
         is_stop=True,
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=2,
         surface_type="paraxial",
         material="mirror",
@@ -978,7 +978,7 @@ def test_mirrored_lens(n1, n2, f, d, set_test_backend):
         thickness=-d,
         is_stop=False,
     )
-    lens.add_surface(
+    lens.surfaces.add(
         index=3,
         surface_type="paraxial",
         f=-f,
@@ -987,10 +987,10 @@ def test_mirrored_lens(n1, n2, f, d, set_test_backend):
         is_stop=False,
     )
 
-    lens.add_surface(index=4, material=IdealMaterial(n1))
-    lens.add_wavelength(value=0.55, is_primary=True)
-    lens.add_field(y=0)
-    lens.set_field_type(field_type="angle")
+    lens.surfaces.add(index=4, material=IdealMaterial(n1))
+    lens.wavelengths.add(value=0.55, is_primary=True)
+    lens.fields.add(y=0)
+    lens.fields.set_type(field_type="angle")
     lens.set_aperture(aperture_type="float_by_stop_size", value=5)
     px = lens.paraxial
     assert_allclose(
@@ -1251,24 +1251,22 @@ def test_equivalence(paraxial_surfaces, real_surfaces, set_test_backend):
     paraxial_lens = Optic()
 
     for surface_args in paraxial_surfaces:
-        paraxial_lens.add_surface(
-            index=paraxial_lens.surface_group.num_surfaces, **surface_args
+        paraxial_lens.surfaces.add(
+            index=paraxial_lens.surfaces.num_surfaces, **surface_args
         )
 
-    paraxial_lens.add_wavelength(value=0.55, is_primary=True)
-    paraxial_lens.add_field(y=0)
-    paraxial_lens.set_field_type(field_type="angle")
+    paraxial_lens.wavelengths.add(value=0.55, is_primary=True)
+    paraxial_lens.fields.add(y=0)
+    paraxial_lens.fields.set_type(field_type="angle")
     paraxial_lens.set_aperture(aperture_type="float_by_stop_size", value=5)
 
     real_lens = Optic()
     for surface_args in real_surfaces:
-        real_lens.add_surface(
-            index=real_lens.surface_group.num_surfaces, **surface_args
-        )
+        real_lens.surfaces.add(index=real_lens.surfaces.num_surfaces, **surface_args)
 
-    real_lens.add_wavelength(value=0.55, is_primary=True)
-    real_lens.add_field(y=0)
-    real_lens.set_field_type(field_type="angle")
+    real_lens.wavelengths.add(value=0.55, is_primary=True)
+    real_lens.fields.add(y=0)
+    real_lens.fields.set_type(field_type="angle")
     real_lens.set_aperture(aperture_type="float_by_stop_size", value=5)
 
     assert_allclose(

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -140,20 +140,33 @@ class TestThinLensInteractionModel:
         assert surface.interaction_model.from_dict(data, None)
 
     def test_refractive_paraxial_ray_trace(self, set_test_backend):
+    @pytest.mark.parametrize(
+        "focal_length, n1",
+        [
+            (50.0, 1.0),
+            (50.0, 1.5),
+            (50.0, 2.0),
+            (-50.0, 1.0),
+            (-50.0, 1.5),
+            (-50.0, 2.0),
+        ],
+    )
+    def test_paraxial_surface_perfect_imaging_reflection(
+        self, focal_length, n1, set_test_backend
+    ):
         lens = Optic()
 
         # add surfaces
-        lens.surfaces.add(index=0, thickness=be.inf)
+        lens.surfaces.add(index=0, thickness=be.inf, material=IdealMaterial(n1))
         lens.surfaces.add(
             index=1,
             surface_type="paraxial",
-            thickness=75,
-            f=50,
+            material="mirror",
+            thickness=focal_length,
+            f=focal_length,
             is_stop=True,
-            material=IdealMaterial(1.5, 0),
-            is_reflective=False,
         )
-        lens.surfaces.add(index=2, material=IdealMaterial(1.5, 0))
+        lens.surfaces.add(index=2)
 
         # add aperture
         lens.set_aperture(aperture_type="EPD", value=20)
@@ -177,4 +190,5 @@ class TestThinLensInteractionModel:
         assert_allclose(rays.y, 0)
 
         # confirm all points at exact same z
-        assert_allclose(rays.z, 75)
+        assert_allclose(rays.z, focal_length)
+

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -124,22 +124,6 @@ class TestThinLensInteractionModel:
         # confirm all points at exact same z
         assert_allclose(rays.z, focal_length * n2)
 
-    def test_flip(self, surface):
-        f_initial = be.copy(surface.interaction_model.f)
-        surface.interaction_model.flip()
-        assert_allclose(surface.interaction_model.f, f_initial)
-
-    def test_to_dict(self, surface):
-        data = surface.interaction_model.to_dict()
-        assert "focal_length" in data
-        assert data["focal_length"] == 42
-
-    def test_from_dict(self, surface):
-        data = surface.interaction_model.to_dict()
-        data["material_pre"] = None
-        assert surface.interaction_model.from_dict(data, None)
-
-    def test_refractive_paraxial_ray_trace(self, set_test_backend):
     @pytest.mark.parametrize(
         "focal_length, n1",
         [
@@ -192,3 +176,48 @@ class TestThinLensInteractionModel:
         # confirm all points at exact same z
         assert_allclose(rays.z, focal_length)
 
+    @pytest.mark.parametrize("n1, n2", [(1.0, 1.0), (2.0, 1.5), (1.5, 2.0)])
+    def test_plane_paraxial_surface_refraction(self, n1, n2, set_test_backend):
+        lens = Optic()
+
+        # add surfaces
+        lens.add_surface(index=0, thickness=be.inf, material=IdealMaterial(n1))
+        lens.add_surface(
+            index=1,
+            surface_type="paraxial",
+            material=IdealMaterial(n2),
+            thickness=0.0,
+            f=be.inf,
+            is_stop=True,
+        )
+        lens.add_surface(index=2, material=IdealMaterial(n2))
+
+        model = lens.surface_group.surfaces[1].interaction_model
+        assert isinstance(model, ThinLensInteractionModel)
+
+        ray_in = RealRays(0.0, 0.0, -1.0, 0.1, 0.2, 1.0, intensity=1.0, wavelength=0.55)
+        ray_out = RealRays(
+            0.0, 0.0, -1.0, 0.1, 0.2, 1.0 * n2 / n1, intensity=1.0, wavelength=0.55
+        )
+        ray_out.normalize()
+        model.interact_real_rays(ray_in)
+
+        assert_allclose(
+            [ray_in.x, ray_in.y, ray_in.z, ray_in.L, ray_in.M, ray_in.N],
+            [ray_out.x, ray_out.y, ray_out.z, ray_out.L, ray_out.M, ray_out.N],
+        )
+
+    def test_flip(self, surface):
+        f_initial = be.copy(surface.interaction_model.f)
+        surface.interaction_model.flip()
+        assert_allclose(surface.interaction_model.f, f_initial)
+
+    def test_to_dict(self, surface):
+        data = surface.interaction_model.to_dict()
+        assert "focal_length" in data
+        assert data["focal_length"] == 42
+
+    def test_from_dict(self, surface):
+        data = surface.interaction_model.to_dict()
+        data["material_pre"] = None
+        assert surface.interaction_model.from_dict(data, None)

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -72,16 +72,30 @@ class TestThinLensInteractionModel:
         traced_rays = surface.trace(rays)
         assert isinstance(traced_rays, RealRays)
 
-    def test_paraxial_surface_perfect_imaging(self, set_test_backend):
+    @pytest.mark.parametrize(
+        "focal_length, n1, n2",
+        [
+            (50.0, 1.0, 1.0),
+            (50.0, 1.5, 2.0),
+            (50.0, 2.0, 1.5),
+            (-50.0, 1.0, 1.0),
+            (-50.0, 1.5, 2.0),
+            (-50.0, 2.0, 1.5),
+        ],
+    )
+    def test_paraxial_surface_perfect_imaging_refraction(
+        self, focal_length, n1, n2, set_test_backend
+    ):
         lens = Optic()
 
         # add surfaces
-        lens.surfaces.add(index=0, thickness=be.inf)
+        lens.surfaces.add(index=0, thickness=be.inf, material=IdealMaterial(n1))
         lens.surfaces.add(
             index=1,
             surface_type="paraxial",
-            thickness=100,
-            f=100,
+            material=IdealMaterial(n2),
+            thickness=focal_length * n2,
+            f=focal_length,
             is_stop=True,
         )
         lens.surfaces.add(index=2)
@@ -92,7 +106,6 @@ class TestThinLensInteractionModel:
         # add field
         lens.fields.set_type(field_type="angle")
         lens.fields.add(y=0)
-        # lens.fields.add(y=5)
 
         # add wavelength
         lens.wavelengths.add(value=0.55, is_primary=True)
@@ -109,7 +122,7 @@ class TestThinLensInteractionModel:
         assert_allclose(rays.y, 0)
 
         # confirm all points at exact same z
-        assert_allclose(rays.z, 100)
+        assert_allclose(rays.z, focal_length * n2)
 
     def test_flip(self, surface):
         f_initial = be.copy(surface.interaction_model.f)


### PR DESCRIPTION
**Background**
While working on #382 I ran into a few issues regarding the handling of paraxial mirrors, and the backward tracing of real rays through paraxial surfaces. Those issues lead to erroneous results for the locations and magnitudes of the front and back focal plane when paraxial mirrors are involved. In addition, the RealRay interaction with paraxial surfaces was not handling backward tracing well, leading to confusing ray diagrams that did not reflect the expected outcome. 

This PR hopes to address these shortcomings, and consists of two parts: 
1. Fixing the tracing of paraxial rays through the system that includes rays bouncing back from paraxial mirrors.
2. Fixing the interaction of real rays with paraxial surfaces, in order to fix the display of the ray diagram. 

**Approach** 
The tracing of rays through real surfaces seems to be accurate regardless the direction, and also the paraxial calculations (`f1`, `f2`, etc.) seem accurate. Therefore, I've used the outcome of "real" models as the "gold standard" to compare the results with when using paraxial surfaces.

Sign convention:
For mirrors and a collimated beam coming from the left, the rays will be focused to the left of the surface when the focal length is negative. For a positive focal length, the rays will seem like coming from the right of the surface. The sign is flipped for rays coming from the right, i.e., after having reflected off an mirror earlier in the path. This sign convention seems to be in step with real mirrors: for a collimated beam coming from the left, a negative radius yields a real focus on the left, and a positive radius gives a virtual focus on the right. For rays from the right, it's vice versa.

**Examples**
Below I show a few examples of problematic lens systems. I tabulated the outcome of the paraxial calculations as obtained from `master` (at the time of writing based on [this](https://github.com/rjmoerland/optiland/commit/ebd2de23cab280bd10773ae27d5624055a49f611) commit ), together with the outcomes obtained with the code in this PR (labeled as "This PR") and the outcome of paraxial calculations for an equivalent "real" lens system. Sometimes the results from `master` and this PR are identical, but then the ray diagram is off, sometimes both are off.

Below each table I plot the ray diagrams as obtained with the `master` branch, this branch, and the equivalent real systems. Also here, the paraxial ray diagrams obtained with this branch and the equivalent real systems are identical.

## Example 1

A single paraxial mirror, with focal length -50 (real focus to the left):

|         | f1 | F1 | P1 | f2 | F2 | P2 |
|---------|----|----|----|----|----|----|
| Master  | 50.000   | 50.000   |  0.000  | -50.000   |  -50.000  | 0.000  |
| This PR  | -50.000   | -50.000   |  0.000  | -50.000   |  -50.000  | 0.000  |
| Real mirror*   | -50.000   | -50.000   |  0.000  | -50.000   |  -50.000  | 0.000  |

*R = -100

**master**
<img width="857" height="218" alt="image" src="https://github.com/user-attachments/assets/7c1b50ec-b2d5-42bc-b1f0-29be12bc2b2f" />

**This PR**
<img width="857" height="142" alt="image" src="https://github.com/user-attachments/assets/f1de75f5-63e8-47b7-bcca-9ccb3c60d23e" />

**Reference equivalent system**
<img width="857" height="142" alt="image" src="https://github.com/user-attachments/assets/c205ade8-977a-4e42-aa26-6471a2ac06cf" />

## Example 2

A paraxial lens with f=50, followed by a flat mirror at 10 units distance, reflecting the light back through the lens:

|         | f1 | F1 | P1 | f2 | F2 | P2 |
|---------|----|----|----|----|----|----|
| Master  | -31.250   | -18.750   |  12.500  | -31.250   |  -18.750  | 12.500  |
| This PR  | -31.250   | -18.750   |  12.500  | -31.250   |  -18.750  | 12.500  |
| Real lens*  | -31.250   | -18.750   |  12.500  | -31.250   |  -18.750  | 12.500  |

*Lens consisting of two surfaces with R = 100 and R = -100, respectively, with n = 2 and thickness 0.

**master**
<img width="844" height="225" alt="image" src="https://github.com/user-attachments/assets/795fd119-4033-4ba0-87fe-2516fb966ded" />

**This PR**
<img width="844" height="198" alt="image" src="https://github.com/user-attachments/assets/cad9f5bc-f3d5-4d54-8a7e-8ed20c203094" />

**Reference equivalent system**
<img width="844" height="198" alt="image" src="https://github.com/user-attachments/assets/8c3f1f2c-89b0-4cbb-94db-200ba2cc603e" />

## Example 3 

Two paraxial mirrors, with f = -50 and f = 50 respectively, and a gap of 20 in between:

|         | f1 | F1 | P1 | f2 | F2 | P2 |
|---------|----|----|----|----|----|----|
| Master  | 20.833   | 29.167   |  8.333  | 31.250   |  -1.250  | -32.500  |
| This PR  | -31.250   | -18.750   |  12.500  | 31.250   |  -1.250  | -32.500  |
| Real mirrors*  | -31.250   | -18.750   |  12.500  | 31.250   |  -1.250  | -32.500  |

*Real mirrors with radius -100 and +100, respectively.

**master:**
<img width="739" height="371" alt="image" src="https://github.com/user-attachments/assets/60b6f006-4537-4139-815e-fd8174a0e63a" />

**This PR:**
<img width="844" height="218" alt="image" src="https://github.com/user-attachments/assets/5e4e9961-a737-40ce-a7be-8f945cdf17aa" />

**Reference equivalent system**
<img width="844" height="218" alt="image" src="https://github.com/user-attachments/assets/1c1b3350-3ee0-478b-b5eb-017a4ce069b6" />

**Final remark**
_As far as my understanding goes_, the paraxial ray tracer seems like it was written largely with linear optical lens systems in mind, and perhaps at a time when computing power was more limited. Optiland's real ray tracing has no issues with tracing rays through 3D space, and though I don't know what the best approach would be, I would like to see a fully vectorial approach for paraxial rays as well. Ideally, surfaces would be placed in the optical system with well-defined surface normals, and those normals would be used for paraxial ray tracing. In that case, there could be no confusion about the direction from which light is hitting the element. But, perhaps this is already considered in the non-sequential mode?

As a thought, perhaps attaching a `ThinLensInteractionModel` to every real surface, to be used during paraxial ray tracing only, could be a way to leverage the current RealRay tracing engine to obtain paraxial results relatively easily?