### PR TITLE
add BatchedRayEvaluator to eliminate redundant ray trace calls during optimization

### DIFF
--- a/docs/developers_guide/code_structure.rst
+++ b/docs/developers_guide/code_structure.rst
@@ -39,6 +39,11 @@ This page provides a high-level overview of the `optiland` package's structure. 
     │   ├── real_ray_tracer.py (RealRayTracer class)
     │   └── paraxial_ray_tracer.py (ParaxialRayTracer class)
     │
+    ├── optimization/
+    │   ├── problem.py (OptimizationProblem class)
+    │   ├── batched_evaluator.py (BatchedRayEvaluator class)
+    │   └── ... (operands, variables, and optimizers)
+    │
     └── backend/
         ├── __init__.py (dynamic backend dispatcher)
         ├── base.py (AbstractBackend class)
@@ -54,4 +59,5 @@ Key Relationships
 - The **InteractionModel** defines how rays interact with the surface.
 - Each **Material** has a **PropagationModel**, which defines how rays propagate through the material.
 - The **RealRayTracer** and **ParaxialRayTracer** use the **SurfaceGroup** to trace **Rays** through the system.
+- The **OptimizationProblem** coordinates operands and variables, and can delegate merit evaluation to **BatchedRayEvaluator** to reduce redundant tracing.
 - All numerical operations are dispatched to the active **Backend**.

--- a/docs/developers_guide/optimization_framework.rst
+++ b/docs/developers_guide/optimization_framework.rst
@@ -116,11 +116,9 @@ Typical Optimization Process
    # Add radius of curvature variable for second surface
    problem.add_variable(lens, 'radius', surface_number=2)
 
-4. **(Optional) Enable Batched Ray Evaluation**. If your merit function has many ray-based operands (for example `real_*` intercepts or `rms_spot_size`), enable batching to reduce repeated tracing work:
+4. **(Optional) Configure Batched Ray Evaluation**. Batching is enabled by default. If you need to compare with legacy per-operand behavior, disable it explicitly:
 
 .. code:: python
-
-   problem.enable_batching()
 
    # Squared weighted deltas (used by many optimizers)
    merit = problem.sum_squared()
@@ -128,7 +126,7 @@ Typical Optimization Process
    # Unsquared weighted deltas (useful for least-squares style methods)
    residuals = problem.residual_vector()
 
-   # Disable batching again if needed
+   # Disable batching to opt out (legacy per-operand evaluation)
    problem.disable_batching()
 
 5. **Choose an Optimizer**. Select an optimizer and run the optimization:
@@ -151,7 +149,7 @@ Typical Optimization Process
 Batched Ray Evaluation Internals
 --------------------------------
 
-The batching path is implemented by `optiland.optimization.batched_evaluator.BatchedRayEvaluator` and is integrated into `OptimizationProblem` via `enable_batching()`.
+The batching path is implemented by `optiland.optimization.batched_evaluator.BatchedRayEvaluator` and is integrated into `OptimizationProblem` by default. You can opt out with `disable_batching()` and re-enable with `enable_batching()`.
 
 When enabled, the evaluator performs three steps:
 

--- a/docs/developers_guide/optimization_framework.rst
+++ b/docs/developers_guide/optimization_framework.rst
@@ -38,6 +38,8 @@ Components Explained
      - Adding **operands** to define the merit function.
      - Adding **variables** to define the parameters to optimize.
      - Computing the overall objective function value.
+   - Optionally batching compatible ray operands to avoid redundant traces.
+   - Providing both squared terms (`fun_array`) and residual vectors (`residual_vector`) for least-squares optimizers.
 
 2. **Optimizers**:
 
@@ -96,7 +98,7 @@ Typical Optimization Process
 .. code:: python
 
    from optiland.optimization import OptimizationProblem
-   problem = OptimizationProblem(optic)
+   problem = OptimizationProblem()
 
 2. **Add Operands**. Add operands to define the merit function:
 
@@ -114,7 +116,22 @@ Typical Optimization Process
    # Add radius of curvature variable for second surface
    problem.add_variable(lens, 'radius', surface_number=2)
 
-4. **Choose an Optimizer**. Select an optimizer and run the optimization:
+4. **(Optional) Enable Batched Ray Evaluation**. If your merit function has many ray-based operands (for example `real_*` intercepts or `rms_spot_size`), enable batching to reduce repeated tracing work:
+
+.. code:: python
+
+   problem.enable_batching()
+
+   # Squared weighted deltas (used by many optimizers)
+   merit = problem.sum_squared()
+
+   # Unsquared weighted deltas (useful for least-squares style methods)
+   residuals = problem.residual_vector()
+
+   # Disable batching again if needed
+   problem.disable_batching()
+
+5. **Choose an Optimizer**. Select an optimizer and run the optimization:
 
 .. code:: python
 
@@ -122,13 +139,34 @@ Typical Optimization Process
    optimizer = OptimizerGeneric(problem)
    result = optimizer.optimize()
 
-5. **Review Results**. Print optimization results and visualize performance:
+6. **Review Results**. Print optimization results and visualize performance:
 
 .. code:: python
 
    problem.info()  # print optimization problem details
    print(result)   # standard output from scipy.optimize.minimize
    lens.draw()     # Plot the lens in 2D
+
+
+Batched Ray Evaluation Internals
+--------------------------------
+
+The batching path is implemented by `optiland.optimization.batched_evaluator.BatchedRayEvaluator` and is integrated into `OptimizationProblem` via `enable_batching()`.
+
+When enabled, the evaluator performs three steps:
+
+1. Group compatible operands that can share the same trace call.
+2. Execute the minimum required set of `trace_generic` and `trace` calls.
+3. Extract per-operand values from shared traced arrays while preserving backend behavior and autograd.
+
+Current batching support includes:
+
+- **Single-ray (`trace_generic`) operands** such as `real_x_intercept`, `real_y_intercept`, `real_z_intercept`, local-coordinate intercept variants, direction cosines (`real_L`, `real_M`, `real_N`), and `AOI`.
+- **Distribution (`trace`) operands** for `rms_spot_size` when trace parameters match.
+
+Operands that are not currently batchable are evaluated through the standard direct path, so mixed merit functions are fully supported.
+
+For PyTorch workflows, this design keeps gradients valid because values are extracted by tensor indexing from traced data (without detaching). For NumPy workflows, behavior remains numerically equivalent to the standard per-operand evaluation path.
 
 
 .. figure:: ../_static/cooke_triplet_starting_point.png

--- a/optiland/backend/torch_backend.py
+++ b/optiland/backend/torch_backend.py
@@ -369,8 +369,9 @@ class TorchBackend(AbstractBackend):
             if any(isinstance(v, torch.Tensor) for v in x):
                 # Ensure all are tensors and stack them to preserve gradients
                 tensors = [
-                    v if isinstance(v, torch.Tensor) 
-                    else torch.tensor(v, device=self._device(), dtype=self._dtype()) 
+                    v
+                    if isinstance(v, torch.Tensor)
+                    else torch.tensor(v, device=self._device(), dtype=self._dtype())
                     for v in x
                 ]
                 return torch.stack(tensors)

--- a/optiland/backend/torch_backend.py
+++ b/optiland/backend/torch_backend.py
@@ -374,7 +374,14 @@ class TorchBackend(AbstractBackend):
                     else torch.tensor(v, device=self._device(), dtype=self._dtype())
                     for v in x
                 ]
-                return torch.stack(tensors)
+                # Normalize 0-d (scalar) tensors to 1-d to ensure consistent
+                # shapes before stacking (e.g. mix of [] and [1] tensors)
+                if len(set(t.shape for t in tensors)) > 1:
+                    tensors = [t.unsqueeze(0) if t.dim() == 0 else t for t in tensors]
+                try:
+                    return torch.stack(tensors)
+                except RuntimeError:
+                    return torch.cat(tensors)
             elif isinstance(x[0], np.ndarray):
                 x = np.array(x)
 

--- a/optiland/backend/torch_backend.py
+++ b/optiland/backend/torch_backend.py
@@ -364,8 +364,18 @@ class TorchBackend(AbstractBackend):
         if isinstance(x, torch.Tensor):
             return x
 
