### PR TITLE
Fix NumPy 2.x Compatibility Issues

### DIFF
--- a/optiland/coordinate_system.py
+++ b/optiland/coordinate_system.py
@@ -188,12 +188,12 @@ class CoordinateSystem:
             The dictionary representation of the coordinate system.
         """
         return {
-            "x": float(self.x),
-            "y": float(self.y),
-            "z": float(self.z),
-            "rx": float(self.rx),
-            "ry": float(self.ry),
-            "rz": float(self.rz),
+            "x": float(self.x.item()),
+            "y": float(self.y.item()),
+            "z": float(self.z.item()),
+            "rx": float(self.rx.item()),
+            "ry": float(self.ry.item()),
+            "rz": float(self.rz.item()),
             "reference_cs": self.reference_cs.to_dict() if self.reference_cs else None,
         }
 

--- a/optiland/wavefront/strategy.py
+++ b/optiland/wavefront/strategy.py
@@ -468,9 +468,9 @@ class CentroidStrategy(ReferenceStrategy):
             SphericalReference: The spherical reference geometry.
         """
         distances_wf = be.linalg.norm(wavefront_points - centroid, axis=1)
-        radius = float(be.sum(weights * distances_wf) / be.sum(weights))
+        radius = (be.sum(weights * distances_wf) / be.sum(weights)).item()
         return SphericalReference(
-            (float(centroid[0]), float(centroid[1]), float(centroid[2])), radius
+            (centroid[0].item(), centroid[1].item(), centroid[2].item()), radius
         )
 
     def _calculate_reference_sphere(
@@ -508,11 +508,11 @@ class CentroidStrategy(ReferenceStrategy):
             mean_direction = mean_direction / norm
 
         return PlanarReference(
-            (float(centroid[0]), float(centroid[1]), float(centroid[2])),
+            (centroid[0].item(), centroid[1].item(), centroid[2].item()),
             (
-                float(mean_direction[0]),
-                float(mean_direction[1]),
-                float(mean_direction[2]),
+                mean_direction[0].item(),
+                mean_direction[1].item(),
+                mean_direction[2].item(),
             ),
         )
 
@@ -578,8 +578,8 @@ class BestFitStrategy(CentroidStrategy):
         yc = c[1] / 2
         zc = c[2] / 2
         radius = be.sqrt(c[3] + xc**2 + yc**2 + zc**2)
-        self.center = (float(xc), float(yc), float(zc))
-        return SphericalReference(self.center, float(radius))
+        self.center = (xc.item(), yc.item(), zc.item())
+        return SphericalReference(self.center, radius.item())
 
     def _create_planar_ref(self, wavefront_points: be.ndarray) -> PlanarReference:
         """Create a planar reference geometry using least-squares fit.
@@ -601,8 +601,8 @@ class BestFitStrategy(CentroidStrategy):
         normal = vh[-1, :]
 
         return PlanarReference(
-            (float(centroid[0]), float(centroid[1]), float(centroid[2])),
-            (float(normal[0]), float(normal[1]), float(normal[2])),
+            (centroid[0].item(), centroid[1].item(), centroid[2].item()),
+            (normal[0].item(), normal[1].item(), normal[2].item()),
         )
 
 


### PR DESCRIPTION
## Fix NumPy 2.x Compatibility Issues
Resolves #558

### Changes
- Updated `CoordinateSystem.to_dict()` to use `.item()` for coordinate fields.
- Refactored `CentroidStrategy` and `BestFitStrategy` in `strategy.py` to use `.item()` for all reference geometry components.
- Ensures robust backend-agnostic scalar extraction, preventing `TypeError` on NumPy 2.x when handling 1D arrays of size 1.

### Verification
- Verified successful serialization for all catalog lenses (Petzval, Telephoto, etc.).
- All tests in `tests/test_wavefront.py` and `tests/test_optic.py` passed.
