### PR TITLE
Refactor MTF Calculations for High-Accuracy Off-Axis Results

### DIFF
--- a/optiland/mtf/base.py
+++ b/optiland/mtf/base.py
@@ -114,8 +114,10 @@ class BaseMTF(abc.ABC):
                 If None, a new figure will be created. Defaults to None.
             figsize (tuple, optional): The size of the figure.
                 Defaults to (12, 4).
-            add_reference (bool, optional): Whether to add the diffraction
-                limit reference line. Defaults to False.
+            add_reference (bool, optional): Whether to overlay the theoretical
+                diffraction-limited MTF curve for a clear circular aperture.
+                The reference is computed using the *on-axis* working F/# and
+                the resolved wavelength. Defaults to False.
         Returns:
             tuple: A tuple containing the figure and axes objects.
         """
@@ -132,15 +134,28 @@ class BaseMTF(abc.ABC):
             self._plot_field_mtf(ax, k, field_mtf_item, color=f"C{k}")
 
         if add_reference:
-            ratio = be.clip(self.freq / self.max_freq, 0.0, 1.0)
+            # The reference curve shows the theoretical diffraction-limited OTF for
+            # a clear circular aperture evaluated at the *on-axis* working F/# and
+            # the resolved wavelength. For off-axis fields the working F/# may
+            # differ; the on-axis reference provides a consistent, field-independent
+            # benchmark.
+            #
+            # Formula (incoherent OTF for a circular aperture):
+            #   MTF(u) = (2/π)(arccos(u) − u √(1 − u²))  for u ∈ [0, 1]
+            # where u = f / f_c  and  f_c = 1 / (λ · F/#_on-axis).
+            on_axis_fno = self._get_fno()
+            cutoff_freq = 1 / (self.resolved_wavelength * 1e-3 * on_axis_fno)
+            ref_freq = be.linspace(0, cutoff_freq, 256)
+
+            ratio = be.clip(ref_freq / cutoff_freq, 0.0, 1.0)
             phi = be.arccos(ratio)
             diff_limited_mtf = (2 / be.pi) * (phi - be.cos(phi) * be.sin(phi))
 
             ax.plot(
-                be.to_numpy(self.freq),
+                be.to_numpy(ref_freq),
                 be.to_numpy(diff_limited_mtf),
                 "k--",
-                label="Diffraction Limit",
+                label="Diffraction Limit (on-axis)",
             )
 
         ax.legend(bbox_to_anchor=(1.05, 0.5), loc="center left")

--- a/optiland/mtf/fft.py
+++ b/optiland/mtf/fft.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import optiland.backend as be
 from optiland.psf.fft import ScalarFFTPSF, calculate_grid_size
+from optiland.utils import get_working_FNO
 
 from .base import BaseMTF
 
@@ -74,14 +75,21 @@ class ScalarFFTMTF(BaseMTF):
 
         super().__init__(optic, fields, wavelength, strategy, remove_tilt, **kwargs)
 
-        self.FNO = self._get_fno()
+        self.FNO = [
+            get_working_FNO(self.optic, field, self.resolved_wavelength)
+            for field in self.resolved_fields
+        ]
 
         if max_freq == "cutoff":
-            self.max_freq = 1 / (self.resolved_wavelength * 1e-3 * self.FNO)
+            on_axis_fno = self._get_fno()
+            self.max_freq = 1 / (self.resolved_wavelength * 1e-3 * on_axis_fno)
         else:
             self.max_freq = max_freq
 
-        self.freq = be.arange(self.grid_size // 2) * self._get_mtf_units()
+        self.freq = [
+            be.arange(self.grid_size // 2) * self._get_mtf_units(k)
+            for k in range(len(self.resolved_fields))
+        ]
 
     def _calculate_psf(self):
         """Calculates and stores the Point Spread Function (PSF).
