### PR TITLE
improve NR implicit differentiation

### DIFF
--- a/optiland/geometries/forbes/geometry.py
+++ b/optiland/geometries/forbes/geometry.py
@@ -167,7 +167,7 @@ class ForbesGeometryBase(NewtonRaphsonGeometry):
             return 1.0, 0.0
 
         c2 = (1.0 / self.radius) ** 2
-        rho = be.sqrt(r2)
+        rho = be.sqrt(r2 + _EPSILON**2)
         num_arg = 1 - self.k * c2 * r2
         den_arg = 1 - (self.k + 1) * c2 * r2
 
@@ -553,7 +553,7 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         rho = be.sqrt(r2 + _EPSILON)
 
         u = rho / self.norm_radius
-        safe_x = be.where(rho < _EPSILON, x + 1e-12, x)
+        safe_x = be.where(r2 < _EPSILON, x + 1e-12, x)
         theta = be.arctan2(y, safe_x)
 
         poly_sum_m0, _, poly_sum_m_gt0, _, _ = compute_z_zprime_q2d(
@@ -626,12 +626,13 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         df_dx_vertex, df_dy_vertex = self._surface_normal_analytical_vertex()
 
         r2 = x_in**2 + y_in**2
-        rho = be.sqrt(r2)
-        is_vertex = rho < _EPSILON
+        is_vertex = r2 < _EPSILON**2
+        rho = be.sqrt(r2 + _EPSILON**2)
 
         rho_safe = be.where(is_vertex, _EPSILON, rho)
         u = rho / self.norm_radius
-        theta = be.arctan2(y_in, x_in)
+        safe_x = be.where(is_vertex, x_in + _EPSILON, x_in)
+        theta = be.arctan2(y_in, safe_x)
 
         vals = compute_z_zprime_q2d(
             self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs, u, theta

--- a/optiland/geometries/newton_raphson.py
+++ b/optiland/geometries/newton_raphson.py
@@ -4,17 +4,29 @@ The Newton Raphson geometry represents a surface utilizing the Newton-Raphson
 method for ray tracing. This is an abstract base class that should be inherited
 by any geometry that uses the Newton-Raphson method for ray tracing.
 
+When the PyTorch backend is active with gradient tracking enabled, the
+``distance`` method uses a DiffOptics-style one-step implicit correction
+to compute correct first-order gradients through the converged intersection
+point without unrolling the Newton-Raphson iterations through the autograd
+graph.
+
 Kramer Harrison, 2024
 """
 
 from __future__ import annotations
 
+import contextlib
 import warnings
 from abc import ABC, abstractmethod
 
 import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries.standard import StandardGeometry
+
+try:
+    import torch
+except (ImportError, ModuleNotFoundError):
+    torch = None
 
 
 # -- utility functions --
@@ -37,6 +49,15 @@ def _is_radius_infinite(radius):
         bool(is_inf_tensor.item())
         if hasattr(is_inf_tensor, "item")
         else bool(is_inf_tensor)
+    )
+
+
+def _sign_preserving_floor(value, eps=1e-14):
+    """Clamp values to a minimum absolute magnitude while preserving sign."""
+    return be.where(
+        be.abs(value) > eps,
+        value,
+        be.where(value >= 0, eps, -eps),
     )
 
 
@@ -116,11 +137,84 @@ class NewtonRaphsonGeometry(StandardGeometry, ABC):
         """
         return self._surface_normal(rays.x, rays.y)
 
+    # ------------------------------------------------------------------
+    # Primal Newton-Raphson solve (no autograd graph)
+    # ------------------------------------------------------------------
+
+    def _solve_distance_primal(self, rays):
+        """Run the Newton-Raphson iteration to find the intersection distance.
+
+        This is a pure numerical solve with **no** autograd graph.  It is
+        used both by the differentiable path (inside torch.no_grad) and by
+        the non-differentiable path.
+
+        The current implementation evaluates ``sag()`` and
+        ``_surface_normal()`` separately at each iteration.
+
+        Potential future optimization: support an optional fused
+        ``eval_sag_and_grad(x, y)`` API to return ``(sag_val, fx, fy)``
+        in a single pass and reduce duplicate surface computations.
+
+        Args:
+            rays: An object with attributes x, y, z, L, M, N.
+
+        Returns:
+            Tensor or ndarray: Converged propagation distance t*.
+        """
+        # Better initial guess via base conic intersection
+        t = super().distance(rays)
+
+        for _ in range(self.max_iter):
+            x_int = rays.x + t * rays.L
+            y_int = rays.y + t * rays.M
+            z_int = rays.z + t * rays.N
+
+            f_t = self.sag(x_int, y_int) - z_int
+
+            nx, ny, nz = self._surface_normal(x_int, y_int)
+            nz_safe = _sign_preserving_floor(nz)
+            fx = -nx / nz_safe
+            fy = -ny / nz_safe
+            df_dt = fx * rays.L + fy * rays.M - rays.N
+
+            if be.max(be.abs(f_t)) < self.tol:
+                break
+
+            safe_df_dt = _sign_preserving_floor(df_dt)
+            t = t - f_t / safe_df_dt
+
+        return t
+
+    # ------------------------------------------------------------------
+    # Public distance method with autograd dispatch
+    # ------------------------------------------------------------------
+
     def distance(self, rays):
         """
         Calculates the distance from the ray origin to the surface intersection
         using a robust Newton-Raphson method. This version uses the base conic
         intersection as a strong initial guess.
+
+        **Differentiable mode (torch backend with grad enabled):**
+
+        The primal Newton-Raphson solve runs inside ``torch.no_grad()`` so
+        that the iterative loop is never recorded in the autograd graph.  A
+        one step implicit correction (in DiffOptics style) is then applied:
+
+            t_implicit = t_detached - F(t_detached) / (dF/dt)_detached
+
+        Since F is near zero at convergence, the forward value is unchanged,
+        but the gradients are correct to first order via the implicit function
+        theorem.
+
+        Note:
+            This implicit correction is intended for correct first-order
+            gradients. Higher order derivatives (double backward and beyond)
+            are not guaranteed to match the exact unrolled Newton system.
+
+        **Non differentiable mode (numpy backend, or torch without grad):**
+
+        Returns the converged t directly.
 
         Args:
             rays (RealRays): The rays used for calculating distance.
@@ -129,43 +223,43 @@ class NewtonRaphsonGeometry(StandardGeometry, ABC):
             be.ndarray: An array of propagation distances 't' from each ray's
             current position to its intersection point with the geometry.
         """
-        # better initial guess for the propagation distance 't' by
-        # intersecting with the base conic surface.
-        t = super().distance(rays)
+        use_torch_diff = (
+            torch is not None
+            and be.get_backend() == "torch"
+            and torch.is_grad_enabled()
+        )
 
-        # Newton-Raphson method to refine the intersection point
-        for _ in range(self.max_iter):
-            # current intersection point P(t) = P0 + t*D
-            x_int = rays.x + t * rays.L
-            y_int = rays.y + t * rays.M
-            z_int = rays.z + t * rays.N
+        # --- Primal solve (no gradient tracking) -------------------------
+        ctx = torch.no_grad() if use_torch_diff else contextlib.nullcontext()
 
-            # error function f(t) = sag(x(t), y(t)) - z(t)
-            # find the root t such that f(t) = 0
-            f_t = self.sag(x_int, y_int) - z_int
+        with ctx:
+            t = self._solve_distance_primal(rays)
 
-            # convergence check
-            if be.max(be.abs(f_t)) < self.tol:
-                break
+        if not use_torch_diff:
+            return t
 
-            # derivative of the error func at the
-            # curr intersection point
-            # f'(t) = (d_sag/d_x)*Lx + (d_sag/d_y)*My - Nz
-            nx, ny, nz = self._surface_normal(x_int, y_int)
+        # --- DiffOptics-style one-step implicit correction ----------------
+        t_detached = t.detach()
 
-            # normalized normal components:
-            # fx = -nx / nz and fy = -ny / nz.
-            nz_safe = be.where(be.abs(nz) > 1e-14, nz, 1e-14)
-            fx = -nx / nz_safe
-            fy = -ny / nz_safe
+        x_int = rays.x + t_detached * rays.L
+        y_int = rays.y + t_detached * rays.M
+        z_int = rays.z + t_detached * rays.N
 
-            df_dt = fx * rays.L + fy * rays.M - rays.N
+        F = self.sag(x_int, y_int) - z_int
 
-            # update step: t_new = t - f(t) / f'(t).
-            safe_df_dt = be.where(be.abs(df_dt) > 1e-14, df_dt, 1e-14)
-            t = t - f_t / safe_df_dt
+        nx, ny, nz = self._surface_normal(x_int, y_int)
+        nz_safe = _sign_preserving_floor(nz)
+        fx = -nx / nz_safe
+        fy = -ny / nz_safe
+        dF_dt = (fx * rays.L + fy * rays.M - rays.N).detach()
 
-        return t
+        safe_dF_dt = _sign_preserving_floor(dF_dt)
+
+        # Implicit correction: t_implicit has value approx t_detached (since
+        # F approx 0) but carries correct gradients: dt*/dtheta = -F_theta / F_t.
+        t_implicit = t_detached - F / safe_dF_dt
+
+        return t_implicit
 
     def _intersection_plane(self, rays):
         """Calculates the intersection points of the rays with a plane (z=0).

--- a/tests/nr_implicit_test_utils.py
+++ b/tests/nr_implicit_test_utils.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.geometries.even_asphere import EvenAsphere
+from optiland.rays import RealRays
+
+
+def _precision_name(precision_bits: int) -> str:
+    return "float64" if precision_bits == 64 else "float32"
+
+
+@contextmanager
+def backend_state(backend: str, precision: str = "float64"):
+    """Temporarily switch backend/precision and restore previous state."""
+    old_backend = be.get_backend()
+    old_precision = be.get_precision()
+
+    be.set_backend(backend)
+    if backend == "torch":
+        be.set_device("cpu")
+    be.set_precision(precision)
+
+    try:
+        yield
+    finally:
+        be.set_backend(old_backend)
+        if old_backend == "torch":
+            be.set_device("cpu")
+        be.set_precision(_precision_name(old_precision))
+
+
+def build_reference_even_asphere() -> EvenAsphere:
+    """Reference NR geometry used by implicit-diff tests."""
+    return EvenAsphere(
+        CoordinateSystem(),
+        radius=20.0,
+        conic=-0.35,
+        tol=1e-12,
+        max_iter=80,
+        coefficients=[-2.248851e-4, -4.690412e-6],
+    )
+
+
+def build_reference_rays(
+    *,
+    off_axis: bool = False,
+    x_override=None,
+    y_override=None,
+    L_override=None,
+    M_override=None,
+):
+    """Build a deterministic ray for direct distance() testing."""
+    x = 0.0 if not off_axis else 0.35
+    y = 0.0 if not off_axis else -0.27
+    L = 0.02 if not off_axis else 0.06
+    M = -0.015 if not off_axis else -0.035
+
+    if x_override is not None:
+        x = x_override
+    if y_override is not None:
+        y = y_override
+    if L_override is not None:
+        L = L_override
+    if M_override is not None:
+        M = M_override
+
+    N = be.sqrt(1.0 - L * L - M * M)
+
+    return RealRays(
+        x=x,
+        y=y,
+        z=-5.0,
+        L=L,
+        M=M,
+        N=N,
+        intensity=1.0,
+        wavelength=0.587,
+    )
+
+
+def central_difference_scalar(fun, x0: float, eps: float) -> float:
+    """Central finite-difference derivative for scalar-valued functions."""
+    return (fun(x0 + eps) - fun(x0 - eps)) / (2.0 * eps)
+
+
+def finite_diff_reference(fun, x0: float, epsilons: tuple[float, ...]):
+    """Compute central-difference derivatives at multiple epsilons."""
+    values = [central_difference_scalar(fun, x0, eps) for eps in epsilons]
+    return values[-1], values
+
+
+def assert_fd_is_stable(
+    fd_values: list[float],
+    *,
+    abs_tol: float,
+    rel_tol: float,
+):
+    """Check that finite-difference estimates are not overly epsilon-sensitive."""
+    spread = max(fd_values) - min(fd_values)
+    scale = max(max(abs(v) for v in fd_values), 1e-12)
+    assert spread <= max(abs_tol, rel_tol * scale), (
+        f"FD estimates are unstable across epsilons: {fd_values}"
+    )
+
+
+def count_autograd_nodes(tensor) -> int:
+    """Count autograd Function nodes reachable from tensor.grad_fn.
+
+    This helper tracks Function objects directly. Counting by ``id`` can
+    undercount in Python due to object-id reuse during traversal.
+    """
+    grad_fn = getattr(tensor, "grad_fn", None)
+    if grad_fn is None:
+        return 0
+
+    seen = set()
+    stack = [grad_fn]
+
+    while stack:
+        fn = stack.pop()
+        if fn is None or fn in seen:
+            continue
+        seen.add(fn)
+
+        for next_fn, _ in fn.next_functions:
+            if next_fn is not None:
+                stack.append(next_fn)
+
+    return len(seen)

--- a/tests/test_implicit_differentiation.py
+++ b/tests/test_implicit_differentiation.py
@@ -1,0 +1,179 @@
+"""Tests for implicit differentiation of Newton-Raphson ray-surface intersection.
+
+Validates that:
+1. Gradients through aspheric surfaces (EvenAsphere / NR geometry) are non-None
+   and finite when using the torch backend with implicit differentiation.
+2. Autograd gradients match finite-difference gradients to within tolerance.
+3. The numpy backend is not affected (no regression).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.optimization import OptimizationProblem
+from optiland.samples.simple import AsphericSinglet
+
+# Skip the entire module if torch is not installed
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_torch_backend():
+    """Ensure the torch backend is active for this test module."""
+    original = be.get_backend()
+    be.set_backend("torch")
+    be.set_precision("float64")
+    yield
+    be.set_precision("float32")
+    be.set_backend(original)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _make_problem(variable_type="radius", surface_number=1, **var_kwargs):
+    """Build a minimal optimisation problem around the AsphericSinglet."""
+    lens = AsphericSinglet()
+    problem = OptimizationProblem()
+    problem.add_variable(
+        lens,
+        variable_type,
+        surface_number=surface_number,
+        **var_kwargs,
+    )
+    problem.add_operand(
+        operand_type="rms_spot_size",
+        target=0.0,
+        weight=1.0,
+        input_data={
+            "optic": lens,
+            "surface_number": lens.surface_group.num_surfaces - 1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "num_rays": 20,
+            "wavelength": 0.587,
+        },
+    )
+    return problem, lens
+
+
+def _scalar_loss(problem):
+    """Compute the scalar merit function (sum of squared residuals)."""
+    problem.update_optics()
+    return problem.sum_squared()
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+class TestImplicitDiffGradientExists:
+    """Gradients through NR intersection should be non-None and finite."""
+
+    @pytest.mark.parametrize(
+        "var_type,extra",
+        [
+            ("radius", {}),
+            ("conic", {}),
+            ("asphere_coeff", {"coeff_number": 0}),
+        ],
+    )
+    def test_gradient_is_finite(self, var_type, extra):
+        problem, _ = _make_problem(variable_type=var_type, **extra)
+
+        with be.grad_mode.temporary_enable():
+            val = problem.variables[0].variable.get_value()
+            param = torch.nn.Parameter(be.array(val))
+            problem.variables[0].variable.update_value(param)
+            problem.update_optics()
+
+            loss = problem.sum_squared()
+            assert loss.requires_grad, "Loss should require grad"
+
+            loss.backward()
+            assert param.grad is not None, f"Gradient is None for {var_type}"
+            assert torch.isfinite(param.grad).all(), (
+                f"Non-finite gradient for {var_type}: {param.grad}"
+            )
+
+
+class TestImplicitDiffMatchesFiniteDifference:
+    """Autograd gradients must agree with finite-difference approximations."""
+
+    @pytest.mark.parametrize(
+        "var_type,extra",
+        [
+            ("radius", {}),
+            ("conic", {}),
+            ("asphere_coeff", {"coeff_number": 0}),
+        ],
+    )
+    def test_gradient_matches_finite_diff(self, var_type, extra):
+        eps = 1e-6
+        problem, lens = _make_problem(variable_type=var_type, **extra)
+
+        # --- Autograd gradient ---
+        with be.grad_mode.temporary_enable():
+            param = torch.nn.Parameter(
+                be.array(problem.variables[0].variable.get_value())
+            )
+            problem.variables[0].variable.update_value(param)
+            problem.update_optics()
+
+            loss = problem.sum_squared()
+            loss.backward()
+            ad_grad = param.grad.item()
+
+        # --- Finite-difference gradient ---
+        val0 = float(param.data.item())
+
+        # f(x + eps)
+        problem.variables[0].variable.update_value(val0 + eps)
+        problem.update_optics()
+        with torch.no_grad():
+            loss_plus = problem.sum_squared().item()
+
+        # f(x - eps)
+        problem.variables[0].variable.update_value(val0 - eps)
+        problem.update_optics()
+        with torch.no_grad():
+            loss_minus = problem.sum_squared().item()
+
+        fd_grad = (loss_plus - loss_minus) / (2.0 * eps)
+
+        # Restore original value
+        problem.variables[0].variable.update_value(val0)
+        problem.update_optics()
+
+        assert ad_grad != 0.0, "Autograd gradient should be non-zero"
+        rel_err = abs(ad_grad - fd_grad) / (abs(fd_grad) + 1e-12)
+        assert rel_err < 0.05, (
+            f"Gradient mismatch for {var_type}: AD={ad_grad:.8f}, "
+            f"FD={fd_grad:.8f}, rel_err={rel_err:.4f}"
+        )
+
+
+class TestNumpyPathUnchanged:
+    """The numpy backend should still work identically (no regression)."""
+
+    def test_numpy_distance_returns_same_result(self):
+        """Verify aspheric singlet can be traced with numpy backend."""
+        original = be.get_backend()
+        try:
+            be.set_backend("numpy")
+            lens = AsphericSinglet()
+            lens.trace(0, 0, 0.587, 20, "hexapolar")
+            # Just verify that tracing completes without error and
+            # produces finite intercept values on the image surface
+            img = lens.surface_group.num_surfaces - 1
+            x = lens.surface_group.x[img, :]
+            import numpy as np
+
+            assert np.all(np.isfinite(x)), "Non-finite values in numpy trace"
+        finally:
+            be.set_backend(original)

--- a/tests/test_nr_implicit_diff_distance.py
+++ b/tests/test_nr_implicit_diff_distance.py
@@ -1,0 +1,218 @@
+"""Direct tests of Newton-Raphson implicit-diff distance() behavior.
+
+These tests target the primitive that was changed:
+``NewtonRaphsonGeometry.distance(rays)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+
+from .nr_implicit_test_utils import (
+    assert_fd_is_stable,
+    backend_state,
+    build_reference_even_asphere,
+    build_reference_rays,
+    finite_diff_reference,
+)
+from .utils import assert_allclose
+
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(autouse=True)
+def _torch_backend_float64():
+    with backend_state("torch", precision="float64"):
+        yield
+
+
+def _distance_for_surface_param(param_name: str, param_value, *, off_axis: bool) -> torch.Tensor:
+    geometry = build_reference_even_asphere()
+
+    if param_name == "radius":
+        geometry.radius = param_value
+    elif param_name == "conic":
+        geometry.k = param_value
+    elif param_name == "asphere_coeff":
+        coeffs = list(geometry.coefficients)
+        coeffs[0] = param_value
+        geometry.coefficients = coeffs
+    else:
+        raise ValueError(f"Unknown parameter name: {param_name}")
+
+    rays = build_reference_rays(off_axis=off_axis)
+    return geometry.distance(rays)[0]
+
+
+def _distance_for_ray_x(x0, *, off_axis: bool) -> torch.Tensor:
+    geometry = build_reference_even_asphere()
+    rays = build_reference_rays(off_axis=off_axis, x_override=x0)
+    return geometry.distance(rays)[0]
+
+
+class TestDistanceSurfaceParameterGradients:
+    """AD-vs-FD checks for distance() w.r.t. surface parameters."""
+
+    @pytest.mark.parametrize(
+        "param_name,base_value,grad_abs_tol,grad_rel_tol,fd_abs_tol,fd_rel_tol",
+        [
+            ("radius", 20.0, 1e-9, 5e-3, 1e-9, 1e-2),
+            # Conic derivative is very small in this configuration, so use a
+            # meaningful absolute tolerance in addition to relative tolerance.
+            ("conic", -0.35, 8e-10, 2e-1, 5e-10, 8e-2),
+            ("asphere_coeff", -2.248851e-4, 1e-8, 5e-3, 1e-8, 1e-2),
+        ],
+    )
+    def test_distance_grad_matches_fd_on_axis(
+        self,
+        param_name,
+        base_value,
+        grad_abs_tol,
+        grad_rel_tol,
+        fd_abs_tol,
+        fd_rel_tol,
+    ):
+        param = torch.nn.Parameter(torch.tensor(base_value, dtype=torch.float64))
+        t = _distance_for_surface_param(param_name, param, off_axis=False)
+        assert t.requires_grad
+        t.backward()
+        ad_grad = float(param.grad.detach().item())
+
+        def scalar_distance(value: float) -> float:
+            with torch.no_grad():
+                return float(
+                    _distance_for_surface_param(param_name, value, off_axis=False)
+                    .detach()
+                    .item()
+                )
+
+        # Two epsilons reduce the risk of cancellation or solver-noise artifacts.
+        fd_ref, fd_values = finite_diff_reference(
+            scalar_distance,
+            base_value,
+            epsilons=(2e-6, 1e-6),
+        )
+        assert_fd_is_stable(fd_values, abs_tol=fd_abs_tol, rel_tol=fd_rel_tol)
+
+        assert abs(ad_grad - fd_ref) <= max(grad_abs_tol, grad_rel_tol * abs(fd_ref)), (
+            f"AD/FD mismatch for {param_name}: AD={ad_grad:.12e}, "
+            f"FD={fd_ref:.12e}, FD samples={fd_values}"
+        )
+
+    def test_distance_grad_matches_fd_off_axis_for_radius(self):
+        base_value = 20.0
+        param = torch.nn.Parameter(torch.tensor(base_value, dtype=torch.float64))
+        t = _distance_for_surface_param("radius", param, off_axis=True)
+        t.backward()
+        ad_grad = float(param.grad.detach().item())
+
+        def scalar_distance(value: float) -> float:
+            with torch.no_grad():
+                return float(
+                    _distance_for_surface_param("radius", value, off_axis=True)
+                    .detach()
+                    .item()
+                )
+
+        fd_ref, fd_values = finite_diff_reference(
+            scalar_distance,
+            base_value,
+            epsilons=(2e-6, 1e-6),
+        )
+        assert_fd_is_stable(fd_values, abs_tol=1e-8, rel_tol=1e-2)
+
+        assert abs(ad_grad - fd_ref) <= max(1e-8, 1e-2 * abs(fd_ref)), (
+            f"Off-axis AD/FD mismatch for radius: AD={ad_grad:.12e}, "
+            f"FD={fd_ref:.12e}, FD samples={fd_values}"
+        )
+
+
+class TestDistanceRayStateGradients:
+    """AD-vs-FD checks for distance() w.r.t. ray-state variables."""
+
+    def test_distance_grad_matches_fd_wrt_initial_x(self):
+        x0 = 0.31
+        x_param = torch.nn.Parameter(torch.tensor(x0, dtype=torch.float64))
+        t = _distance_for_ray_x(x_param, off_axis=True)
+        t.backward()
+        ad_grad = float(x_param.grad.detach().item())
+
+        def scalar_distance(value: float) -> float:
+            with torch.no_grad():
+                return float(_distance_for_ray_x(value, off_axis=True).detach().item())
+
+        fd_ref, fd_values = finite_diff_reference(
+            scalar_distance,
+            x0,
+            epsilons=(2e-6, 1e-6),
+        )
+        assert_fd_is_stable(fd_values, abs_tol=1e-8, rel_tol=1e-2)
+
+        assert abs(ad_grad - fd_ref) <= max(1e-8, 1e-2 * abs(fd_ref)), (
+            f"AD/FD mismatch for ray x0: AD={ad_grad:.12e}, "
+            f"FD={fd_ref:.12e}, FD samples={fd_values}"
+        )
+
+
+class TestForwardConsistency:
+    """Differentiable distance() should preserve the primal converged root."""
+
+    @pytest.mark.parametrize("off_axis", [False, True])
+    def test_diff_forward_matches_primal_root(self, off_axis):
+        radius_param = torch.nn.Parameter(torch.tensor(20.0, dtype=torch.float64))
+        geometry = build_reference_even_asphere()
+        geometry.radius = radius_param
+        rays = build_reference_rays(off_axis=off_axis)
+
+        with torch.no_grad():
+            t_primal = geometry._solve_distance_primal(rays)
+
+        t_diff = geometry.distance(rays)
+        assert t_diff.requires_grad
+        assert_allclose(t_diff.detach(), t_primal, rtol=0.0, atol=1e-12)
+
+
+class TestHigherOrderContract:
+    """The implicit correction contract is first-order gradient accuracy only."""
+
+    def test_second_derivative_not_contractually_matched(self):
+        # This oblique configuration accentuates the difference between
+        # double-backward through the implicit-correction graph and a finite-
+        # difference estimate of d/dR(dt/dR). We keep this as an explicit
+        # first-order-only contract test.
+
+        def distance_from_radius(radius_value):
+            geometry = build_reference_even_asphere()
+            geometry.radius = radius_value
+            rays = build_reference_rays(
+                off_axis=True,
+                x_override=1.0,
+                y_override=-0.8,
+                L_override=0.28,
+                M_override=-0.18,
+            )
+            return geometry.distance(rays)[0]
+
+        radius_param = torch.nn.Parameter(torch.tensor(20.0, dtype=torch.float64))
+        t = distance_from_radius(radius_param)
+        d1 = torch.autograd.grad(t, radius_param, create_graph=True)[0]
+        d2_autograd = float(torch.autograd.grad(d1, radius_param)[0].detach().item())
+
+        def first_derivative_at(radius_value: float) -> float:
+            p = torch.nn.Parameter(torch.tensor(radius_value, dtype=torch.float64))
+            t_local = distance_from_radius(p)
+            d1_local = torch.autograd.grad(t_local, p)[0]
+            return float(d1_local.detach().item())
+
+        d2_fd = (first_derivative_at(20.0 + 5e-5) - first_derivative_at(20.0 - 5e-5)) / (
+            2.0 * 5e-5
+        )
+
+        rel_err = abs(d2_autograd - d2_fd) / (abs(d2_fd) + 1e-15)
+        assert rel_err > 2e-2, (
+            "Second-order behavior appears too close to finite differences for a "
+            "first-order-only contract. If higher-order support was intentionally "
+            "added, update this test and the Newton-Raphson distance contract."
+        )

--- a/tests/test_nr_implicit_diff_end_to_end.py
+++ b/tests/test_nr_implicit_diff_end_to_end.py
@@ -1,0 +1,95 @@
+"""End-to-end implicit-diff tests through OptimizationProblem objectives."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from optiland.optimization import OptimizationProblem
+from optiland.samples.simple import AsphericSinglet
+
+from .nr_implicit_test_utils import (
+    assert_fd_is_stable,
+    backend_state,
+    finite_diff_reference,
+)
+
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(autouse=True)
+def _torch_backend_float64():
+    with backend_state("torch", precision="float64"):
+        yield
+
+
+def _make_problem(*, Hx: float, Hy: float):
+    lens = AsphericSinglet()
+    # Add a nonzero configured field so normalized off-axis coordinates map to
+    # a physically off-axis trace rather than the degenerate single-field case.
+    lens.fields.add(y=5.0)
+
+    problem = OptimizationProblem()
+    problem.add_variable(lens, "radius", surface_number=1)
+    problem.add_operand(
+        operand_type="rms_spot_size",
+        target=0.0,
+        weight=1.0,
+        input_data={
+            "optic": lens,
+            "surface_number": lens.surfaces.num_surfaces - 1,
+            "Hx": Hx,
+            "Hy": Hy,
+            "num_rays": 24,
+            "wavelength": 0.587,
+        },
+    )
+    return problem, lens
+
+
+@pytest.mark.parametrize("Hx,Hy", [(0.0, 0.0), (0.2, 0.3)])
+def test_merit_gradient_matches_fd_on_and_off_axis(Hx, Hy):
+    problem, lens = _make_problem(Hx=Hx, Hy=Hy)
+
+    base_raw = problem.variables[0].variable.get_value()
+    if torch.is_tensor(base_raw):
+        base_value = float(base_raw.detach().item())
+    else:
+        base_value = float(base_raw)
+    param = torch.nn.Parameter(torch.tensor(base_value, dtype=torch.float64))
+    problem.variables[0].variable.update_value(param)
+
+    problem.update_optics()
+    loss = problem.sum_squared()
+    loss.backward()
+    ad_grad = float(param.grad.detach().item())
+
+    assert np.isfinite(ad_grad), f"AD gradient is non-finite for field ({Hx}, {Hy})"
+
+    def scalar_loss(radius_value: float) -> float:
+        fd_problem, _ = _make_problem(Hx=Hx, Hy=Hy)
+        fd_problem.variables[0].variable.update_value(radius_value)
+        fd_problem.update_optics()
+        with torch.no_grad():
+            return float(fd_problem.sum_squared().item())
+
+    # Two-epsilon FD check to reduce risk of accidental cancellation.
+    fd_ref, fd_values = finite_diff_reference(
+        scalar_loss,
+        base_value,
+        epsilons=(2e-6, 1e-6),
+    )
+    assert_fd_is_stable(fd_values, abs_tol=1e-8, rel_tol=2e-2)
+
+    assert abs(ad_grad - fd_ref) <= max(1e-7, 2e-2 * abs(fd_ref)), (
+        f"Merit AD/FD mismatch at field ({Hx}, {Hy}): "
+        f"AD={ad_grad:.12e}, FD={fd_ref:.12e}, FD samples={fd_values}"
+    )
+
+    if (Hx, Hy) != (0.0, 0.0):
+        # Explicitly verify this is genuinely off-axis ray geometry.
+        lens.trace(Hx, Hy, 0.587, 24, "hexapolar")
+        img = lens.surfaces.num_surfaces - 1
+        x = np.asarray(lens.surfaces.x[img, :].detach().cpu())
+        y = np.asarray(lens.surfaces.y[img, :].detach().cpu())
+        assert abs(x.mean()) > 1e-3 or abs(y.mean()) > 1e-3

--- a/tests/test_nr_implicit_diff_graph_complexity.py
+++ b/tests/test_nr_implicit_diff_graph_complexity.py
@@ -1,0 +1,129 @@
+"""Graph-complexity regressions for Newton-Raphson implicit differentiation.
+
+Scientific purpose:
+- verify first-order gradients remain available,
+- while autograd graph size stays O(1) in ``max_iter`` for the implicit path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from optiland.geometries.newton_raphson import _sign_preserving_floor
+from optiland.geometries.standard import StandardGeometry
+
+from .nr_implicit_test_utils import (
+    backend_state,
+    build_reference_even_asphere,
+    build_reference_rays,
+    count_autograd_nodes,
+)
+
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture(autouse=True)
+def _torch_backend_float64_cpu():
+    with backend_state("torch", precision="float64"):
+        yield
+
+
+def _distance_unrolled_with_graph(geometry, rays):
+    """Differentiable Newton loop baseline used only in this test module."""
+    t = StandardGeometry.distance(geometry, rays)
+    for _ in range(geometry.max_iter):
+        x_int = rays.x + t * rays.L
+        y_int = rays.y + t * rays.M
+        z_int = rays.z + t * rays.N
+
+        f_t = geometry.sag(x_int, y_int) - z_int
+
+        nx, ny, nz = geometry._surface_normal(x_int, y_int)
+        nz_safe = _sign_preserving_floor(nz)
+        fx = -nx / nz_safe
+        fy = -ny / nz_safe
+        df_dt = fx * rays.L + fy * rays.M - rays.N
+
+        t = t - f_t / _sign_preserving_floor(df_dt)
+
+    return t
+
+
+def _evaluate_case(max_iter: int, mode: str):
+    geometry = build_reference_even_asphere()
+    geometry.max_iter = max_iter
+
+    # Force a fixed iteration budget so graph-scaling is actually measurable.
+    # If tol allows early exit, max_iter changes may not affect loop work.
+    geometry.tol = -1.0
+
+    radius_param = torch.nn.Parameter(torch.tensor(20.0, dtype=torch.float64))
+    geometry.radius = radius_param
+    rays = build_reference_rays(off_axis=True)
+
+    if mode == "implicit":
+        scalar = geometry.distance(rays).sum()
+    elif mode == "unrolled":
+        scalar = _distance_unrolled_with_graph(geometry, rays).sum()
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+    node_count = count_autograd_nodes(scalar)
+    scalar.backward()
+
+    grad = radius_param.grad
+    return {
+        "scalar": scalar,
+        "node_count": node_count,
+        "grad": grad,
+    }
+
+
+def test_implicit_graph_size_is_flat_vs_max_iter():
+    iter_values = [5, 10, 20, 40]
+
+    node_counts = []
+    for max_iter in iter_values:
+        result = _evaluate_case(max_iter=max_iter, mode="implicit")
+
+        assert torch.isfinite(result["scalar"]), f"Non-finite scalar at max_iter={max_iter}"
+        assert result["grad"] is not None, f"Missing gradient at max_iter={max_iter}"
+        assert torch.isfinite(result["grad"]), f"Non-finite gradient at max_iter={max_iter}"
+
+        node_counts.append(result["node_count"])
+
+    spread = max(node_counts) - min(node_counts)
+    assert spread <= 1, (
+        "Implicit-path graph size should remain effectively constant vs max_iter; "
+        f"counts={node_counts}, spread={spread}"
+    )
+
+
+def test_unrolled_baseline_graph_size_grows_vs_max_iter():
+    iter_values = [5, 10, 20, 40]
+
+    node_counts = [
+        _evaluate_case(max_iter=max_iter, mode="unrolled")["node_count"]
+        for max_iter in iter_values
+    ]
+
+    assert node_counts[-1] > node_counts[0], (
+        "Unrolled baseline should show graph growth with max_iter; "
+        f"counts={node_counts}"
+    )
+    assert node_counts[-1] >= 2 * node_counts[0], (
+        "Expected clear graph-size growth for unrolled Newton baseline; "
+        f"counts={node_counts}"
+    )
+
+
+def test_implicit_graph_is_much_smaller_than_unrolled_at_high_iter():
+    max_iter = 40
+
+    implicit_nodes = _evaluate_case(max_iter=max_iter, mode="implicit")["node_count"]
+    unrolled_nodes = _evaluate_case(max_iter=max_iter, mode="unrolled")["node_count"]
+
+    assert implicit_nodes < unrolled_nodes, (
+        "Implicit graph should be smaller than unrolled baseline; "
+        f"implicit={implicit_nodes}, unrolled={unrolled_nodes}"
+    )

--- a/tests/test_nr_numpy_regression.py
+++ b/tests/test_nr_numpy_regression.py
@@ -1,0 +1,116 @@
+"""Regression tests for the NumPy path of Newton-Raphson distance/tracing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.rays import RealRays
+from optiland.samples.simple import AsphericSinglet
+
+from .nr_implicit_test_utils import backend_state, build_reference_even_asphere
+from .utils import assert_allclose
+
+
+def _build_distance_regression_bundle() -> RealRays:
+    x = np.array([0.0, 0.35, -0.22])
+    y = np.array([0.0, -0.27, 0.18])
+    z = np.array([-5.0, -5.0, -4.5])
+    L = np.array([0.02, 0.06, -0.04])
+    M = np.array([-0.015, -0.035, 0.025])
+    N = np.sqrt(1.0 - L**2 - M**2)
+    return RealRays(x=x, y=y, z=z, L=L, M=M, N=N, intensity=1.0, wavelength=0.587)
+
+
+def test_numpy_distance_matches_reference_values():
+    with backend_state("numpy", precision="float64"):
+        geometry = build_reference_even_asphere()
+        rays = _build_distance_regression_bundle()
+
+        t = geometry.distance(rays)
+        x_int = rays.x + t * rays.L
+        y_int = rays.y + t * rays.M
+        z_int = rays.z + t * rays.N
+
+        assert_allclose(
+            t,
+            np.array([5.0019507685589124, 5.0275941535358291, 4.5111182791860802]),
+            rtol=0.0,
+            atol=1e-11,
+        )
+        assert_allclose(
+            x_int,
+            np.array([0.10003901537117825, 0.65165564921214969, -0.40044473116744322]),
+            rtol=0.0,
+            atol=1e-11,
+        )
+        assert_allclose(
+            y_int,
+            np.array([-0.075029261528383684, -0.44596579537375403, 0.29277795697965203]),
+            rtol=0.0,
+            atol=1e-11,
+        )
+        assert_allclose(
+            z_int,
+            np.array([0.00038741463150682165, 0.015450416545310652, 0.0060968653836308562]),
+            rtol=0.0,
+            atol=1e-11,
+        )
+
+
+def test_numpy_off_axis_trace_matches_reference_metrics():
+    with backend_state("numpy", precision="float64"):
+        lens = AsphericSinglet()
+        lens.fields.add(y=5.0)
+        lens.trace(0.2, 0.3, 0.587, 24, "hexapolar")
+
+        img = lens.surfaces.num_surfaces - 1
+        x = be.to_numpy(lens.surfaces.x[img, :])
+        y = be.to_numpy(lens.surfaces.y[img, :])
+        rms = np.sqrt(((x - x.mean()) ** 2 + (y - y.mean()) ** 2).mean())
+
+        assert_allclose(x.mean(), 0.4533279377925549, rtol=0.0, atol=1e-12)
+        assert_allclose(y.mean(), 0.6800782393520015, rtol=0.0, atol=1e-12)
+        assert_allclose(rms, 0.0283767065911844, rtol=0.0, atol=1e-12)
+
+
+def test_numpy_distance_matches_torch_no_grad():
+    torch = pytest.importorskip("torch")
+
+    with backend_state("numpy", precision="float64"):
+        geometry = build_reference_even_asphere()
+        rays = _build_distance_regression_bundle()
+        t_numpy = be.to_numpy(geometry.distance(rays))
+
+    with backend_state("torch", precision="float64"):
+        geometry = build_reference_even_asphere()
+        rays = _build_distance_regression_bundle()
+        with torch.no_grad():
+            t_torch = be.to_numpy(geometry.distance(rays))
+
+    assert_allclose(t_numpy, t_torch, rtol=0.0, atol=1e-12)
+
+
+def test_numpy_off_axis_trace_matches_torch_no_grad():
+    torch = pytest.importorskip("torch")
+
+    with backend_state("numpy", precision="float64"):
+        lens_np = AsphericSinglet()
+        lens_np.fields.add(y=5.0)
+        lens_np.trace(0.2, 0.3, 0.587, 24, "hexapolar")
+        img_np = lens_np.surfaces.num_surfaces - 1
+        x_np = be.to_numpy(lens_np.surfaces.x[img_np, :])
+        y_np = be.to_numpy(lens_np.surfaces.y[img_np, :])
+
+    with backend_state("torch", precision="float64"):
+        lens_t = AsphericSinglet()
+        lens_t.fields.add(y=5.0)
+        with torch.no_grad():
+            lens_t.trace(0.2, 0.3, 0.587, 24, "hexapolar")
+        img_t = lens_t.surfaces.num_surfaces - 1
+        x_t = be.to_numpy(lens_t.surfaces.x[img_t, :])
+        y_t = be.to_numpy(lens_t.surfaces.y[img_t, :])
+
+    assert_allclose(x_np, x_t, rtol=0.0, atol=3e-7)
+    assert_allclose(y_np, y_t, rtol=0.0, atol=3e-7)


### PR DESCRIPTION
### Newton-Raphson implicit-diff hardening: direct gradient tests, graph-size regressions, and benchmark coverage

**Summary**
This PR strengthens the Newton-Raphson implicit-differentiation path by improving numerical safeguards, expanding direct correctness coverage, and adding explicit regressions for the key design claim that autograd graph size should remain O(1) in max_iter for the implicit path.

**Why**
The implicit NR path is intended to preserve first order gradients without storing per-iteration autograd history. This behavior is central to memory scalability and needed direct regression coverage at the geometry.distance primitive level.

**What changed**
1. Reworked torch differentiable distance path around no-grad primal solve plus implicit correction
2. Added sign-preserving denominator floor logic for stability near small denominators
3. Documented first-order-only derivative contract for the implicit formulation

4. Added direct distance-level tests:
- AD vs FD for radius, conic, and one asphere coefficient
- AD vs FD for a ray-state variable
- On-axis and off-axis cases
- Forward-value consistency check between differentiable and primal results

5. Added stronger numpy regressions:
- Deterministic reference outputs
- Numpy vs torch no-grad consistency checks

6. Added graph-complexity regressions over max_iter:
- Implicit path graph nodes remain effectively constant
- Unrolled baseline graph nodes grow with max_iter

**Key regression result**
- Implicit path node count stays flat as max_iter increases
- Unrolled baseline node count grows strongly with max_iter

To-Do:
- [x] ray-surface intersection improvement.
- [ ] improvement on iterative NR for real image height field type (more iinfo in #547)



Closes #335 