-        if isinstance(x, list | tuple) and len(x) > 0 and isinstance(x[0], np.ndarray):
-            x = np.array(x)
+        if isinstance(x, (list, tuple)) and len(x) > 0:
+            # Check if any element is a Tensor
+            if any(isinstance(v, torch.Tensor) for v in x):
+                # Ensure all are tensors and stack them to preserve gradients
+                tensors = [
+                    v if isinstance(v, torch.Tensor) 
+                    else torch.tensor(v, device=self._device(), dtype=self._dtype()) 
+                    for v in x
+                ]
+                return torch.stack(tensors)
+            elif isinstance(x[0], np.ndarray):
+                x = np.array(x)
 
         return torch.tensor(
             x,

--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -83,6 +83,10 @@ class OpticUpdater:
             return
 
         positions = self.optic.surfaces.positions
+        # Detach positions used as reference points to prevent stale computation
+        # graphs (from prior iterations) from being pulled into the current graph.
+        if hasattr(positions, "detach"):
+            positions = positions.detach()
         delta_t = value - positions[surface_number + 1] + positions[surface_number]
         positions = be.copy(positions)  # required to avoid in-place modification
         positions[surface_number + 1 :] = positions[surface_number + 1 :] + delta_t

--- a/optiland/optimization/batched_evaluator.py
+++ b/optiland/optimization/batched_evaluator.py
@@ -1,0 +1,681 @@
+"""Batched Ray Evaluator Module
+
+This module provides the BatchedRayEvaluator class which accelerates
+optimization by eliminating redundant ray tracing through intelligent batching
+of operand evaluations.
+
+The evaluator analyzes optimization problems to group operands that require
+ray tracing with the same optic and wavelength, then executes a minimal number
+of traces. Each operand extracts its value from the shared trace results.
+
+This approach works with both NumPy and PyTorch backends and preserves
+automatic differentiation (autograd) by indexing directly into the traced
+tensor data.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import optiland.backend as be
+from optiland.optimization.operand.operand import operand_registry
+
+if TYPE_CHECKING:
+    from optiland.optimization.problem import OptimizationProblem
+
+
+# Operand types that call optic.trace_generic (single-ray operands)
+_TRACE_GENERIC_OPERANDS = frozenset(
+    {
+        "real_x_intercept",
+        "real_y_intercept",
+        "real_z_intercept",
+        "real_x_intercept_lcs",
+        "real_y_intercept_lcs",
+        "real_z_intercept_lcs",
+        "real_L",
+        "real_M",
+        "real_N",
+        "AOI",
+    }
+)
+
+# Operand types that call optic.trace (distribution-of-rays operands)
+_TRACE_OPERANDS = frozenset(
+    {
+        "rms_spot_size",
+    }
+)
+
+
+def _make_generic_trace_key(optic, wavelength):
+    """Create a grouping key for trace_generic operands.
+
+    All single-ray operands sharing the same optic and wavelength can be
+    batched into a single ``optic.trace_generic`` call.
+    """
+    return (id(optic), float(wavelength))
+
+
+def _make_trace_key(optic, Hx, Hy, wavelength, num_rays, distribution):
+    """Create a grouping key for trace (distribution) operands.
+
+    ``rms_spot_size`` operands with identical parameters share a single
+    ``optic.trace`` call.
+    """
+    return (
+        id(optic),
+        float(Hx),
+        float(Hy),
+        float(wavelength) if wavelength != "all" else "all",
+        int(num_rays),
+        str(distribution),
+    )
+
+
+class _GenericTraceJob:
+    """Batched trace_generic job for single-ray operands.
+
+    Accumulates (Hx, Hy, Px, Py) pairs and traces them all in one call.
+    After execution, operands extract their values by ray index.
+    """
+
+    __slots__ = ("optic", "wavelength", "ray_params", "operand_indices")
+
+    def __init__(self, optic, wavelength):
+        self.optic = optic
+        self.wavelength = wavelength
+        self.ray_params: list[dict[str, float]] = []
+        self.operand_indices: list[int] = []
+
+    def add_operand(self, operand_idx: int, Hx: float, Hy: float, Px: float, Py: float):
+        """Register an operand and its ray parameters."""
+        ray_index = len(self.ray_params)
+        self.ray_params.append({"Hx": Hx, "Hy": Hy, "Px": Px, "Py": Py})
+        self.operand_indices.append(operand_idx)
+        return ray_index
+
+    def execute(self):
+        """Execute the batched trace_generic call.
+
+        Returns the optic's surface_group (with traced data stored on
+        surfaces).
+        """
+        if not self.ray_params:
+            return None
+
+        Hx = be.array([p["Hx"] for p in self.ray_params])
+        Hy = be.array([p["Hy"] for p in self.ray_params])
+        Px = be.array([p["Px"] for p in self.ray_params])
+        Py = be.array([p["Py"] for p in self.ray_params])
+
+        self.optic.trace_generic(Hx, Hy, Px, Py, self.wavelength)
+        return self.optic.surface_group
+
+
+class _DistributionTraceJob:
+    """Shared trace job for distribution-based operands (``rms_spot_size``).
+
+    Operands with identical trace parameters share a single ``optic.trace``
+    call.
+    """
+
+    __slots__ = (
+        "optic",
+        "Hx",
+        "Hy",
+        "wavelength",
+        "num_rays",
+        "distribution",
+        "operand_indices",
+    )
+
+    def __init__(self, optic, Hx, Hy, wavelength, num_rays, distribution):
+        self.optic = optic
+        self.Hx = Hx
+        self.Hy = Hy
+        self.wavelength = wavelength
+        self.num_rays = num_rays
+        self.distribution = distribution
+        self.operand_indices: list[int] = []
+
+    def add_operand(self, operand_idx: int):
+        """Register an operand that uses this trace."""
+        self.operand_indices.append(operand_idx)
+
+    def execute(self):
+        """Execute the trace call.
+
+        Returns the optic's surface_group.
+        """
+        if self.wavelength == "all":
+            # Multi-wavelength rms_spot_size — let the operand handle it
+            # directly since it does multiple traces internally.
+            return None
+
+        self.optic.trace(
+            self.Hx,
+            self.Hy,
+            self.wavelength,
+            self.num_rays,
+            self.distribution,
+        )
+        return self.optic.surface_group
+
+
+def _extract_value_generic(operand_type, surface_group, input_data, ray_index):
+    """Extract a single operand value from a batched trace_generic result.
+
+    This reads from the surface_group arrays at the correct ``ray_index``
+    position, preserving the autograd computation graph.
+
+    Args:
+        operand_type: The type string of the operand.
+        surface_group: The optic's surface group (post-trace).
+        input_data: The operand's ``input_data`` dict.
+        ray_index: The index of this operand's ray in the batch.
+
+    Returns:
+        The scalar value for the operand.
+    """
+    surface_number = input_data["surface_number"]
+
+    if operand_type == "real_x_intercept":
+        return surface_group.x[surface_number, ray_index]
+
+    if operand_type == "real_y_intercept":
+        return surface_group.y[surface_number, ray_index]
+
+    if operand_type == "real_z_intercept":
+        return surface_group.z[surface_number, ray_index]
+
+    if operand_type == "real_x_intercept_lcs":
+        intercept = surface_group.x[surface_number, ray_index]
+        decenter = surface_group.surfaces[surface_number].geometry.cs.x
+        return intercept - decenter
+
+    if operand_type == "real_y_intercept_lcs":
+        intercept = surface_group.y[surface_number, ray_index]
+        decenter = surface_group.surfaces[surface_number].geometry.cs.y
+        return intercept - decenter
+
+    if operand_type == "real_z_intercept_lcs":
+        intercept = surface_group.z[surface_number, ray_index]
+        decenter = surface_group.surfaces[surface_number].geometry.cs.z
+        if be.is_array_like(decenter):
+            decenter = decenter.item()
+        return intercept - decenter
+
+    if operand_type == "real_L":
+        return surface_group.L[surface_number, ray_index]
+
+    if operand_type == "real_M":
+        return surface_group.M[surface_number, ray_index]
+
+    if operand_type == "real_N":
+        return surface_group.N[surface_number, ray_index]
+
+    if operand_type == "AOI":
+        return _extract_aoi(surface_group, input_data, ray_index)
+
+    raise ValueError(f"Unknown trace_generic operand type: {operand_type}")
+
+
+def _extract_aoi(surface_group, input_data, ray_index):
+    """Extract angle of incidence from batched trace_generic result."""
+    from optiland.rays import RealRays
+
+    surface_number = input_data["surface_number"]
+    wavelength = input_data["wavelength"]
+
+    surface = surface_group.surfaces[surface_number]
+    geometry = surface.geometry
+
+    # Incident direction cosines (from previous surface)
+    L_inc = surface_group.L[surface_number - 1, ray_index]
+    M_inc = surface_group.M[surface_number - 1, ray_index]
+    N_inc = surface_group.N[surface_number - 1, ray_index]
+
+    rays_at_surface = RealRays(
+        x=surface_group.x[surface_number, ray_index],
+        y=surface_group.y[surface_number, ray_index],
+        z=surface_group.z[surface_number, ray_index],
+        L=L_inc,
+        M=M_inc,
+        N=N_inc,
+        intensity=1.0,
+        wavelength=wavelength,
+    )
+
+    nx, ny, nz = geometry.surface_normal(rays=rays_at_surface)
+    dot_product = be.abs(L_inc * nx + M_inc * ny + N_inc * nz)
+    dot_product_clip = be.minimum(dot_product, be.array(1.0))
+    angle_rad = be.arccos(dot_product_clip)
+    angle_deg = be.rad2deg(angle_rad)
+
+    if be.is_array_like(angle_deg):
+        angle_deg = angle_deg.item()
+
+    return angle_deg
+
+
+def _extract_rms_spot(surface_group, input_data):
+    """Extract rms_spot_size from a shared trace result.
+
+    This replicates the calculation from ``RayOperand.rms_spot_size`` but
+    reads from the already-traced surface_group data, preserving autograd.
+    """
+    surface_number = input_data["surface_number"]
+    x = surface_group.x[surface_number, :].flatten()
+    y = surface_group.y[surface_number, :].flatten()
+    r2 = (x - be.mean(x)) ** 2 + (y - be.mean(y)) ** 2
+    return be.sqrt(be.mean(r2))
+
+
+class BatchedRayEvaluator:
+    """High-performance evaluator for optimization problems using batched
+    ray tracing.
+
+    This evaluator analyses the optimization problem to identify operands that
+    can share ray traces, groups them into minimal trace jobs, and provides
+    ``fun_array`` / ``sum_squared`` methods that compute all operand values
+    efficiently.
+
+    The evaluator is fully compatible with both NumPy and PyTorch backends.
+    When using PyTorch, the autograd computation graph is preserved because
+    operand values are extracted by indexing into the traced tensor arrays
+    (no detach / clone operations).
+
+    Usage::
+
+        problem = OptimizationProblem()
+        # ... add operands and variables ...
+
+        evaluator = BatchedRayEvaluator(problem)
+
+        # Use instead of problem.sum_squared()
+        loss = evaluator.sum_squared()
+
+    Args:
+        problem: The optimization problem to evaluate.
+    """
+
+    def __init__(self, problem: OptimizationProblem):
+        self.problem = problem
+
+        # Jobs populated by _analyze
+        self._generic_jobs: list[_GenericTraceJob] = []
+        self._distribution_jobs: list[_DistributionTraceJob] = []
+
+        # Per-operand evaluation strategy:
+        #   ("generic", job_idx, ray_index)
+        #   ("distribution", job_idx, None)
+        #   ("direct", None, None)   -- fallback to standard evaluation
+        self._operand_plan: list[tuple[str, Any, Any]] = []
+
+        self._analyze()
+
+    # ------------------------------------------------------------------
+    # Analysis
+    # ------------------------------------------------------------------
+
+    def _analyze(self):
+        """Analyse the problem and create batching plan."""
+        self._generic_jobs.clear()
+        self._distribution_jobs.clear()
+        self._operand_plan.clear()
+
+        # ---- trace_generic grouping ----
+        # key -> job index
+        generic_key_to_idx: dict[tuple, int] = {}
+
+        # ---- distribution trace grouping ----
+        dist_key_to_idx: dict[tuple, int] = {}
+
+        for i, operand in enumerate(self.problem.operands):
+            op_type = operand.operand_type
+            data = operand.input_data
+
+            if op_type in _TRACE_GENERIC_OPERANDS:
+                wl = data["wavelength"]
+                optic = data["optic"]
+                key = _make_generic_trace_key(optic, wl)
+
+                if key not in generic_key_to_idx:
+                    job = _GenericTraceJob(optic, wl)
+                    generic_key_to_idx[key] = len(self._generic_jobs)
+                    self._generic_jobs.append(job)
+
+                job_idx = generic_key_to_idx[key]
+                job = self._generic_jobs[job_idx]
+                ray_idx = job.add_operand(
+                    i,
+                    data["Hx"],
+                    data["Hy"],
+                    data["Px"],
+                    data["Py"],
+                )
+                self._operand_plan.append(("generic", job_idx, ray_idx))
+
+            elif op_type in _TRACE_OPERANDS:
+                wl = data.get("wavelength", 0.587)
+                optic = data["optic"]
+
+                # Multi-wavelength rms_spot_size must be evaluated directly
+                if wl == "all":
+                    self._operand_plan.append(("direct", None, None))
+                    continue
+
+                num_rays = data.get("num_rays", 100)
+                dist = data.get("distribution", "hexapolar")
+                key = _make_trace_key(
+                    optic,
+                    data["Hx"],
+                    data["Hy"],
+                    wl,
+                    num_rays,
+                    dist,
+                )
+
+                if key not in dist_key_to_idx:
+                    job = _DistributionTraceJob(
+                        optic,
+                        data["Hx"],
+                        data["Hy"],
+                        wl,
+                        num_rays,
+                        dist,
+                    )
+                    dist_key_to_idx[key] = len(self._distribution_jobs)
+                    self._distribution_jobs.append(job)
+
+                job_idx = dist_key_to_idx[key]
+                self._distribution_jobs[job_idx].add_operand(i)
+                self._operand_plan.append(("distribution", job_idx, None))
+
+            else:
+                # Non-ray operand (paraxial, aberration, lens, etc.)
+                self._operand_plan.append(("direct", None, None))
+
+    # ------------------------------------------------------------------
+    # Re-analysis (if the problem structure has changed)
+    # ------------------------------------------------------------------
+
+    def refresh(self):
+        """Re-analyse the problem.
+
+        Call this if operands or variables have been added/removed since
+        the evaluator was created.
+        """
+        self._analyze()
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def fun_array(self):
+        """Compute contribution terms for each active operand.
+
+        This is the batched equivalent of
+        ``OptimizationProblem.fun_array()``.
+
+        Trace jobs are executed one at a time and operand values are
+        extracted immediately after each trace, before the next trace
+        overwrites the shared ``surface_group`` state.
+        """
+        if len(self._operand_plan) != len(self.problem.operands):
+            self._analyze()
+
+        num_operands = len(self.problem.operands)
+
+        # Pre-allocate operand values — None means "not yet computed"
+        raw_values: list[Any] = [None] * num_operands
+
+        # --- Execute generic trace jobs and extract values eagerly ---
+        for job_idx, job in enumerate(self._generic_jobs):
+            try:
+                sg = job.execute()
+            except Exception:
+                sg = None
+
+            if sg is None:
+                continue
+
+            # Extract values for every operand mapped to this job
+            for i in range(num_operands):
+                plan_type, pj, ray_idx = self._operand_plan[i]
+                if plan_type == "generic" and pj == job_idx:
+                    raw_values[i] = _extract_value_generic(
+                        self.problem.operands[i].operand_type,
+                        sg,
+                        self.problem.operands[i].input_data,
+                        ray_idx,
+                    )
+
+        # --- Execute distribution trace jobs and extract values eagerly ---
+        for job_idx, job in enumerate(self._distribution_jobs):
+            try:
+                sg = job.execute()
+            except Exception:
+                sg = None
+
+            for i in range(num_operands):
+                plan_type, pj, _ = self._operand_plan[i]
+                if plan_type == "distribution" and pj == job_idx:
+                    operand = self.problem.operands[i]
+                    if sg is not None:
+                        raw_values[i] = _extract_rms_spot(
+                            sg,
+                            operand.input_data,
+                        )
+                    else:
+                        # Fallback (e.g. multi-wavelength)
+                        metric_fn = operand_registry.get(operand.operand_type)
+                        raw_values[i] = metric_fn(**operand.input_data)
+
+        # --- Evaluate direct (non-ray) operands ---
+        for i in range(num_operands):
+            if raw_values[i] is not None:
+                continue
+            plan_type, _, _ = self._operand_plan[i]
+            if plan_type == "direct":
+                operand = self.problem.operands[i]
+                metric_fn = operand_registry.get(operand.operand_type)
+                if metric_fn is None:
+                    raise ValueError(f"Unknown operand type: {operand.operand_type}")
+                raw_values[i] = metric_fn(**operand.input_data)
+
+        # --- Compute contribution terms using effective_weight * delta**2 ---
+        terms = []
+        for i, operand in enumerate(self.problem.operands):
+            value = raw_values[i]
+            if value is None:
+                raise RuntimeError(
+                    f"Operand {i} ({operand.operand_type}) was not evaluated"
+                )
+            ew = operand.effective_weight()
+            if ew == 0.0:
+                continue
+            delta = self._compute_delta(operand, value)
+            terms.append(ew * delta**2)
+
+        if not terms:
+            return be.array([0.0])
+        return be.stack(terms)
+
+    def residual_vector(self):
+        """Compute the vector of weighted operand deltas (unsquared).
+
+        Returns a 1-D array whose *i*-th element is ``weight_i * delta_i``
+        for each operand. This is the residual vector **r** needed by
+        least-squares algorithms such as Levenberg-Marquardt.
+
+        Trace jobs are executed one at a time and operand values are
+        extracted immediately after each trace, before the next trace
+        overwrites the shared ``surface_group`` state.
+        """
+        if len(self._operand_plan) != len(self.problem.operands):
+            self._analyze()
+
+        num_operands = len(self.problem.operands)
+
+        # Use a list to hold the computed tensor node for EACH operand.
+        # This avoids PyTorch in-place modification errors, allowing us
+        # to safely use be.stack() at the end to fuse the graph.
+        computed_residuals = [None] * num_operands
+
+        # --- 1. Process Batched Ray Traces (Vectorized) ---
+        for job_idx, job in enumerate(self._generic_jobs):
+            try:
+                sg = job.execute()
+            except Exception:
+                sg = None
+
+            if sg is None:
+                continue
+
+            op_indices = job.operand_indices
+
+            # Map operand types to surface_group tensor attributes
+            attr_map = {
+                "real_x_intercept": "x", "real_y_intercept": "y",
+                "real_z_intercept": "z",
+                "real_L": "L", "real_M": "M", "real_N": "N",
+            }
+
+            # Vectorize extraction by grouping operands of the same type
+            for op_type, attr in attr_map.items():
+                mask = [
+                    self.problem.operands[i].operand_type == op_type
+                    for i in op_indices
+                ]
+                if not any(mask):
+                    continue
+
+                matching_op_indices = [
+                    op_indices[idx] for idx, is_match in enumerate(mask) if is_match
+                ]
+                ray_indices = [
+                    idx for idx, is_match in enumerate(mask) if is_match
+                ]
+                surfs = [
+                    self.problem.operands[i].input_data["surface_number"]
+                    for i in matching_op_indices
+                ]
+
+                # THE VECTORIZED EXTRACTION —
+                # Pulls all needed ray data in ONE clean autograd operation
+                data_tensor = getattr(sg, attr)
+                extracted_vals = data_tensor[surfs, ray_indices]
+
+                # Vectorized target and weight arrays
+                targets = be.array([
+                    self.problem.operands[i].target for i in matching_op_indices
+                ])
+                weights = be.array([
+                    self.problem.operands[i].weight for i in matching_op_indices
+                ])
+
+                # Compute all deltas for this group simultaneously
+                deltas = weights * (extracted_vals - targets)
+
+                # Assign the resulting scalar tensors to our list
+                for local_idx, global_op_idx in enumerate(matching_op_indices):
+                    computed_residuals[global_op_idx] = deltas[local_idx]
+
+            # Handle non-vectorizable generic operands (AOI, local coords) via
+            # scalar fallback
+            for local_idx, global_op_idx in enumerate(op_indices):
+                if computed_residuals[global_op_idx] is not None:
+                    continue  # Already processed vectorially above
+
+                operand = self.problem.operands[global_op_idx]
+                val = _extract_value_generic(
+                    operand.operand_type, sg, operand.input_data, local_idx
+                )
+                delta = self._compute_delta(operand, val)
+                computed_residuals[global_op_idx] = operand.weight * delta
+
+        # --- 2. Process Distribution Jobs ---
+        for job_idx, job in enumerate(self._distribution_jobs):
+            try:
+                sg = job.execute()
+            except Exception:
+                sg = None
+            for i in range(num_operands):
+                plan_type, pj, _ = self._operand_plan[i]
+                if plan_type == "distribution" and pj == job_idx:
+                    operand = self.problem.operands[i]
+                    if sg is not None:
+                        val = _extract_rms_spot(sg, operand.input_data)
+                    else:
+                        metric_fn = operand_registry.get(operand.operand_type)
+                        val = metric_fn(**operand.input_data)
+
+                    delta = self._compute_delta(operand, val)
+                    computed_residuals[i] = operand.weight * delta
+
+        # --- 3. Process Direct Jobs ---
+        for i in range(num_operands):
+            if computed_residuals[i] is not None:
+                continue
+            plan_type, _, _ = self._operand_plan[i]
+            if plan_type == "direct":
+                operand = self.problem.operands[i]
+                metric_fn = operand_registry.get(operand.operand_type)
+                val = metric_fn(**operand.input_data)
+
+                delta = self._compute_delta(operand, val)
+                computed_residuals[i] = operand.weight * delta
+
+        # --- Final Graph Assembly ---
+        for i, res in enumerate(computed_residuals):
+            if res is None:
+                raise RuntimeError(
+                    f"Operand {i} ({self.problem.operands[i].operand_type}) "
+                    "was not evaluated"
+                )
+
+        if not computed_residuals:
+            return be.array([])
+
+        return be.stack(computed_residuals)
+
+    def sum_squared(self):
+        """Compute the sum of squared weighted deltas.
+
+        This is the batched equivalent of
+        ``OptimizationProblem.sum_squared()``.
+        """
+        return be.sum(self.fun_array())
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_delta(operand, value):
+        """Compute the delta between the operand value and its target/bounds.
+
+        This replicates the logic from ``Operand.delta()`` but accepts a
+        pre-computed *value* so we avoid re-evaluating the operand.
+        """
+        if operand.target is not None:
+            return value - operand.target
+
+        if operand.min_val is not None or operand.max_val is not None:
+            lower_penalty = (
+                be.maximum(be.array(0.0), be.array(operand.min_val) - value)
+                if operand.min_val is not None
+                else be.array(0.0)
+            )
+            upper_penalty = (
+                be.maximum(be.array(0.0), value - be.array(operand.max_val))
+                if operand.max_val is not None
+                else be.array(0.0)
+            )
+            return lower_penalty + upper_penalty
+
+        raise ValueError(f"Operand '{operand.operand_type}' has no target or bounds")

--- a/optiland/optimization/batched_evaluator.py
+++ b/optiland/optimization/batched_evaluator.py
@@ -411,39 +411,27 @@ class BatchedRayEvaluator:
         """
         self._analyze()
 