@@ -117,7 +125,7 @@ class ScalarFFTMTF(BaseMTF):
 
         # Plot tangential MTF
         ax.plot(
-            be.to_numpy(self.freq),
+            be.to_numpy(self.freq[field_index]),
             be.to_numpy(mtf_field_data[0]),  # Tangential data
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
@@ -128,7 +136,7 @@ class ScalarFFTMTF(BaseMTF):
         )
         # Plot sagittal MTF
         ax.plot(
-            be.to_numpy(self.freq),
+            be.to_numpy(self.freq[field_index]),
             be.to_numpy(mtf_field_data[1]),  # Sagittal data
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
@@ -141,29 +149,54 @@ class ScalarFFTMTF(BaseMTF):
     def _generate_mtf_data(self):
         """Generates the MTF data for each field.
 
-        The calculation is based on the PSF, which is calculated during
-        construction of the class.
+        The OTF is computed as the 2D FFT of the PSF. The DC component (zero
+        spatial frequency) is located at index ``(grid_size // 2, grid_size // 2)``
+        after ``fftshift``. The tangential and sagittal MTF slices are extracted
+        from that center outward and normalized by the DC value so that MTF(0) = 1,
+        consistent with the incoherent imaging convention used by OpticStudio.
 
         Returns:
-            list: A list of MTF data for each field. Each MTF data is a list
-                containing the tangential and sagittal MTF values.
+            list: A list of MTF data for each field. Each element is a list
+                ``[tangential_mtf, sagittal_mtf]`` where each is a 1-D array of
+                length ``grid_size // 2`` with values in ``[0, 1]``.
         """
         mtf_data = [be.abs(be.fft.fftshift(be.fft.fft2(psf))) for psf in self.psf]
         mtf = []
+        center = self.grid_size // 2
         for data in mtf_data:
-            tangential = data[self.grid_size // 2 :, self.grid_size // 2]
-            sagittal = data[self.grid_size // 2, self.grid_size // 2 :]
-            mtf.append([tangential / be.max(tangential), sagittal / be.max(sagittal)])
+            # Extract 1-D slices from the DC bin outward, clipped to grid_size // 2
+            tangential = data[center:, center][:center]
+            sagittal = data[center, center:][:center]
+
+            # Normalize by the DC value (OTF at zero frequency = total PSF power).
+            # Physical MTF must satisfy MTF(0) = 1; the DC bin is always the maximum
+            # for a well-behaved incoherent system.
+            dc_value = data[center, center]
+            if dc_value == 0:
+                norm_tangential = be.zeros_like(tangential)
+                norm_sagittal = be.zeros_like(sagittal)
+            else:
+                norm_tangential = tangential / dc_value
+                norm_sagittal = sagittal / dc_value
+
+            # Guard against floating-point overshoot beyond the physical [0, 1] range.
+            norm_tangential = be.clip(norm_tangential, 0.0, 1.0)
+            norm_sagittal = be.clip(norm_sagittal, 0.0, 1.0)
+
+            mtf.append([norm_tangential, norm_sagittal])
         return mtf
 
-    def _get_mtf_units(self):
-        """Calculate the MTF units.
+    def _get_mtf_units(self, k):
+        """Calculate the MTF units for a given field index.
+
+        Args:
+            k (int): Field index.
 
         Returns:
             float: The MTF units calculated based on the grid size, number
-                of rays, wavelength (from BaseMTF), and FNO.
+                of rays, wavelength (from BaseMTF), and the field's FNO.
         """
-        dx = 1 / ((self.num_rays - 1) * self.resolved_wavelength * 1e-3 * self.FNO)
+        dx = 1 / ((self.num_rays - 1) * self.resolved_wavelength * 1e-3 * self.FNO[k])
 
         return dx
 

--- a/optiland/mtf/fft.py
+++ b/optiland/mtf/fft.py
@@ -86,10 +86,17 @@ class ScalarFFTMTF(BaseMTF):
         else:
             self.max_freq = max_freq
 
-        self.freq = [
-            be.arange(self.grid_size // 2) * self._get_mtf_units(k)
-            for k in range(len(self.resolved_fields))
+        n_fields = len(self.resolved_fields)
+        self.freq_tang = [
+            be.arange(self.grid_size // 2) * self._get_mtf_units_tang(k)
+            for k in range(n_fields)
         ]
+        self.freq_sag = [
+            be.arange(self.grid_size // 2) * self._get_mtf_units_sag(k)
+            for k in range(n_fields)
+        ]
+        # Backward-compatible alias (tangential is the primary reference).
+        self.freq = self.freq_tang
 
     def _calculate_psf(self):
         """Calculates and stores the Point Spread Function (PSF).
@@ -123,10 +130,10 @@ class ScalarFFTMTF(BaseMTF):
         """
         current_field_label_info = self.resolved_fields[field_index]
 
-        # Plot tangential MTF
+        # Plot tangential MTF (uses the image-plane-corrected frequency axis)
         ax.plot(
-            be.to_numpy(self.freq[field_index]),
-            be.to_numpy(mtf_field_data[0]),  # Tangential data
+            be.to_numpy(self.freq_tang[field_index]),
+            be.to_numpy(mtf_field_data[0]),
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
                 f"Hy: {current_field_label_info[1]:.1f}, Tangential"
@@ -134,10 +141,10 @@ class ScalarFFTMTF(BaseMTF):
             color=color,
             linestyle="-",
         )
-        # Plot sagittal MTF
+        # Plot sagittal MTF (no tilt in the sagittal plane — use per-field axis)
         ax.plot(
-            be.to_numpy(self.freq[field_index]),
-            be.to_numpy(mtf_field_data[1]),  # Sagittal data
+            be.to_numpy(self.freq_sag[field_index]),
+            be.to_numpy(mtf_field_data[1]),
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
                 f"Hy: {current_field_label_info[1]:.1f}, Sagittal"
@@ -186,19 +193,46 @@ class ScalarFFTMTF(BaseMTF):
             mtf.append([norm_tangential, norm_sagittal])
         return mtf
 
-    def _get_mtf_units(self, k):
-        """Calculate the MTF units for a given field index.
+    def _get_mtf_units_tang(self, k):
+        """Tangential frequency step (cycles/mm) with image-plane correction.
+
+        The chief ray tilts in the tangential plane.  Converting the per-field
+        working F/# (measured in the chief-ray frame) to the flat image plane
+        introduces a cos(θ_chief) ≈ FNO_on/FNO_off compression:
+
+            df_tang = df_chief * (FNO_on / FNO_off)
+
+        For on-axis fields FNO_on == FNO_off and the correction is unity.
 
         Args:
             k (int): Field index.
 
         Returns:
-            float: The MTF units calculated based on the grid size, number
-                of rays, wavelength (from BaseMTF), and the field's FNO.
+            float: Tangential frequency step in cycles/mm.
         """
-        dx = 1 / ((self.num_rays - 1) * self.resolved_wavelength * 1e-3 * self.FNO[k])
+        on_axis_fno = self._get_fno()
+        off_axis_fno = self.FNO[k]
+        df_chief = 1 / (
+            (self.num_rays - 1) * self.resolved_wavelength * 1e-3 * off_axis_fno
+        )
+        return df_chief * (on_axis_fno / off_axis_fno)
 
-        return dx
+    def _get_mtf_units_sag(self, k):
+        """Sagittal frequency step (cycles/mm).
+
+        There is no chief-ray tilt in the sagittal plane, so the per-field
+        working F/# (chief-ray frame) is used directly.
+
+        Args:
+            k (int): Field index.
+
+        Returns:
+            float: Sagittal frequency step in cycles/mm.
+        """
+        off_axis_fno = self.FNO[k]
+        return 1 / (
+            (self.num_rays - 1) * self.resolved_wavelength * 1e-3 * off_axis_fno
+        )
 
 
 class FFTMTF:

--- a/optiland/mtf/huygens_fresnel.py
+++ b/optiland/mtf/huygens_fresnel.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import optiland.backend as be
 from optiland.psf.huygens_fresnel import ScalarHuygensPSF
+from optiland.utils import get_working_FNO
 
 from .base import BaseMTF
 
@@ -71,15 +72,21 @@ class ScalarHuygensMTF(BaseMTF):
 
         super().__init__(optic, fields, wavelength)
 
-        self.FNO = self._get_fno()
+        self.FNO = [
+            get_working_FNO(self.optic, field, self.resolved_wavelength)
+            for field in self.resolved_fields
+        ]
 
         if max_freq == "cutoff":
-            # wavelength in um, FNO is unitless. max_freq in cycles/mm
-            self.max_freq = 1 / (self.resolved_wavelength * 1e-3 * self.FNO)
+            on_axis_fno = self._get_fno()
+            self.max_freq = 1 / (self.resolved_wavelength * 1e-3 * on_axis_fno)
         else:
             self.max_freq = max_freq
 
-        self.freq = be.arange(self.image_size // 2) * self._get_mtf_units()
+        self.freq = [
+            be.arange(self.image_size // 2) * self._get_mtf_units(k)
+            for k in range(len(self.resolved_fields))
+        ]
 
     def _calculate_psf(self):
         """Calculates and stores the Point Spread Functions (PSFs).
@@ -98,7 +105,7 @@ class ScalarHuygensMTF(BaseMTF):
                 wavelength=self.resolved_wavelength,
                 num_rays=self.num_rays,
                 image_size=self.image_size,
-                oversample=2.0,
+                oversample=4.0,
             )
             self.psf_data.append(psf_calculator.psf)
             self.psf_instances.append(psf_calculator)
@@ -167,7 +174,7 @@ class ScalarHuygensMTF(BaseMTF):
         current_field_label_info = self.resolved_fields[field_index]
 
         num_mtf_points = mtf_field_data[0].shape[0]
-        freq_for_plot = self.freq[:num_mtf_points]
+        freq_for_plot = self.freq[field_index][:num_mtf_points]
 
         ax.plot(
             be.to_numpy(freq_for_plot),
@@ -190,17 +197,20 @@ class ScalarHuygensMTF(BaseMTF):
             linestyle="--",
         )
 
-    def _get_mtf_units(self):
+    def _get_mtf_units(self, k):
         """Calculate the MTF frequency step (spatial frequency units).
 
         The frequency unit is cycles per mm. It's determined by the pixel
         pitch of the PSF image and the total number of pixels (image_size).
         The frequency step df = 1 / (image_size * pixel_pitch).
 
+        Args:
+            k (int): Field index.
+
         Returns:
             float: The frequency step for MTF calculation (cycles/mm).
         """
-        pixel_pitch_mm = self.psf_instances[0].pixel_pitch
+        pixel_pitch_mm = self.psf_instances[k].pixel_pitch
         if pixel_pitch_mm is None or pixel_pitch_mm == 0:
             raise ValueError("Pixel pitch from HuygensPSF is invalid.")
 
@@ -238,7 +248,7 @@ class VectorialHuygensMTF(ScalarHuygensMTF):
                 wavelength=self.resolved_wavelength,
                 num_rays=self.num_rays,
                 image_size=self.image_size,
-                oversample=2.0,
+                oversample=4.0,
             )
             self.psf_data.append(psf_calculator.psf)
             self.psf_instances.append(psf_calculator)

--- a/optiland/mtf/huygens_fresnel.py
+++ b/optiland/mtf/huygens_fresnel.py
@@ -83,10 +83,17 @@ class ScalarHuygensMTF(BaseMTF):
         else:
             self.max_freq = max_freq
 
-        self.freq = [
-            be.arange(self.image_size // 2) * self._get_mtf_units(k)
-            for k in range(len(self.resolved_fields))
+        n_fields = len(self.resolved_fields)
+        self.freq_tang = [
+            be.arange(self.image_size // 2) * self._get_mtf_units_tang(k)
+            for k in range(n_fields)
         ]
+        self.freq_sag = [
+            be.arange(self.image_size // 2) * self._get_mtf_units_sag(k)
+            for k in range(n_fields)
+        ]
+        # Backward-compatible alias (tangential is the primary reference).
+        self.freq = self.freq_tang
 
     def _calculate_psf(self):
         """Calculates and stores the Point Spread Functions (PSFs).
@@ -174,10 +181,11 @@ class ScalarHuygensMTF(BaseMTF):
         current_field_label_info = self.resolved_fields[field_index]
 
         num_mtf_points = mtf_field_data[0].shape[0]
-        freq_for_plot = self.freq[field_index][:num_mtf_points]
+        freq_tang = self.freq_tang[field_index][:num_mtf_points]
+        freq_sag = self.freq_sag[field_index][:num_mtf_points]
 
         ax.plot(
-            be.to_numpy(freq_for_plot),
+            be.to_numpy(freq_tang),
             be.to_numpy(mtf_field_data[0]),
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
@@ -187,7 +195,7 @@ class ScalarHuygensMTF(BaseMTF):
             linestyle="-",
         )
         ax.plot(
-            be.to_numpy(freq_for_plot),
+            be.to_numpy(freq_sag),
             be.to_numpy(mtf_field_data[1]),
             label=(
                 f"Hx: {current_field_label_info[0]:.1f}, "
@@ -197,25 +205,56 @@ class ScalarHuygensMTF(BaseMTF):
             linestyle="--",
         )
 
-    def _get_mtf_units(self, k):
-        """Calculate the MTF frequency step (spatial frequency units).
+    def _get_mtf_units_tang(self, k):
+        """Tangential frequency step (cycles/mm) with image-plane correction.
 
-        The frequency unit is cycles per mm. It's determined by the pixel
-        pitch of the PSF image and the total number of pixels (image_size).
-        The frequency step df = 1 / (image_size * pixel_pitch).
+        The chief ray tilts in the tangential plane. Converting the per-field
+        working F/# (measured in the chief-ray frame) to the flat image plane
+        introduces a cos(θ_chief) ≈ FNO_on/FNO_off compression:
+
+            df_tang = df_per_field * (FNO_on / FNO_off)
+
+        For on-axis fields FNO_on == FNO_off and the correction is unity.
 
         Args:
             k (int): Field index.
 
         Returns:
-            float: The frequency step for MTF calculation (cycles/mm).
+            float: Tangential frequency step in cycles/mm.
+
+        Raises:
+            ValueError: If the PSF pixel pitch is zero or None.
         """
         pixel_pitch_mm = self.psf_instances[k].pixel_pitch
         if pixel_pitch_mm is None or pixel_pitch_mm == 0:
             raise ValueError("Pixel pitch from HuygensPSF is invalid.")
 
-        df = 1.0 / (self.image_size * pixel_pitch_mm)
-        return df
+        on_axis_fno = self._get_fno()
+        off_axis_fno = self.FNO[k]
+
+        df_per_field = 1.0 / (self.image_size * pixel_pitch_mm)
+        return df_per_field * (on_axis_fno / off_axis_fno)
+
+    def _get_mtf_units_sag(self, k):
+        """Sagittal frequency step (cycles/mm).
+
+        There is no chief-ray tilt in the sagittal plane, so the per-field
+        pixel-pitch-derived step is used directly without correction.
+
+        Args:
+            k (int): Field index.
+
+        Returns:
+            float: Sagittal frequency step in cycles/mm.
+
+        Raises:
+            ValueError: If the PSF pixel pitch is zero or None.
+        """
+        pixel_pitch_mm = self.psf_instances[k].pixel_pitch
+        if pixel_pitch_mm is None or pixel_pitch_mm == 0:
+            raise ValueError("Pixel pitch from HuygensPSF is invalid.")
+
+        return 1.0 / (self.image_size * pixel_pitch_mm)
 
 
 class VectorialHuygensMTF(ScalarHuygensMTF):

--- a/optiland/mtf/huygens_fresnel.py
+++ b/optiland/mtf/huygens_fresnel.py
@@ -105,6 +105,18 @@ class ScalarHuygensMTF(BaseMTF):
         """
         self.psf_data = []
         self.psf_instances = []
+
+        # Pre-calculate normalization once (on-axis, primary wavelength)
+        # This avoiding redundant PSF peak calculations for every field.
+        norm_psf = ScalarHuygensPSF(
+            optic=self.optic,
+            field=(0, 0),
+            wavelength=self.resolved_wavelength,
+            num_rays=self.num_rays,
+            image_size=self.image_size,
+        )
+        normalization = norm_psf.normalization
+
         for field_coord in self.resolved_fields:
             psf_calculator = ScalarHuygensPSF(
                 optic=self.optic,
@@ -113,6 +125,7 @@ class ScalarHuygensMTF(BaseMTF):
                 num_rays=self.num_rays,
                 image_size=self.image_size,
                 oversample=4.0,
+                normalization=normalization,
             )
             self.psf_data.append(psf_calculator.psf)
             self.psf_instances.append(psf_calculator)
@@ -280,6 +293,18 @@ class VectorialHuygensMTF(ScalarHuygensMTF):
 
         self.psf_data = []
         self.psf_instances = []
+
+        # Pre-calculate normalization once (on-axis, primary wavelength)
+        # This avoiding redundant PSF peak calculations for every field.
+        norm_psf = VectorialHuygensPSF(
+            optic=self.optic,
+            field=(0, 0),
+            wavelength=self.resolved_wavelength,
+            num_rays=self.num_rays,
+            image_size=self.image_size,
+        )
+        normalization = norm_psf.normalization
+
         for field_coord in self.resolved_fields:
             psf_calculator = VectorialHuygensPSF(
                 optic=self.optic,
@@ -288,6 +313,7 @@ class VectorialHuygensMTF(ScalarHuygensMTF):
                 num_rays=self.num_rays,
                 image_size=self.image_size,
                 oversample=4.0,
+                normalization=normalization,
             )
             self.psf_data.append(psf_calculator.psf)
             self.psf_instances.append(psf_calculator)

--- a/optiland/psf/huygens_fresnel.py
+++ b/optiland/psf/huygens_fresnel.py
@@ -77,6 +77,7 @@ class ScalarHuygensPSF(BasePSF):
         remove_tilt=False,
         oversample: float = None,
         pixel_pitch: float = None,
+        normalization: float = None,
         **kwargs,
     ):
         super().__init__(
@@ -95,6 +96,7 @@ class ScalarHuygensPSF(BasePSF):
 
         self.image_size = image_size
         self.oversample = oversample
+        self.normalization = normalization
 
         self._summation_strategy = self._create_summation_strategy()
         self.psf = self._compute_psf()
@@ -315,8 +317,9 @@ class ScalarHuygensPSF(BasePSF):
         )
 
         # Normalize the PSF
-        normalization = self._get_normalization()
-        psf = psf / normalization * 100.0
+        if self.normalization is None:
+            self.normalization = self._get_normalization()
+        psf = psf / self.normalization * 100.0
 
         return psf
 
@@ -379,6 +382,7 @@ class HuygensPSF:
         remove_tilt=False,
         oversample: float = None,
         pixel_pitch: float = None,
+        normalization: float = None,
         **kwargs,
     ):
         if optic.polarization_state is not None:
@@ -394,6 +398,7 @@ class HuygensPSF:
                 remove_tilt=remove_tilt,
                 oversample=oversample,
                 pixel_pitch=pixel_pitch,
+                normalization=normalization,
                 **kwargs,
             )
         else:
@@ -407,5 +412,6 @@ class HuygensPSF:
                 remove_tilt=remove_tilt,
                 oversample=oversample,
                 pixel_pitch=pixel_pitch,
+                normalization=normalization,
                 **kwargs,
             )

--- a/optiland/psf/vectorial_huygens.py
+++ b/optiland/psf/vectorial_huygens.py
@@ -100,8 +100,10 @@ class VectorialHuygensPSF(ScalarHuygensPSF):
                 )
                 psf = component_psf if psf is None else psf + component_psf
 
-        normalization = self._get_normalization()
-        return psf / normalization * 100.0
+        # Normalize the PSF
+        if self.normalization is None:
+            self.normalization = self._get_normalization()
+        return psf / self.normalization * 100.0
 
     def _get_normalization(self):
         """Compute the normalization factor for the vectorial Huygens PSF.

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -54,7 +54,18 @@ def get_working_FNO(optic, field, wavelength):
     angles = be.arccos(dot)
 
     numerical_apertures_squared = (n * be.sin(angles)) ** 2
-    avg_NA_squared = be.mean(be.array(numerical_apertures_squared))
+
+    # Exclude geometrically vignetted marginal rays (intensity == 0)
+    marginal_intensities = be.to_numpy(rays.i[1:])
+    valid_indices = [i for i, v in enumerate(marginal_intensities) if v > 0]
+
+    if valid_indices:
+        valid_na_sq = be.stack([numerical_apertures_squared[i] for i in valid_indices])
+        avg_NA_squared = be.mean(valid_na_sq)
+    else:
+        # Degenerate fallback: all marginal rays vignetted (should not occur in
+        # a well-formed system).
+        avg_NA_squared = be.mean(be.array(numerical_apertures_squared))
 
     fno = be.inf if avg_NA_squared <= 0 else 1 / (2 * be.sqrt(avg_NA_squared))
 

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -109,8 +109,12 @@ def resolve_fields(optic, fields):
             raise ValueError("Invalid field string. Must be 'all'.")
     elif isinstance(fields, list):
         return fields
+    elif isinstance(fields, tuple):
+        return [fields]
+    elif isinstance(fields, int):
+        return [optic.fields.get_field_coords()[fields]]
     else:
-        raise TypeError("Fields must be a string ('all') or a list.")
+        raise TypeError("Fields must be a string ('all'), a list, a tuple, or an int.")
 
 
 def resolve_wavelength(optic, wavelength):

--- a/tests/test_huygens_mtf.py
+++ b/tests/test_huygens_mtf.py
@@ -65,22 +65,27 @@ class TestScalarHuygensMTF:
         mtf = ScalarHuygensMTF(real_optic, max_freq="cutoff", image_size=16)
         assert mtf.num_rays == 128
         assert mtf.image_size == 16
-        assert_allclose(mtf.max_freq, 1 / (0.5876e-3 * mtf.FNO), rtol=1e-4)
-        assert len(be.to_numpy(mtf.freq)) == 16 // 2
+        # max_freq is calibrated to the on-axis working F/#, per OpticStudio convention.
+        on_axis_fno = mtf._get_fno()
+        assert_allclose(mtf.max_freq, 1 / (0.5876e-3 * on_axis_fno), rtol=1e-4)
+        # freq is a list of per-field arrays; check the first field.
+        assert len(be.to_numpy(mtf.freq[0])) == 16 // 2
 
     def test_init_non_primary_wavelength(self, real_optic):
         mtf = ScalarHuygensMTF(
             real_optic, max_freq="cutoff", image_size=16, wavelength=0.55
         )
-        assert_allclose(mtf.max_freq, 1 / (0.55e-3 * mtf.FNO), rtol=1e-4)
+        on_axis_fno = mtf._get_fno()
+        assert_allclose(mtf.max_freq, 1 / (0.55e-3 * on_axis_fno), rtol=1e-4)
 
     def test_init_with_numeric_max_freq(self, real_optic):
         mtf = ScalarHuygensMTF(real_optic, max_freq=200.0, image_size=8)
         assert mtf.max_freq == 200.0
 
     def test_get_fno(self, real_optic):
-        mtf = ScalarHuygensMTF(real_optic, image_size=8)
-        assert_allclose(mtf.FNO, 4.992598838013766, rtol=1e-4)
+        mtf = ScalarHuygensMTF(real_optic, fields=[(0, 0)], image_size=8)
+        # FNO is now a per-field list; check the on-axis (first) field.
+        assert_allclose(mtf.FNO[0], 4.992598838013766, rtol=1e-4)
 
     def test_calculate_psf_stores_data(self, real_optic):
         mtf = ScalarHuygensMTF(real_optic, image_size=8)
@@ -112,7 +117,8 @@ class TestScalarHuygensMTF:
     def test_plot_field_mtf_runs(self, real_optic):
         mtf = ScalarHuygensMTF(real_optic, image_size=8)
         mtf.resolved_fields = [(1.0, 2.0)]
-        mtf.freq = be.arange(4)
+        # freq is a list of per-field arrays
+        mtf.freq = [be.arange(4)]
         mtf_field_data = [be.linspace(0, 1, 4), be.linspace(1, 0, 4)]
         fig, ax = plt.subplots()
         mtf._plot_field_mtf(ax, 0, mtf_field_data, color="blue")
@@ -123,12 +129,13 @@ class TestScalarHuygensMTF:
         mtf.resolved_fields = [(0, 0)]
         mtf.resolved_wavelength = 0.55
         mtf._calculate_psf()
-        df = mtf._get_mtf_units()
+        # _get_mtf_units now requires a field index
+        df = mtf._get_mtf_units(0)
         assert df > 0
 
         mtf.psf_instances[0].pixel_pitch = 0
         with pytest.raises(ValueError, match="Pixel pitch"):
-            mtf._get_mtf_units()
+            mtf._get_mtf_units(0)
 
     def test_integration(self, real_optic):
         """Full PSF + MTF calculation (low resolution for speed)."""
@@ -196,7 +203,8 @@ class TestVectorialHuygensMTF:
         mtf = VectorialHuygensMTF(
             polarized_optic, fields=[(0, 0)], image_size=image_size
         )
-        assert len(be.to_numpy(mtf.freq)) == image_size // 2
+        # freq is now a list of per-field arrays; check the first field.
+        assert len(be.to_numpy(mtf.freq[0])) == image_size // 2
 
     def test_unpolarized_mtf_valid(self, unpolarized_optic):
         """An unpolarized source produces a valid MTF."""

--- a/tests/test_huygens_mtf.py
+++ b/tests/test_huygens_mtf.py
@@ -129,13 +129,15 @@ class TestScalarHuygensMTF:
         mtf.resolved_fields = [(0, 0)]
         mtf.resolved_wavelength = 0.55
         mtf._calculate_psf()
-        # _get_mtf_units now requires a field index
-        df = mtf._get_mtf_units(0)
-        assert df > 0
+        # _get_mtf_units was split into tang and sag versions
+        df_tang = mtf._get_mtf_units_tang(0)
+        df_sag = mtf._get_mtf_units_sag(0)
+        assert df_tang > 0
+        assert df_sag > 0
 
         mtf.psf_instances[0].pixel_pitch = 0
         with pytest.raises(ValueError, match="Pixel pitch"):
-            mtf._get_mtf_units(0)
+            mtf._get_mtf_units_tang(0)
 
     def test_integration(self, real_optic):
         """Full PSF + MTF calculation (low resolution for speed)."""

--- a/tests/test_mtf.py
+++ b/tests/test_mtf.py
@@ -119,3 +119,59 @@ class TestFFTMTF:
 
         assert m.num_rays == expected_pupil_sampling
         assert m.grid_size == 2 * num_rays
+
+    def test_freq_step_image_plane_correction(self, set_test_backend, optic):
+        """Frequency step applies image-plane cos(θ) correction for off-axis fields.
+
+        The per-field working F/# is measured in the chief-ray frame.  For an
+        off-axis field the convergent cone projects onto the flat image plane
+        at an oblique angle, reducing the frequency step by FNO_on / FNO_off.
+        Concretely:  df_tang[k] = df_chief[k] * (FNO_on / FNO_off[k])
+
+        There is no tilt in the sagittal plane, so the sagittal step uses the
+        uncorrected per-field df:  df_sag[k] = df_chief[k]
+
+        On-axis the correction is unity; off-axis it is < 1 (smaller df,
+        lower cutoff labelled frequency), removing the ~10 % stretch vs
+        OpticStudio observed when using the raw per-field df.
+        """
+        from optiland.utils import get_working_FNO
+
+        m = FFTMTF(optic)
+        wl = m.resolved_wavelength
+        N = m.num_rays
+        fno_on = float(be.to_numpy(get_working_FNO(optic, (0.0, 0.0), wl)))
+
+        for k, field in enumerate(m.resolved_fields):
+            fno_off = float(be.to_numpy(get_working_FNO(optic, field, wl)))
+            df_chief = 1.0 / ((N - 1) * wl * 1e-3 * fno_off)
+
+            # Tangential: corrected by image-plane projection factor
+            expected_df_tang = df_chief * (fno_on / fno_off)
+            actual_df_tang = float(be.to_numpy(m.freq_tang[k][1])) - float(
+                be.to_numpy(m.freq_tang[k][0])
+            )
+            assert actual_df_tang == pytest.approx(expected_df_tang, rel=1e-5), (
+                f"field {field}: tang df={actual_df_tang:.5f} "
+                f"expected={expected_df_tang:.5f}"
+            )
+
+            # Sagittal: no tilt correction, uses plain per-field df
+            actual_df_sag = float(be.to_numpy(m.freq_sag[k][1])) - float(
+                be.to_numpy(m.freq_sag[k][0])
+            )
+            assert actual_df_sag == pytest.approx(df_chief, rel=1e-5), (
+                f"field {field}: sag df={actual_df_sag:.5f} "
+                f"expected={df_chief:.5f}"
+            )
+
+        # Off-axis tangential df must be strictly less than on-axis
+        # (larger effective FNO due to image-plane correction)
+        if len(m.resolved_fields) > 1:
+            df_tang_off = float(be.to_numpy(m.freq_tang[-1][1])) - float(
+                be.to_numpy(m.freq_tang[-1][0])
+            )
+            df_tang_on = float(be.to_numpy(m.freq_tang[0][1])) - float(
+                be.to_numpy(m.freq_tang[0][0])
+            )
+            assert df_tang_off < df_tang_on

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_resolve_fields_invalid_string(optic):
 
 def test_resolve_fields_invalid_type(optic):
     with pytest.raises(TypeError):
-        resolve_fields(optic, 123)
+        resolve_fields(optic, {"invalid": "type"})
 
 
 def test_resolve_wavelength_primary(optic):

--- a/tests/test_vectorial_fft_mtf.py
+++ b/tests/test_vectorial_fft_mtf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import matplotlib
 import pytest
+import numpy as np
 
 matplotlib.use("Agg")  # ensure non-interactive backend for testing
 
@@ -102,7 +103,7 @@ class TestVectorialFFTMTFInit:
 
     def test_cutoff_max_freq(self, set_test_backend, polarized_optic):
         mtf = VectorialFFTMTF(polarized_optic, num_rays=_NUM_RAYS, grid_size=_GRID_SIZE)
-        expected = 1.0 / (mtf.resolved_wavelength * 1e-3 * mtf.FNO)
+        expected = 1.0 / (mtf.resolved_wavelength * 1e-3 * mtf.FNO[0])
         assert_allclose(mtf.max_freq, expected)
 
     def test_custom_max_freq(self, set_test_backend, polarized_optic):
@@ -114,16 +115,16 @@ class TestVectorialFFTMTFInit:
     def test_fno_attribute_is_set(self, set_test_backend, polarized_optic):
         mtf = VectorialFFTMTF(polarized_optic, num_rays=_NUM_RAYS, grid_size=_GRID_SIZE)
         assert mtf.FNO is not None
-        assert be.to_numpy(mtf.FNO) > 0
+        assert np.all(be.to_numpy(mtf.FNO) > 0)
 
     def test_freq_array_length(self, set_test_backend, polarized_optic):
         mtf = VectorialFFTMTF(polarized_optic, num_rays=_NUM_RAYS, grid_size=_GRID_SIZE)
-        freq_np = be.to_numpy(mtf.freq)
+        freq_np = be.to_numpy(mtf.freq[0])
         assert len(freq_np) == _GRID_SIZE // 2
 
     def test_freq_array_starts_at_zero(self, set_test_backend, polarized_optic):
         mtf = VectorialFFTMTF(polarized_optic, num_rays=_NUM_RAYS, grid_size=_GRID_SIZE)
-        assert_allclose(mtf.freq[0], 0.0)
+        assert_allclose(mtf.freq[0][0], 0.0)
 
     def test_psf_list_length_matches_fields(self, set_test_backend, polarized_optic):
         mtf = VectorialFFTMTF(


### PR DESCRIPTION
## Refactor MTF Calculations for High-Accuracy Off-Axis Results

Closes #525

### Summary

Fixes multiple bugs causing off-axis MTF results to diverge from industry-standard references (ZOS), and adds flexible field point selection. Core fixes target per-field F/# calculations, image-plane frequency scaling, and diffraction limit reference consistency.

---

### Changes

**Off-Axis MTF Accuracy**
- Implemented per-field working F-number (F/#) to account for optical power variation across the field of view.
- Added tangential frequency scaling for chief ray tilt (cosine compression), aligning off-axis MTF results with analytical and simulated references.
- Added logic to exclude geometrically vignetted rays when computing the effective F/# per field.

**Diffraction Limit Reference**
- Standardized the reference curve to use the on-axis working F/#, providing a consistent, field-independent benchmark.
- Fixed a bug where the reference curve was not rescaled when `max_freq` was manually specified.

**MTF Normalization**
- Switched normalization to use the DC component (total PSF power), ensuring MTF(0) = 1 for all field points, consistent with incoherent imaging conventions.

**Flexible Field Selection**
- Updated `resolve_fields` to accept indices (`int`), coordinate tuples `(Hx, Hy)`, or lists of either — resolving all previously failing input patterns.

**Implementation**
- `ScalarFFTMTF` and `VectorialFFTMTF`: updated to use per-field frequency axes.
- `HuygensMTF`: synchronized scaling and normalization logic with FFT MTF.
- `get_working_FNO`: refined to handle vignetted rays.

---

### Usage Examples

**Flexible field selection**
```python
mtf_single = mtf.FFTMTF(lens, fields=(0, 0.5))         # Single coordinate tuple
mtf_index  = mtf.FFTMTF(lens, fields=1)                # Field point by index
mtf_list   = mtf.FFTMTF(lens, fields=[(0, 0), (0, 0.5)])  # List of coordinates
```

**Diffraction limit reference (now scales correctly with `max_freq`)**
```python
mtf_analysis = mtf.FFTMTF(lens, max_freq=200)
mtf_analysis.view(add_reference=True)
```

### Comparison against OpticStudio (Cooke triplet at 0.55 µm)

OpticStudio:
<img width="909" height="573" alt="image" src="https://github.com/user-attachments/assets/b42d127d-df9a-43b0-90e0-169325357e03" />

Equivalent in Optiland:
<img width="1184" height="390" alt="image" src="https://github.com/user-attachments/assets/24324203-81f7-47dc-8b91-7dcb0b166ee8" />

