### PR TITLE
perf(materials): optimize large-array wavelength cache key generation

### DIFF
--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -46,6 +46,7 @@ class BaseMaterial(ABC):
     """
 
     _registry = {}
+    _MAX_VALUE_KEY_ARRAY_SIZE = 64
 
     def __init__(self, propagation_model: BasePropagationModel | None = None):
         """Initializes the material and its caches.
@@ -70,10 +71,62 @@ class BaseMaterial(ABC):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, type(self)) and value.to_dict() == self.to_dict()
 
+    @classmethod
+    def _array_size(cls, value) -> int | None:
+        """Return the total element count for array-like values if available."""
+        shape = getattr(value, "shape", None)
+        if shape is None:
+            return None
+
+        try:
+            return int(np.prod(shape, dtype=np.int64))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _array_metadata_key(value) -> tuple:
+        """Build an O(1) hash key for large arrays without materializing all elements."""
+        # Torch tensors expose stable storage metadata and a version counter
+        # that changes on in-place writes.
+        if hasattr(value, "data_ptr"):
+            try:
+                return (
+                    "tensor-meta",
+                    int(value.data_ptr()),
+                    tuple(value.shape),
+                    tuple(value.stride()) if hasattr(value, "stride") else None,
+                    int(value.storage_offset()) if hasattr(value, "storage_offset") else 0,
+                    str(value.dtype),
+                    str(value.device) if hasattr(value, "device") else None,
+                    int(getattr(value, "_version", 0)),
+                )
+            except Exception:
+                pass
+
+        if isinstance(value, np.ndarray):
+            return (
+                "ndarray-meta",
+                int(value.__array_interface__["data"][0]),
+                tuple(value.shape),
+                tuple(value.strides),
+                str(value.dtype),
+            )
+
+        return (
+            "array-meta",
+            id(value),
+            tuple(getattr(value, "shape", ())),
+            str(getattr(value, "dtype", type(value))),
+        )
+
     def _create_cache_key(self, wavelength: float | be.ndarray, **kwargs) -> tuple:
         """Creates a hashable cache key from wavelength and kwargs."""
         if be.is_array_like(wavelength):
-            wavelength_key = tuple(np.ravel(be.to_numpy(wavelength)))
+            size = self._array_size(wavelength)
+            if size is not None and size <= self._MAX_VALUE_KEY_ARRAY_SIZE:
+                wavelength_key = tuple(np.ravel(be.to_numpy(wavelength)))
+            else:
+                wavelength_key = self._array_metadata_key(wavelength)
         else:
             wavelength_key = wavelength
         return (wavelength_key,) + tuple(sorted(kwargs.items()))

--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -85,7 +85,8 @@ class BaseMaterial(ABC):
 
     @staticmethod
     def _array_metadata_key(value) -> tuple:
-        """Build an O(1) hash key for large arrays without materializing all elements."""
+        """Build an O(1) hash key for large arrays without
+        materializing all elements."""
         # Torch tensors expose stable storage metadata and a version counter
         # that changes on in-place writes.
         if hasattr(value, "data_ptr"):
@@ -95,7 +96,9 @@ class BaseMaterial(ABC):
                     int(value.data_ptr()),
                     tuple(value.shape),
                     tuple(value.stride()) if hasattr(value, "stride") else None,
-                    int(value.storage_offset()) if hasattr(value, "storage_offset") else 0,
+                    int(value.storage_offset())
+                    if hasattr(value, "storage_offset")
+                    else 0,
                     str(value.dtype),
                     str(value.device) if hasattr(value, "device") else None,
                     int(getattr(value, "_version", 0)),

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import resources
+import time
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -63,6 +64,52 @@ class TestBaseMaterial:
         """_detach_if_tensor returns plain values unchanged."""
         assert BaseMaterial._detach_if_tensor(1.5) == 1.5
         assert BaseMaterial._detach_if_tensor(None) is None
+
+    def test_large_array_cache_key_runtime_is_sublinear(self, set_test_backend):
+        """Regression guard for O(N) array cache-key construction.
+
+        Large wavelength arrays should use metadata-based keys rather than
+        materializing every array element into a Python tuple.
+        """
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return wavelength
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return wavelength
+
+        material = DummyMaterial()
+
+        small = np.linspace(0.45, 0.65, 1_000, dtype=np.float64)
+        large = np.linspace(0.45, 0.65, 200_000, dtype=np.float64)
+
+        # Warm up once to reduce one-time effects.
+        material._create_cache_key(small, temperature=25)
+        material._create_cache_key(large, temperature=25)
+
+        small_iters = 200
+        t0 = time.perf_counter()
+        for _ in range(small_iters):
+            material._create_cache_key(small, temperature=25)
+        small_avg_s = (time.perf_counter() - t0) / small_iters
+
+        large_iters = 5
+        t0 = time.perf_counter()
+        for _ in range(large_iters):
+            material._create_cache_key(large, temperature=25)
+        large_avg_s = (time.perf_counter() - t0) / large_iters
+
+        ratio = large_avg_s / max(small_avg_s, 1e-9)
+        assert ratio < 40.0, (
+            "Large-array cache-key generation appears to scale linearly with array size "
+            f"(ratio={ratio:.2f}, small_avg={small_avg_s:.3e}s, large_avg={large_avg_s:.3e}s)"
+        )
+
+        # Keys should still be deterministic for repeated calls on same input.
+        key1 = material._create_cache_key(large, temperature=25)
+        key2 = material._create_cache_key(large, temperature=25)
+        assert key1 == key2
 
     def test_detach_if_tensor_numpy(self, set_test_backend):
         """_detach_if_tensor returns numpy arrays unchanged."""


### PR DESCRIPTION
- avoid O(N) tuple materialization for large wavelength arrays in BaseMaterial cache keys

- keep deterministic value-based keys for small arrays

- add regression test to guard sublinear cache-key runtime scaling