-    # ------------------------------------------------------------------
-    # Evaluation
-    # ------------------------------------------------------------------
-
-    def fun_array(self):
-        """Compute contribution terms for each active operand.
-
-        This is the batched equivalent of
-        ``OptimizationProblem.fun_array()``.
-
-        Trace jobs are executed one at a time and operand values are
-        extracted immediately after each trace, before the next trace
-        overwrites the shared ``surface_group`` state.
-        """
+    def _ensure_plan_current(self) -> None:
+        """Rebuild the operand plan when the problem size has changed."""
         if len(self._operand_plan) != len(self.problem.operands):
             self._analyze()
 
+    @staticmethod
+    def _safe_execute(job):
+        """Execute a trace job and return ``None`` on trace failures."""
+        try:
+            return job.execute()
+        except Exception:
+            return None
+
+    def _evaluate_generic_jobs(self, raw_values: list[Any]) -> None:
+        """Populate values for operands covered by ``trace_generic`` jobs."""
         num_operands = len(self.problem.operands)
-
-        # Pre-allocate operand values — None means "not yet computed"
-        raw_values: list[Any] = [None] * num_operands
-
-        # --- Execute generic trace jobs and extract values eagerly ---
         for job_idx, job in enumerate(self._generic_jobs):
-            try:
-                sg = job.execute()
-            except Exception:
-                sg = None
-
+            sg = self._safe_execute(job)
             if sg is None:
                 continue
 
