### PR TITLE
Fix torch backend: replace .copy() with be.copy() in real_image_height

### DIFF
--- a/optiland/fields/field_types/real_image_height.py
+++ b/optiland/fields/field_types/real_image_height.py
@@ -110,8 +110,8 @@ class RealImageHeightField(BaseFieldDefinition):
                 jac_update_x[mask_x] = d_curr_x[mask_x] / d_val_x[mask_x]
 
                 # Store current values before updating val_x
-                prev_val_x = val_x.copy()
-                prev_curr_x = curr_x.copy()
+                prev_val_x = be.copy(val_x)
+                prev_curr_x = be.copy(curr_x)
 
                 # Apply update X
                 val_x -= err_x / jac_update_x
@@ -124,17 +124,17 @@ class RealImageHeightField(BaseFieldDefinition):
                 jac_update_y = be.ones_like(val_y) * jacobian  # Fallback
                 jac_update_y[mask_y] = d_curr_y[mask_y] / d_val_y[mask_y]
 
-                prev_val_y = val_y.copy()  # Save OLD val
-                prev_curr_y = curr_y.copy()
+                prev_val_y = be.copy(val_y)  # Save OLD val
+                prev_curr_y = be.copy(curr_y)
 
                 val_y -= err_y / jac_update_y
             else:
-                prev_val_x = val_x.copy()
-                prev_curr_x = curr_x.copy()
+                prev_val_x = be.copy(val_x)
+                prev_curr_x = be.copy(curr_x)
                 val_x -= err_x / jacobian
 
-                prev_val_y = val_y.copy()
-                prev_curr_y = curr_y.copy()
+                prev_val_y = be.copy(val_y)
+                prev_curr_y = be.copy(curr_y)
                 val_y -= err_y / jacobian
 
         # Generate final ray origins using the converged field parameters

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -104,6 +104,58 @@ def test_paraxial_image_height_cooke_triplet(set_test_backend):
     assert_allclose(u_chief_angle, u_chief_pih)
 
 
+def test_real_image_height_get_ray_origins(set_test_backend):
+    """Test that real image height field type get_ray_origins method works."""
+    # load a Cooke triplet
+    optic = objectives.CookeTriplet()
+
+    # change the field type to real image height
+    optic.fields.set_type("real_image_height")
+
+    # set the field value
+    optic.fields.fields = []
+    optic.fields.add(y=0)
+    optic.fields.add(y=20.0)
+
+    # get the ray origins
+    origins = optic.fields.field_definition.get_ray_origins(
+        optic,
+        Hx=0,
+        Hy=1,
+        Px=0,
+        Py=0,
+        vx=0,
+        vy=0,
+    )
+
+    # basic structural checks
+    assert len(origins) == 3
+    assert_allclose(origins[0], [0.0])
+
+    # Change to finite object
+    optic = objectives.CookeTriplet()
+    optic.object_surface.geometry.cs.z = be.array([-555.0])
+    optic.fields.set_type("real_image_height")
+    optic.fields.fields = []
+    optic.fields.add(y=0)
+    optic.fields.add(y=20.0)
+
+    origins = optic.fields.field_definition.get_ray_origins(
+        optic,
+        Hx=0,
+        Hy=1,
+        Px=0,
+        Py=0,
+        vx=0,
+        vy=0,
+    )
+
+    # stronger checks
+    assert len(origins) == 3
+    assert_allclose(origins[0], [0.0])
+    assert_allclose(origins[2], [-555.0])
+
+
 def test_paraxial_get_ray_origins(set_test_backend):
     """Test that paraxial image height field type get_ray_origins method
     works."""


### PR DESCRIPTION
## Description

Fixes an issue with the torch backend where `.copy()` is called on tensors in `real_image_height`, causing an AttributeError.

Replaced `.copy()` with `be.copy()` to ensure backend compatibility.

## Changes

- Replaced `.copy()` with `be.copy()` in `real_image_height`
- Included minor formatting changes from pre-commit (ruff)

## Issue

Closes #546