-            # Extract values for every operand mapped to this job
             for i in range(num_operands):
                 plan_type, pj, ray_idx = self._operand_plan[i]
                 if plan_type == "generic" and pj == job_idx:
@@ -454,12 +442,11 @@ class BatchedRayEvaluator:
                         ray_idx,
                     )
 
-        # --- Execute distribution trace jobs and extract values eagerly ---
+    def _evaluate_distribution_jobs(self, raw_values: list[Any]) -> None:
+        """Populate values for operands covered by distribution trace jobs."""
+        num_operands = len(self.problem.operands)
         for job_idx, job in enumerate(self._distribution_jobs):
-            try:
-                sg = job.execute()
-            except Exception:
-                sg = None
+            sg = self._safe_execute(job)
 
             for i in range(num_operands):
                 plan_type, pj, _ = self._operand_plan[i]
@@ -475,31 +462,68 @@ class BatchedRayEvaluator:
                         metric_fn = operand_registry.get(operand.operand_type)
                         raw_values[i] = metric_fn(**operand.input_data)
 
-        # --- Evaluate direct (non-ray) operands ---
+    def _evaluate_direct_operands(self, raw_values: list[Any]) -> None:
+        """Populate values for non-ray operands evaluated directly."""
+        num_operands = len(self.problem.operands)
         for i in range(num_operands):
             if raw_values[i] is not None:
                 continue
             plan_type, _, _ = self._operand_plan[i]
             if plan_type == "direct":
                 operand = self.problem.operands[i]
+                # Match OptimizationProblem.fun_array semantics: zero-effective-
+                # weight operands are excluded and should not be evaluated.
+                if operand.effective_weight() == 0.0:
+                    continue
                 metric_fn = operand_registry.get(operand.operand_type)
                 if metric_fn is None:
                     raise ValueError(f"Unknown operand type: {operand.operand_type}")
                 raw_values[i] = metric_fn(**operand.input_data)
 
-        # --- Compute contribution terms using effective_weight * delta**2 ---
+    def _build_contribution_terms(self, raw_values: list[Any]) -> list[Any]:
+        """Convert raw operand values into merit contribution terms."""
         terms = []
         for i, operand in enumerate(self.problem.operands):
+            ew = operand.effective_weight()
+            if ew == 0.0:
+                continue
             value = raw_values[i]
             if value is None:
                 raise RuntimeError(
                     f"Operand {i} ({operand.operand_type}) was not evaluated"
                 )
-            ew = operand.effective_weight()
-            if ew == 0.0:
-                continue
             delta = self._compute_delta(operand, value)
             terms.append(ew * delta**2)
+        return terms
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def fun_array(self):
+        """Compute contribution terms for each active operand.
+
+        This is the batched equivalent of
+        ``OptimizationProblem.fun_array()``.
+
+        Trace jobs are executed one at a time and operand values are
+        extracted immediately after each trace, before the next trace
+        overwrites the shared ``surface_group`` state.
+        """
+        self._ensure_plan_current()
+
+        num_operands = len(self.problem.operands)
+
+        # Pre-allocate operand values — None means "not yet computed"
+        raw_values: list[Any] = [None] * num_operands
+
+        # Three-stage evaluation: generic traces, distribution traces, and
+        # direct/non-ray metrics.
+        self._evaluate_generic_jobs(raw_values)
+        self._evaluate_distribution_jobs(raw_values)
+        self._evaluate_direct_operands(raw_values)
+
+        terms = self._build_contribution_terms(raw_values)
 
         if not terms:
             return be.array([0.0])
@@ -516,8 +540,7 @@ class BatchedRayEvaluator:
         extracted immediately after each trace, before the next trace
         overwrites the shared ``surface_group`` state.
         """
-        if len(self._operand_plan) != len(self.problem.operands):
-            self._analyze()
+        self._ensure_plan_current()
 
         num_operands = len(self.problem.operands)
 
@@ -528,10 +551,7 @@ class BatchedRayEvaluator:
 
         # --- 1. Process Batched Ray Traces (Vectorized) ---
         for _job_idx, job in enumerate(self._generic_jobs):
-            try:
-                sg = job.execute()
-            except Exception:
-                sg = None
+            sg = self._safe_execute(job)
 
             if sg is None:
                 continue
@@ -600,10 +620,7 @@ class BatchedRayEvaluator:
 
         # --- 2. Process Distribution Jobs ---
         for job_idx, job in enumerate(self._distribution_jobs):
-            try:
-                sg = job.execute()
-            except Exception:
-                sg = None
+            sg = self._safe_execute(job)
             for i in range(num_operands):
                 plan_type, pj, _ = self._operand_plan[i]
                 if plan_type == "distribution" and pj == job_idx:

--- a/optiland/optimization/batched_evaluator.py
+++ b/optiland/optimization/batched_evaluator.py
@@ -527,7 +527,7 @@ class BatchedRayEvaluator:
         computed_residuals = [None] * num_operands
 
         # --- 1. Process Batched Ray Traces (Vectorized) ---
-        for job_idx, job in enumerate(self._generic_jobs):
+        for _job_idx, job in enumerate(self._generic_jobs):
             try:
                 sg = job.execute()
             except Exception:
@@ -540,16 +540,18 @@ class BatchedRayEvaluator:
 
             # Map operand types to surface_group tensor attributes
             attr_map = {
-                "real_x_intercept": "x", "real_y_intercept": "y",
+                "real_x_intercept": "x",
+                "real_y_intercept": "y",
                 "real_z_intercept": "z",
-                "real_L": "L", "real_M": "M", "real_N": "N",
+                "real_L": "L",
+                "real_M": "M",
+                "real_N": "N",
             }
 
             # Vectorize extraction by grouping operands of the same type
             for op_type, attr in attr_map.items():
                 mask = [
-                    self.problem.operands[i].operand_type == op_type
-                    for i in op_indices
+                    self.problem.operands[i].operand_type == op_type for i in op_indices
                 ]
                 if not any(mask):
                     continue
@@ -557,9 +559,7 @@ class BatchedRayEvaluator:
                 matching_op_indices = [
                     op_indices[idx] for idx, is_match in enumerate(mask) if is_match
                 ]
-                ray_indices = [
-                    idx for idx, is_match in enumerate(mask) if is_match
-                ]
+                ray_indices = [idx for idx, is_match in enumerate(mask) if is_match]
                 surfs = [
                     self.problem.operands[i].input_data["surface_number"]
                     for i in matching_op_indices
@@ -571,12 +571,12 @@ class BatchedRayEvaluator:
                 extracted_vals = data_tensor[surfs, ray_indices]
 
                 # Vectorized target and weight arrays
-                targets = be.array([
-                    self.problem.operands[i].target for i in matching_op_indices
-                ])
-                weights = be.array([
-                    self.problem.operands[i].weight for i in matching_op_indices
-                ])
+                targets = be.array(
+                    [self.problem.operands[i].target for i in matching_op_indices]
+                )
+                weights = be.array(
+                    [self.problem.operands[i].weight for i in matching_op_indices]
+                )
 
                 # Compute all deltas for this group simultaneously
                 deltas = weights * (extracted_vals - targets)

--- a/optiland/optimization/problem.py
+++ b/optiland/optimization/problem.py
@@ -48,7 +48,13 @@ class OptimizationProblem:
 
     """
 
-    def __init__(self):
+    def __init__(self, batching: bool = True):
+        """Initialize an optimization problem.
+
+        Args:
+            batching: If ``True`` (default), batched ray evaluation is enabled.
+                Set to ``False`` to opt out and use per-operand evaluation.
+        """
         self.operands = OperandManager()
         self.variables = VariableManager()
         self.initial_value = 0.0
@@ -58,6 +64,9 @@ class OptimizationProblem:
         if be.get_backend() == "torch" and not be.grad_mode.requires_grad:
             warnings.warn("Gradient tracking is enabled for PyTorch.", stacklevel=2)
             be.grad_mode.enable()
+
+        if batching:
+            self.enable_batching()
 
     @staticmethod
     def _to_item(x):

--- a/optiland/optimization/problem.py
+++ b/optiland/optimization/problem.py
@@ -20,6 +20,7 @@ from optiland.optimization.operand import OperandManager
 from optiland.optimization.variable import VariableManager
 
 if TYPE_CHECKING:
+    from optiland.optimization.batched_evaluator import BatchedRayEvaluator
     from optiland.optimization.scaling.base import Scaler
 
 
@@ -51,6 +52,7 @@ class OptimizationProblem:
         self.operands = OperandManager()
         self.variables = VariableManager()
         self.initial_value = 0.0
+        self._batched_evaluator: BatchedRayEvaluator | None = None
 
         # Enable gradient tracking for PyTorch
         if be.get_backend() == "torch" and not be.grad_mode.requires_grad:
@@ -69,6 +71,31 @@ class OptimizationProblem:
             return x.item()
         return x
 
+    def enable_batching(self):
+        """Enable batched ray evaluation for faster optimization.
+
+        When batching is enabled, operands that require ray tracing are
+        grouped by optic and wavelength so that redundant traces are
+        eliminated. This can dramatically speed up merit-function
+        evaluation for problems with many ray operands.
+
+        The evaluator is re-created whenever this method is called, so
+        it always reflects the current set of operands.
+        """
+        from optiland.optimization.batched_evaluator import BatchedRayEvaluator
+
+        self._batched_evaluator = BatchedRayEvaluator(self)
+
+    def disable_batching(self):
+        """Disable batched ray evaluation and use standard per-operand
+        evaluation."""
+        self._batched_evaluator = None
+
+    @property
+    def batching_enabled(self) -> bool:
+        """Whether batched evaluation is currently active."""
+        return self._batched_evaluator is not None
+
     def add_operand(
         self,
         operand_type=None,
@@ -82,6 +109,9 @@ class OptimizationProblem:
         if input_data is None:
             input_data = {}
         self.operands.add(operand_type, target, min_val, max_val, weight, input_data)
+        # Invalidate batch plan when operands change
+        if self._batched_evaluator is not None:
+            self._batched_evaluator.refresh()
 
     def add_variable(self, optic, variable_type, scaler: Scaler = None, **kwargs):
         """Add a variable to the merit function"""
@@ -91,6 +121,8 @@ class OptimizationProblem:
         """Clear all operands from the merit function"""
         self.initial_value = 0.0
         self.operands.clear()
+        if self._batched_evaluator is not None:
+            self._batched_evaluator.refresh()
 
     def clear_variables(self):
         """Clear all variables from the merit function"""
@@ -102,17 +134,24 @@ class OptimizationProblem:
 
         Each term is computed as::
 
-            effective_weight(op) × op.delta() ** 2
+            effective_weight(op) * op.delta() ** 2
 
-        where ``effective_weight = operand.weight × field_weight × wl_weight``.
+        where ``effective_weight = operand.weight * field_weight * wl_weight``.
         Field and wavelength weights are read from the optic stored in each
-        operand's ``input_data``.  Operands with an effective weight of zero are
-        excluded from the result (their delta is never evaluated).
+        operand's ``input_data``. Operands with an effective weight of zero are
+        excluded from the result.
+
+        When batching is enabled, delegates to the
+        :class:`~optiland.optimization.batched_evaluator.BatchedRayEvaluator`
+        which minimises redundant ray traces.
 
         Returns:
-            be.ndarray: 1-D array of per-operand contribution values.  Returns
+            be.ndarray: 1-D array of per-operand contribution values. Returns
             ``[0.0]`` when there are no active operands.
         """
+        if self._batched_evaluator is not None:
+            return self._batched_evaluator.fun_array()
+
         terms = []
         for op in self.operands:
             ew = op.effective_weight()
@@ -123,8 +162,40 @@ class OptimizationProblem:
             return be.array([0.0])
         return be.stack(terms)
 
+    def residual_vector(self):
+        """Vector of weighted operand deltas (unsquared).
+
+        Returns a 1-D array whose *i*-th element is
+        ``weight_i * delta_i`` for each operand. This is the residual
+        vector **r** needed by least-squares algorithms such as the
+        Damped Least-Squares (Levenberg-Marquardt) optimizer.
+
+        Unlike :meth:`fun_array`, the values are *not* squared, so the
+        merit function equals ``sum(residual_vector() ** 2)``.
+
+        When batching is enabled, delegates to the
+        :class:`~optiland.optimization.batched_evaluator.BatchedRayEvaluator`
+        which minimises redundant ray traces.
+
+        Returns:
+            be.ndarray: A 1-D array of length ``len(self.operands)``.
+        """
+        if self._batched_evaluator is not None:
+            return self._batched_evaluator.residual_vector()
+        terms = [op.fun() for op in self.operands]
+        if not terms:
+            return be.array([])
+        return be.stack(terms)
+
     def sum_squared(self):
-        """Calculate the sum of squared operand weighted deltas"""
+        """Calculate the sum of squared operand weighted deltas.
+
+        When batching is enabled, delegates to the
+        :class:`~optiland.optimization.batched_evaluator.BatchedRayEvaluator`
+        which minimises redundant ray traces.
+        """
+        if self._batched_evaluator is not None:
+            return self._batched_evaluator.sum_squared()
         return be.sum(self.fun_array())
 
     def rss(self):

--- a/tests/optimization/test_batched_evaluator.py
+++ b/tests/optimization/test_batched_evaluator.py
@@ -1,0 +1,921 @@
+"""Tests for the BatchedRayEvaluator.
+
+These tests verify that:
+1. Batched evaluation produces the same results as standard evaluation.
+2. It works with both trace_generic and trace (distribution) operands.
+3. Mixed operand types (ray + non-ray) are handled correctly.
+4. Inequality operands (min/max bounds) work correctly.
+5. The evaluator can be refreshed after operand changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.optimization import optimization
+from optiland.optimization.batched_evaluator import BatchedRayEvaluator
+from optiland.samples.microscopes import Microscope20x, Objective60x
+from optiland.samples.objectives import CookeTriplet
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_problem_with_ray_operands(lens=None):
+    """Create a problem with several trace_generic ray operands."""
+    if lens is None:
+        lens = CookeTriplet()
+    problem = optimization.OptimizationProblem()
+
+    # Add some trace_generic operands (different fields, same wavelength)
+    for op_type in ("real_x_intercept", "real_y_intercept", "real_L"):
+        problem.add_operand(
+            operand_type=op_type,
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+    return problem, lens
+
+
+def _make_problem_with_rms_spot(lens=None):
+    """Create a problem with rms_spot_size operands."""
+    if lens is None:
+        lens = CookeTriplet()
+    problem = optimization.OptimizationProblem()
+
+    # Two rms_spot_size operands — same trace params, different surface
+    # (they share one trace)
+    problem.add_operand(
+        operand_type="rms_spot_size",
+        target=0.0,
+        weight=1.0,
+        input_data={
+            "optic": lens,
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "wavelength": 0.55,
+            "num_rays": 50,
+            "distribution": "hexapolar",
+        },
+    )
+    return problem, lens
+
+
+def _make_mixed_problem(lens=None):
+    """Create a problem with ray, rms_spot, paraxial, and lens operands."""
+    if lens is None:
+        lens = CookeTriplet()
+    problem = optimization.OptimizationProblem()
+
+    # Paraxial operand (non-ray)
+    problem.add_operand(
+        operand_type="f2",
+        target=50.0,
+        weight=1.0,
+        input_data={"optic": lens},
+    )
+
+    # Ray operands (trace_generic)
+    problem.add_operand(
+        operand_type="real_y_intercept",
+        target=0.0,
+        weight=1.0,
+        input_data={
+            "optic": lens,
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "Px": 0.0,
+            "Py": 1.0,
+            "wavelength": 0.55,
+        },
+    )
+
+    # rms_spot_size operand (trace)
+    problem.add_operand(
+        operand_type="rms_spot_size",
+        target=0.0,
+        weight=1.0,
+        input_data={
+            "optic": lens,
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "wavelength": 0.55,
+            "num_rays": 50,
+            "distribution": "hexapolar",
+        },
+    )
+
+    return problem, lens
+
+
+# ---------------------------------------------------------------------------
+# Tests: Batched vs Standard evaluation — numerical agreement
+# ---------------------------------------------------------------------------
+
+
+class TestBatchedVsStandard:
+    """Verify that batched evaluation gives the same result as standard."""
+
+    def test_trace_generic_operands_match(self):
+        """Batched trace_generic operands produce same sum_squared."""
+        problem, _ = _make_problem_with_ray_operands()
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_rms_spot_operands_match(self):
+        """Batched rms_spot_size operands produce same sum_squared."""
+        problem, _ = _make_problem_with_rms_spot()
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_mixed_operands_match(self):
+        """Mixed ray + non-ray operands produce same sum_squared."""
+        problem, _ = _make_mixed_problem()
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_fun_array_match(self):
+        """fun_array gives the same per-operand values."""
+        problem, _ = _make_mixed_problem()
+        standard = be.to_numpy(problem.fun_array())
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = be.to_numpy(evaluator.fun_array())
+
+        assert len(batched) == len(standard)
+        for s, b in zip(standard, batched, strict=True):
+            assert float(b) == pytest.approx(float(s), rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Specific operand types via batching
+# ---------------------------------------------------------------------------
+
+
+class TestTraceGenericOperands:
+    """Tests for all individual trace_generic operand types."""
+
+    @pytest.mark.parametrize(
+        "op_type",
+        [
+            "real_x_intercept",
+            "real_y_intercept",
+            "real_z_intercept",
+            "real_x_intercept_lcs",
+            "real_y_intercept_lcs",
+            "real_z_intercept_lcs",
+            "real_L",
+            "real_M",
+            "real_N",
+        ],
+    )
+    def test_single_operand_matches(self, op_type):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type=op_type,
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": 3,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 0.5,
+                "wavelength": 0.55,
+            },
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_aoi_operand_matches(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="AOI",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": 3,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 0.5,
+                "wavelength": 0.55,
+            },
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Multiple operands sharing a trace
+# ---------------------------------------------------------------------------
+
+
+class TestBatching:
+    """Verify that multiple operands sharing a trace produce correct results."""
+
+    def test_multiple_operands_same_wavelength(self):
+        """Multiple trace_generic operands on same optic+wavelength batch."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        # Add several operands — same optic, same wavelength, different Px/Py
+        for py in [0.0, 0.5, 1.0]:
+            problem.add_operand(
+                operand_type="real_y_intercept",
+                target=0.0,
+                weight=1.0,
+                input_data={
+                    "optic": lens,
+                    "surface_number": -1,
+                    "Hx": 0.0,
+                    "Hy": 0.0,
+                    "Px": 0.0,
+                    "Py": py,
+                    "wavelength": 0.55,
+                },
+            )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_operands_different_wavelengths(self):
+        """Operands with different wavelengths go to different trace jobs."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        for wl in [0.48, 0.55, 0.65]:
+            problem.add_operand(
+                operand_type="real_y_intercept",
+                target=0.0,
+                weight=1.0,
+                input_data={
+                    "optic": lens,
+                    "surface_number": -1,
+                    "Hx": 0.0,
+                    "Hy": 0.0,
+                    "Px": 0.0,
+                    "Py": 1.0,
+                    "wavelength": wl,
+                },
+            )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        # Should create 3 separate trace_generic jobs (one per wavelength)
+        assert len(evaluator._generic_jobs) == 3
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_rms_spot_shared_trace(self):
+        """Two rms_spot_size with same params share one trace."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        # Two operands with same trace params but different weights
+        for weight in [1.0, 2.0]:
+            problem.add_operand(
+                operand_type="rms_spot_size",
+                target=0.0,
+                weight=weight,
+                input_data={
+                    "optic": lens,
+                    "surface_number": -1,
+                    "Hx": 0.0,
+                    "Hy": 0.0,
+                    "wavelength": 0.55,
+                    "num_rays": 50,
+                    "distribution": "hexapolar",
+                },
+            )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        # Should share one distribution trace job
+        assert len(evaluator._distribution_jobs) == 1
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Inequality operands
+# ---------------------------------------------------------------------------
+
+
+class TestInequalityOperands:
+    """Test that inequality (min/max) operands work with batching."""
+
+    def test_min_max_ray_operand(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="real_y_intercept",
+            min_val=-5.0,
+            max_val=5.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_min_only_ray_operand(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="real_y_intercept",
+            min_val=-10.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Problem integration (enable_batching / disable_batching)
+# ---------------------------------------------------------------------------
+
+
+class TestProblemIntegration:
+    """Test that enable_batching/disable_batching on OptimizationProblem works."""
+
+    def test_enable_disable_batching(self):
+        problem, _ = _make_mixed_problem()
+
+        # Standard evaluation
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        # Enable batching
+        problem.enable_batching()
+        assert problem.batching_enabled
+        batched = float(be.to_numpy(problem.sum_squared()))
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+        # Disable batching
+        problem.disable_batching()
+        assert not problem.batching_enabled
+        standard_again = float(be.to_numpy(problem.sum_squared()))
+        assert standard_again == pytest.approx(standard, rel=1e-6)
+
+    def test_batching_refresh_on_add_operand(self):
+        """Adding an operand refreshes the evaluator."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="f2",
+            target=50.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+        problem.enable_batching()
+
+        # Add another operand — evaluator should auto-refresh
+        problem.add_operand(
+            operand_type="real_y_intercept",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+
+        # Should still produce correct results
+        expected = float(be.to_numpy(problem.fun_array().sum()))
+        problem.disable_batching()
+        problem.enable_batching()
+        actual = float(be.to_numpy(problem.sum_squared()))
+        assert actual == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Non-ray operands
+# ---------------------------------------------------------------------------
+
+
+class TestNonRayOperands:
+    """Test paraxial, aberration, and lens operands work through batching."""
+
+    def test_paraxial_only(self):
+        lens = Objective60x()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="f2",
+            target=90.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    @pytest.mark.skip(reason="LensOperand.edge_thickness has pre-existing sag bug")
+    def test_edge_thickness(self):
+        lens = CookeTriplet()
+        # First trace to populate semi-apertures
+        lens.trace(0.0, 0.0, 0.55, 100)
+
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="edge_thickness",
+            target=2.0,
+            weight=1.0,
+            input_data={"optic": lens, "surface_number": 1},
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+    def test_aberration_operand(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="TSC",
+            target=0.0,
+            weight=1.0,
+            input_data={"optic": lens, "surface_number": 1},
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Multi-wavelength rms_spot_size falls back correctly
+# ---------------------------------------------------------------------------
+
+
+class TestMultiWavelength:
+    """Test that rms_spot_size with wavelength='all' falls back to direct."""
+
+    def test_rms_spot_all_wavelengths(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_operand(
+            operand_type="rms_spot_size",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "wavelength": "all",
+                "num_rays": 50,
+                "distribution": "hexapolar",
+            },
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+        evaluator = BatchedRayEvaluator(problem)
+        batched = float(be.to_numpy(evaluator.sum_squared()))
+
+        assert batched == pytest.approx(standard, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Evaluator structure
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorStructure:
+    """Test that the evaluator creates the expected job structure."""
+
+    def test_generic_job_count(self):
+        """One job per (optic, wavelength) group."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        # 3 operands at wavelength 0.55, 2 at 0.48
+        for wl, count in [(0.55, 3), (0.48, 2)]:
+            for _ in range(count):
+                problem.add_operand(
+                    operand_type="real_y_intercept",
+                    target=0.0,
+                    weight=1.0,
+                    input_data={
+                        "optic": lens,
+                        "surface_number": -1,
+                        "Hx": 0.0,
+                        "Hy": 0.0,
+                        "Px": 0.0,
+                        "Py": 1.0,
+                        "wavelength": wl,
+                    },
+                )
+
+        evaluator = BatchedRayEvaluator(problem)
+        assert len(evaluator._generic_jobs) == 2
+        assert len(evaluator._generic_jobs[0].ray_params) == 3
+        assert len(evaluator._generic_jobs[1].ray_params) == 2
+
+    def test_distribution_job_count(self):
+        """One job per unique (optic, Hx, Hy, wavelength, num_rays, dist)."""
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        # Two identical trace params -> 1 job
+        for _ in range(2):
+            problem.add_operand(
+                operand_type="rms_spot_size",
+                target=0.0,
+                weight=1.0,
+                input_data={
+                    "optic": lens,
+                    "surface_number": -1,
+                    "Hx": 0.0,
+                    "Hy": 0.0,
+                    "wavelength": 0.55,
+                    "num_rays": 50,
+                },
+            )
+
+        # Different Hy -> new job
+        problem.add_operand(
+            operand_type="rms_spot_size",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.5,
+                "wavelength": 0.55,
+                "num_rays": 50,
+            },
+        )
+
+        evaluator = BatchedRayEvaluator(problem)
+        assert len(evaluator._distribution_jobs) == 2
+
+    def test_refresh(self):
+        """Calling refresh re-creates the plan."""
+        problem, _ = _make_problem_with_ray_operands()
+        evaluator = BatchedRayEvaluator(problem)
+        initial_plan_len = len(evaluator._operand_plan)
+
+        # Add an operand without going through the problem
+        problem.operands.add(
+            "f2", target=50.0, weight=1.0, input_data={"optic": CookeTriplet()},
+        )
+
+        evaluator.refresh()
+        assert len(evaluator._operand_plan) == initial_plan_len + 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Scipy optimization with batching enabled
+# ---------------------------------------------------------------------------
+
+
+class TestScipyWithBatching:
+    """Test that scipy optimizers work when batching is enabled."""
+
+    def test_optimizer_generic_with_batching(self):
+        lens = Microscope20x()
+        problem = optimization.OptimizationProblem()
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=10, max_val=100,
+        )
+        problem.add_operand(
+            operand_type="f2",
+            target=90,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+
+        # Enable batching before optimization
+        problem.enable_batching()
+
+        optimizer = optimization.OptimizerGeneric(problem)
+        result = optimizer.optimize(maxiter=10, disp=False, tol=1e-3)
+        assert result.success
+
+    def test_optimizer_with_ray_operands_and_batching(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=10, max_val=100,
+        )
+
+        problem.add_operand(
+            operand_type="real_y_intercept",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "Px": 0.0,
+                "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+
+        problem.add_operand(
+            operand_type="rms_spot_size",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0,
+                "Hy": 0.0,
+                "wavelength": 0.55,
+                "num_rays": 50,
+            },
+        )
+
+        problem.enable_batching()
+
+        optimizer = optimization.OptimizerGeneric(problem)
+        result = optimizer.optimize(maxiter=5, disp=False, tol=1e-3)
+        # Just verify it ran without error
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Torch autograd compatibility
+# ---------------------------------------------------------------------------
+
+def _torch_available():
+    """Check whether the torch backend is available."""
+    try:
+        import torch  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _torch_available(), reason="torch not installed")
+class TestTorchAutograd:
+    """Verify that the batched evaluator preserves PyTorch autograd graphs."""
+
+    @pytest.fixture(autouse=True)
+    def _set_torch_backend(self):
+        """Switch to torch backend for the duration of each test."""
+        original = be.get_backend()
+        be.set_backend("torch")
+        be.grad_mode.enable()
+        yield
+        be.set_backend(original)
+
+    def test_sum_squared_supports_backward(self):
+        """sum_squared() returns a tensor with a grad_fn when batching is
+        enabled under the torch backend + grad_mode."""
+        import torch
+
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        # Variable: radius of surface 1
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=10, max_val=100,
+        )
+
+        # Operand: y-intercept on image surface
+        problem.add_operand(
+            operand_type="real_y_intercept",
+            target=0.0,
+            weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0, "Hy": 0.0,
+                "Px": 0.0, "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+
+        problem.enable_batching()
+
+        # Make the variable a torch.nn.Parameter so we can track grads
+        param = torch.nn.Parameter(
+            be.array(problem.variables[0].variable.get_value())
+        )
+        problem.variables[0].variable.update_value(param)
+        problem.update_optics()
+
+        loss = problem.sum_squared()
+
+        # The loss should be a torch tensor with an autograd graph
+        assert isinstance(loss, torch.Tensor)
+        assert loss.grad_fn is not None, (
+            "sum_squared() should produce a tensor with grad_fn"
+        )
+
+        # backward() should not raise
+        loss.backward()
+
+        # The parameter should have a non-None gradient
+        assert param.grad is not None, (
+            "Parameter gradient should be populated after backward()"
+        )
+
+    def test_torch_adam_optimizer_with_batching(self):
+        """TorchAdamOptimizer works with batching enabled and reduces loss.
+
+        Uses a paraxial operand (``f2``) because multi-step backward
+        through ``trace_generic`` is a known pre-existing limitation of
+        the ray-tracing graph (also fails without batching).
+        """
+        from optiland.optimization import TorchAdamOptimizer
+
+        lens = CookeTriplet()
+        # Match the setup used in test_torch_optimization.py
+        lens.surface_group.surfaces[1].radius = 5.0
+        problem = optimization.OptimizationProblem()
+
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=1.0, max_val=10.0,
+        )
+
+        # Paraxial operand — the existing torch tests also use f2
+        problem.add_operand(
+            operand_type="f2",
+            target=12.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+
+        problem.enable_batching()
+        problem.update_optics()
+        initial_loss = problem.sum_squared().item()
+
+        optimizer = TorchAdamOptimizer(problem)
+        result = optimizer.optimize(n_steps=50, lr=1e-2, disp=False)
+
+        assert result.fun < initial_loss, (
+            f"Loss should decrease: {result.fun} >= {initial_loss}"
+        )
+
+    def test_batched_fun_array_gradient_flows(self):
+        """fun_array() elements retain grad_fn under torch backend."""
+        import torch
+
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=10, max_val=100,
+        )
+
+        # Two operands to make batching meaningful
+        for py_val in (0.5, 1.0):
+            problem.add_operand(
+                operand_type="real_y_intercept",
+                target=0.0,
+                weight=1.0,
+                input_data={
+                    "optic": lens,
+                    "surface_number": -1,
+                    "Hx": 0.0, "Hy": 0.0,
+                    "Px": 0.0, "Py": py_val,
+                    "wavelength": 0.55,
+                },
+            )
+
+        problem.enable_batching()
+
+        param = torch.nn.Parameter(
+            be.array(problem.variables[0].variable.get_value())
+        )
+        problem.variables[0].variable.update_value(param)
+        problem.update_optics()
+
+        arr = problem.fun_array()
+        assert isinstance(arr, torch.Tensor)
+        assert arr.grad_fn is not None, (
+            "fun_array() should produce tensors with grad_fn"
+        )
+
+    def test_batched_matches_standard_under_torch(self):
+        """Batched and standard evaluation agree numerically under torch."""
+        lens = CookeTriplet()
+
+        # Standard (no batching)
+        p_std = optimization.OptimizationProblem()
+        p_std.add_operand(
+            operand_type="real_y_intercept",
+            target=0.0, weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0, "Hy": 0.0,
+                "Px": 0.0, "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+        standard_val = float(be.to_numpy(p_std.sum_squared()))
+
+        # Batched
+        p_bat = optimization.OptimizationProblem()
+        p_bat.add_operand(
+            operand_type="real_y_intercept",
+            target=0.0, weight=1.0,
+            input_data={
+                "optic": lens,
+                "surface_number": -1,
+                "Hx": 0.0, "Hy": 0.0,
+                "Px": 0.0, "Py": 1.0,
+                "wavelength": 0.55,
+            },
+        )
+        p_bat.enable_batching()
+        batched_val = float(be.to_numpy(p_bat.sum_squared()))
+
+        assert abs(standard_val - batched_val) < 1e-10, (
+            f"standard={standard_val}, batched={batched_val}"
+        )

--- a/tests/optimization/test_batched_evaluator.py
+++ b/tests/optimization/test_batched_evaluator.py
@@ -411,23 +411,45 @@ class TestInequalityOperands:
 class TestProblemIntegration:
     """Test that enable_batching/disable_batching on OptimizationProblem works."""
 
-    def test_enable_disable_batching(self):
+    def test_default_batching_and_enable_disable(self):
         problem, _ = _make_mixed_problem()
 
-        # Standard evaluation
-        standard = float(be.to_numpy(problem.sum_squared()))
+        # Batching is on by default
+        assert problem.batching_enabled
+        batched_default = float(be.to_numpy(problem.sum_squared()))
 
-        # Enable batching
+        # Disable batching for legacy per-operand behavior
+        problem.disable_batching()
+        assert not problem.batching_enabled
+        standard = float(be.to_numpy(problem.sum_squared()))
+        assert batched_default == pytest.approx(standard, rel=1e-6)
+
+        # Re-enable batching
         problem.enable_batching()
         assert problem.batching_enabled
+        batched_again = float(be.to_numpy(problem.sum_squared()))
+        assert batched_again == pytest.approx(standard, rel=1e-6)
+
+    def test_opt_out_constructor_starts_without_batching(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem(batching=False)
+        assert not problem.batching_enabled
+
+        problem.add_operand(
+            operand_type="f2",
+            target=90.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+
+        standard = float(be.to_numpy(problem.sum_squared()))
+
+        problem.enable_batching()
         batched = float(be.to_numpy(problem.sum_squared()))
         assert batched == pytest.approx(standard, rel=1e-6)
 
-        # Disable batching
         problem.disable_batching()
         assert not problem.batching_enabled
-        standard_again = float(be.to_numpy(problem.sum_squared()))
-        assert standard_again == pytest.approx(standard, rel=1e-6)
 
     def test_batching_refresh_on_add_operand(self):
         """Adding an operand refreshes the evaluator."""
@@ -652,6 +674,80 @@ class TestEvaluatorStructure:
 
         evaluator.refresh()
         assert len(evaluator._operand_plan) == initial_plan_len + 1
+
+
+class TestEvaluatorHelpers:
+    """Coverage-oriented tests for internal helper methods."""
+
+    def test_ensure_plan_current_rebuilds_when_mismatched(self):
+        problem, _ = _make_problem_with_ray_operands()
+        evaluator = BatchedRayEvaluator(problem)
+
+        # Simulate stale internal state and ensure helper re-analyzes.
+        evaluator._operand_plan = []
+        evaluator._ensure_plan_current()
+
+        assert len(evaluator._operand_plan) == len(problem.operands)
+
+    def test_safe_execute_returns_none_on_exception(self):
+        class _BadJob:
+            def execute(self):
+                raise RuntimeError("boom")
+
+        assert BatchedRayEvaluator._safe_execute(_BadJob()) is None
+
+    def test_evaluate_direct_operands_skips_zero_effective_weight(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+        problem.add_operand(
+            operand_type="f2",
+            target=50.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+        evaluator = BatchedRayEvaluator(problem)
+
+        # Force the zero-effective-weight path.
+        op = problem.operands[0]
+        op.effective_weight = lambda optic=None: 0.0
+
+        raw_values = [None]
+        evaluator._evaluate_direct_operands(raw_values)
+        assert raw_values[0] is None
+
+        # No contribution terms should be produced for zero-effective-weight ops.
+        assert evaluator._build_contribution_terms(raw_values) == []
+
+    def test_evaluate_direct_operands_unknown_operand_raises(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+        problem.add_operand(
+            operand_type="f2",
+            target=50.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+        evaluator = BatchedRayEvaluator(problem)
+
+        # Force unknown direct metric lookup branch.
+        problem.operands[0].operand_type = "not_registered_operand"
+
+        with pytest.raises(ValueError, match="Unknown operand type"):
+            evaluator._evaluate_direct_operands([None])
+
+    def test_build_contribution_terms_raises_for_missing_value(self):
+        lens = CookeTriplet()
+        problem = optimization.OptimizationProblem()
+        problem.add_operand(
+            operand_type="f2",
+            target=50.0,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+        evaluator = BatchedRayEvaluator(problem)
+
+        with pytest.raises(RuntimeError, match="was not evaluated"):
+            evaluator._build_contribution_terms([None])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_torch_optimization.py
+++ b/tests/test_torch_optimization.py
@@ -367,10 +367,90 @@ class TestTorchOptimizerScaledSpace:
         )
         problem.add_variable(lens, "thickness", surface_number=2)
 
+        initial_loss = problem.sum_squared().item()
         optimizer = TorchAdamOptimizer(problem)
         result = optimizer.optimize(n_steps=10, disp=False)
 
         assert not math.isnan(result.fun), (
             f"Loss should not be NaN with Material('N-BK7') and bounded "
             f"variables, got {result.fun}"
+        )
+        assert result.fun < initial_loss, (
+            "Optimizer should reduce loss for the real-material bounded case; "
+            "otherwise gradients may be disconnected."
+        )
+
+    def test_legacy_array_behavior_breaks_gradient_flow(self, monkeypatch):
+        """Regression guard for the historical graph-break behavior.
+
+        The legacy TorchBackend.array implementation converted lists containing
+        tensors with torch.tensor(...), which detached them from autograd.
+        This test monkeypatches that legacy behavior and verifies gradients on
+        optimizer parameters become None, proving learning was broken.
+        """
+        import numpy as np
+        import torch
+
+        from optiland.backend.torch_backend import TorchBackend
+        from optiland.optic import Optic
+
+        def _legacy_array(self, x):
+            if isinstance(x, torch.Tensor):
+                return x
+            if isinstance(x, (list, tuple)) and len(x) > 0 and isinstance(x[0], np.ndarray):
+                x = np.array(x)
+            return torch.tensor(
+                x,
+                device=self._device(),
+                dtype=self._dtype(),
+                requires_grad=self._grad(),
+            )
+
+        monkeypatch.setattr(TorchBackend, "array", _legacy_array)
+
+        lens = Optic()
+        lens.add_surface(index=0, thickness=be.inf)
+        lens.add_surface(
+            index=1,
+            thickness=7,
+            radius=15,
+            material="N-BK7",
+            is_stop=True,
+        )
+        lens.add_surface(index=2, thickness=30, radius=-1000)
+        lens.add_surface(index=3)
+        lens.set_aperture(aperture_type="EPD", value=15)
+        lens.set_field_type(field_type="angle")
+        lens.add_field(y=0)
+        lens.add_wavelength(value=0.55, is_primary=True)
+
+        problem = OptimizationProblem()
+        problem.add_operand(
+            operand_type="f2",
+            target=50,
+            weight=1,
+            input_data={"optic": lens},
+        )
+        problem.add_variable(
+            lens,
+            "radius",
+            surface_number=1,
+            min_val=10,
+            max_val=30,
+        )
+        problem.add_variable(lens, "thickness", surface_number=2)
+
+        optimizer = TorchAdamOptimizer(problem)
+        torch_opt, _ = optimizer._create_optimizer_and_scheduler(lr=1e-2, gamma=0.99)
+
+        torch_opt.zero_grad()
+        for k, param in enumerate(optimizer.params):
+            problem.variables[k].update(param)
+        problem.update_optics()
+        loss = problem.sum_squared()
+        loss.backward()
+
+        assert all(param.grad is None for param in optimizer.params), (
+            "Legacy array behavior should detach tensors and break gradients; "
+            "expected all parameter grads to be None."
         )


### PR DESCRIPTION
### Add `BatchedRayEvaluator` to eliminate redundant ray traces during optimization

**What this does**

Introduces `BatchedRayEvaluator` (`optiland/optimization/batched_evaluator.py`), a drop-in accelerator for `OptimizationProblem` that eliminates redundant ray tracing when evaluating a merit function.

In the standard evaluation path, each operand independently calls `optic.trace_generic()` or `optic.trace()` — meaning N operands always produce N trace calls, even when those operands share the same optic and wavelength. The batched evaluator analyses the problem up-front, groups operands by `(optic, wavelength)`, and collapses each group into **one** vectorized trace call. Operand values are extracted from the shared result by index, preserving the autograd computation graph for PyTorch.

**How to use it**

```python
problem = OptimizationProblem()
# ... add operands and variables ...

problem.enable_batching()  # activates BatchedRayEvaluator
loss = problem.sum_squared()  # now uses batched path

problem.disable_batching()  # reverts to standard path
```

`enable_batching()` / `disable_batching()` / `batching_enabled` are the three new methods on `OptimizationProblem`. The evaluator is re-analysed automatically when operands or variables are added.

**What gets batched**

| Operand group | Grouping key | Result |
| :--- | :--- | :--- |
| `real_x/y/z_intercept`, `real_x/y/z_intercept_lcs`, `real_L/M/N`, `AOI` | `(optic, wavelength)` | N single-ray operands → 1 `trace_generic` call |
| `rms_spot_size` | `(optic, Hx, Hy, wavelength, num_rays, distribution)` | identical-parameter operands → 1 `trace` call |
| paraxial / other | — | evaluated directly, unchanged |

**Implementation notes**

* `_analyze()` runs once at construction (and on `refresh()`) to build a static plan of `("generic" | "distribution" | "direct", job_idx, ray_idx)` per operand — zero overhead per iteration.
* `residual_vector()` uses a fully vectorized extraction path for the common operand types (intercepts, direction cosines), grouping them into a single tensor index operation per type per job. `AOI` and local-coordinate operands fall back to a scalar path.
* Autograd is preserved: values are extracted by slicing directly into the traced tensor arrays — no `detach()` or `clone()`.
* Multi-wavelength `rms_spot_size` (`wavelength="all"`) is always evaluated directly, since it internally issues multiple traces.

**Benchmark results summary**

Five scenarios were measured (NumPy backend, 50 timed iterations after 5 warmup):

| Scenario | Operands | Std traces → Bat traces | Expected speedup |
| :--- | :--- | :--- | :--- |
| Scaling N=5 (same wavelength) | 5 | 5 → 1 | ~3–4× |
| Scaling N=20 | 20 | 20 → 1 | ~10–15× |
| Scaling N=40 | 40 | 40 → 1 | ~18–25× |
| Multi-wavelength 3×6 ops | 18 | 18 → 3 | ~5–8× |
| Mixed types (CookeTriplet) | 19 | 17 → 4 | ~4–6× |
| Large design DoubleGauss 3×20 | 60 | 60 → 3 | ~15–20× |
| Shared spot size N=5 | 5 | 5 → 1 | ~3–4× |

> Speedup grows with the number of operands sharing a wavelength and approaches — but does not reach — the ideal N× bound due to fixed Python overhead per evaluation call.


**TORCH BACKEND EVALUATED ONLY ON CPU**

Some of the results from the benchmarks i did:
<img width="2137" height="1454" alt="image" src="https://github.com/user-attachments/assets/46ee3b90-5455-4bcd-8be4-0d8339f678b1" />


It seems that the overhead from pytorch relative to numpy is noticeable, at least on cpu. Having grad mode on or off doesnt change the results.

<img width="2008" height="1576" alt="backend_analysis" src="https://github.com/user-attachments/assets/de055757-3fb9-40cc-abc2-0c0fa1e056d6" />

