### PR TITLE
Fix/phase height profile and loading

### DIFF
--- a/optiland/interactions/base.py
+++ b/optiland/interactions/base.py
@@ -81,27 +81,31 @@ class BaseInteractionModel(ABC):
         }
 
     @classmethod
-    def from_dict(cls, data, parent_surface):
-        """Creates an interaction model from a dictionary representation."""
+    def _deserialize_init_data(cls, data):
         from optiland.coatings import BaseCoating
         from optiland.scatter import BaseBSDF
 
+        init_data = data.copy()
+        init_data.pop("type", None)
+        init_data.pop("material_pre", None)
+
+        if init_data.get("coating") is not None:
+            init_data["coating"] = BaseCoating.from_dict(init_data["coating"])
+
+        if init_data.get("bsdf") is not None:
+            init_data["bsdf"] = BaseBSDF.from_dict(init_data["bsdf"])
+
+        return init_data
+
+    @classmethod
+    def from_dict(cls, data, parent_surface):
+        """Creates an interaction model from a dictionary representation."""
         interaction_type = data["type"]
         subclass = cls._registry.get(interaction_type)
         if subclass is None:
             raise ValueError(f"Unknown interaction model type: {interaction_type}")
 
-        # Remove 'type' from data to avoid passing it to the constructor
-        init_data = data.copy()
-        init_data.pop("type")
-        # Ignore 'material_pre' that might be present in older files but is obsolete:
-        if "material_pre" in init_data:
-            init_data.pop("material_pre")
-
-        if "coating" in init_data and init_data["coating"] is not None:
-            init_data["coating"] = BaseCoating.from_dict(init_data["coating"])
-        if "bsdf" in init_data and init_data["bsdf"] is not None:
-            init_data["bsdf"] = BaseBSDF.from_dict(init_data["bsdf"])
+        init_data = subclass._deserialize_init_data(data)
 
         return subclass(
             parent_surface=parent_surface,

--- a/optiland/interactions/phase_interaction_model.py
+++ b/optiland/interactions/phase_interaction_model.py
@@ -32,15 +32,19 @@ class PhaseInteractionModel(BaseInteractionModel):
 
     interaction_type = "phase"
 
-    def __init__(
-        self,
-        parent_surface: Surface | None,
-        phase_profile: BasePhaseProfile,
-        is_reflective: bool,
-        **kwargs,
-    ):
-        super().__init__(parent_surface, is_reflective=is_reflective, **kwargs)
+    def __init__(self, parent_surface, phase_profile, is_reflective, **kwargs):
         self.phase_profile = phase_profile
+        self._parent_surface = None
+        super().__init__(parent_surface, is_reflective=is_reflective, **kwargs)
+
+    @property
+    def parent_surface(self):
+        return self._parent_surface
+
+    @parent_surface.setter
+    def parent_surface(self, value):
+        self._parent_surface = value
+        self.phase_profile.parent_surface = value
 
     def interact_real_rays(self, rays: RealRays) -> RealRays:
         if self.parent_surface is None:

--- a/optiland/interactions/phase_interaction_model.py
+++ b/optiland/interactions/phase_interaction_model.py
@@ -12,7 +12,6 @@ from optiland.phase.base import BasePhaseProfile
 
 if typing.TYPE_CHECKING:
     from optiland.raytrace.rays import ParaxialRays, RealRays
-    from optiland.surfaces.standard_surface import Surface
 
 
 class PhaseInteractionModel(BaseInteractionModel):
@@ -190,22 +189,9 @@ class PhaseInteractionModel(BaseInteractionModel):
         return data
 
     @classmethod
-    def from_dict(cls, data: dict, parent_surface: Surface) -> PhaseInteractionModel:
-        """Deserializes an interaction model from a dictionary.
-
-        Args:
-            data: A dictionary representation of an interaction model.
-            parent_surface: The surface to which this model is attached.
-
-        Returns:
-            An instance of a `PhaseInteractionModel`.
-        """
-        phase_profile = BasePhaseProfile.from_dict(data.pop("phase_profile"))
-        data.pop("type", None)
-        is_reflective = data.pop("is_reflective", False)
-        return cls(
-            parent_surface,
-            phase_profile=phase_profile,
-            is_reflective=is_reflective,
-            **data,
+    def _deserialize_init_data(cls, data):
+        init_data = super()._deserialize_init_data(data)
+        init_data["phase_profile"] = BasePhaseProfile.from_dict(
+            init_data["phase_profile"]
         )
+        return init_data

--- a/optiland/phase/base.py
+++ b/optiland/phase/base.py
@@ -9,6 +9,7 @@ import typing
 
 if typing.TYPE_CHECKING:
     from optiland import backend as be
+    from optiland.surfaces.standard_surface import Surface
 
 
 class BasePhaseProfile(abc.ABC):
@@ -20,6 +21,9 @@ class BasePhaseProfile(abc.ABC):
     """
 
     _registry = {}
+
+    def __init__(self):
+        self.parent_surface: Surface | None = None
 
     def __init_subclass__(cls, **kwargs):
         """Registers subclasses for deserialization."""

--- a/optiland/phase/constant.py
+++ b/optiland/phase/constant.py
@@ -22,6 +22,7 @@ class ConstantPhaseProfile(BasePhaseProfile):
     phase_type = "constant"
 
     def __init__(self, phase: float = 0.0):
+        super().__init__()
         self.phase = phase
 
     def get_phase(

--- a/optiland/phase/grid.py
+++ b/optiland/phase/grid.py
@@ -25,6 +25,7 @@ class GridPhaseProfile(BasePhaseProfile):
     phase_type = "grid"
 
     def __init__(self, x_coords: be.Array, y_coords: be.Array, phase_grid: be.Array):
+        super().__init__()
         self.backend = be.get_backend()
         self.x_coords = x_coords
         self.y_coords = y_coords

--- a/optiland/phase/height_profile.py
+++ b/optiland/phase/height_profile.py
@@ -6,30 +6,22 @@ Gustavo Vasconcelos, 2026
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from optiland import backend as be
 from optiland.phase.base import BasePhaseProfile
 from optiland.phase.interpolators import GridInterpolator
-
-if TYPE_CHECKING:
-    from optiland.materials.base import BaseMaterial
 
 
 class HeightProfile(BasePhaseProfile):
     """A phase profile defined by a height map and a dispersive material.
 
     The phase is calculated as:
-        phi(x, y, λ) = (2π / λ) * (n_material(λ) - 1) * h(x, y)
-
-    Assumes air as the reference medium.
+        phi(x, y, λ) = (2π / λ) * (n_post(λ) - n_pre(λ)) * h(x, y)
 
     Args:
         x_coords (be.Array): X-coordinates of the height map grid.
         y_coords (be.Array): Y-coordinates of the height map grid.
         height_map (be.Array): Height values at grid points
             with shape (len(y_coords), len(x_coords)).
-        material: Material providing wavelength-dependent refractive index n(λ).
     """
 
     phase_type = "height_profile"
@@ -39,13 +31,12 @@ class HeightProfile(BasePhaseProfile):
         x_coords: be.Array,
         y_coords: be.Array,
         height_map: be.Array,
-        material: BaseMaterial,
     ):
+        super().__init__()
         self.backend = be.get_backend()
         self.x_coords = x_coords
         self.y_coords = y_coords
         self.height_map = height_map
-        self.material = material
 
         self._interp = GridInterpolator(x_coords, y_coords, height_map)
 
@@ -64,8 +55,9 @@ class HeightProfile(BasePhaseProfile):
         wavelength: be.Array,
     ) -> be.Array:
         h = self._interpolate_height(x, y)
-        n = self.material.n(wavelength)
-        return 2 * be.pi / (wavelength * 1e-3) * (n - 1.0) * h
+        n_pre = self.parent_surface.material_pre.n(wavelength)
+        n_post = self.parent_surface.material_post.n(wavelength)
+        return 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre) * h
 
     def get_gradient(
         self,
@@ -74,8 +66,9 @@ class HeightProfile(BasePhaseProfile):
         wavelength: be.Array,
     ) -> tuple[be.Array, be.Array, be.Array]:
         dh_dx, dh_dy = self._interpolate_gradient(x, y)
-        n = self.material.n(wavelength)
-        factor = 2 * be.pi / (wavelength * 1e-3) * (n - 1.0)
+        n_pre = self.parent_surface.material_pre.n(wavelength)
+        n_post = self.parent_surface.material_post.n(wavelength)
+        factor = 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre)
         return factor * dh_dx, factor * dh_dy, be.zeros_like(x)
 
     def get_paraxial_gradient(
@@ -85,15 +78,15 @@ class HeightProfile(BasePhaseProfile):
     ) -> be.Array:
         x0 = be.zeros_like(y)
         _, dh_dy = self._interpolate_gradient(x0, y)
-        n = self.material.n(wavelength)
-        return 2 * be.pi / (wavelength * 1e-3) * (n - 1.0) * dh_dy
+        n_pre = self.parent_surface.material_pre.n(wavelength)
+        n_post = self.parent_surface.material_post.n(wavelength)
+        return 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre) * dh_dy
 
     def to_dict(self) -> dict:
         data = super().to_dict()
         data["x_coords"] = be.to_numpy(self.x_coords).tolist()
         data["y_coords"] = be.to_numpy(self.y_coords).tolist()
         data["height_map"] = be.to_numpy(self.height_map).tolist()
-        data["material"] = getattr(self.material, "name", str(self.material))
         return data
 
     @classmethod
@@ -102,5 +95,4 @@ class HeightProfile(BasePhaseProfile):
             x_coords=be.array(data["x_coords"]),
             y_coords=be.array(data["y_coords"]),
             height_map=be.array(data["height_map"]),
-            material=data["material"],
         )

--- a/optiland/phase/linear_grating.py
+++ b/optiland/phase/linear_grating.py
@@ -39,6 +39,7 @@ class LinearGratingPhaseProfile(BasePhaseProfile):
     def __init__(
         self, period: float, angle: float = 0.0, order: int = 1, efficiency: float = 1.0
     ):
+        super().__init__()
         if period <= 0:
             raise ValueError("Grating period must be positive.")
         if not (0.0 <= efficiency <= 1.0):

--- a/optiland/phase/radial.py
+++ b/optiland/phase/radial.py
@@ -21,6 +21,7 @@ class RadialPhaseProfile(BasePhaseProfile):
     phase_type = "radial"
 
     def __init__(self, coefficients: list[float]):
+        super().__init__()
         self.coefficients = coefficients
 
     def get_phase(

--- a/tests/test_height_profile_phase.py
+++ b/tests/test_height_profile_phase.py
@@ -9,62 +9,73 @@ from optiland.phase.height_profile import HeightProfile
 from .utils import assert_allclose
 
 
+class DummySurface:
+    def __init__(self, material_pre, material_post):
+        self.material_pre = material_pre
+        self.material_post = material_post
+
+
 @pytest.fixture
 def height_data():
     x = be.linspace(-1, 1, 25)
     y = be.linspace(-1, 1, 25)
     height_map = be.array([[i + j for i in x] for j in y])
-    material = IdealMaterial(n=1.5)
-    return x, y, height_map, material
+    material_pre = IdealMaterial(n=1.0)
+    material_post = IdealMaterial(n=1.5)
+    return x, y, height_map, material_pre, material_post
+
+
+@pytest.fixture
+def height_profile(height_data):
+    x, y, height_map, material_pre, material_post = height_data
+    profile = HeightProfile(x, y, height_map)
+    profile.parent_surface = DummySurface(
+        material_pre=material_pre,
+        material_post=material_post,
+    )
+    return profile
 
 
 def test_height_profile_init(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
+    x, y, height_map, _, _ = height_data
+    profile = HeightProfile(x, y, height_map)
 
     assert profile.x_coords.shape[0] == len(x)
     assert profile.y_coords.shape[0] == len(y)
     assert profile.height_map.shape == (len(y), len(x))
-    assert profile.material is material
 
 
-def test_height_profile_get_phase(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
-
+def test_height_profile_get_phase(height_profile):
     wavelength = be.array([1.0])
     px = be.array([0.0])
     py = be.array([0.0])
 
-    phase = profile.get_phase(px, py, wavelength)
+    phase = height_profile.get_phase(px, py, wavelength)
 
     assert phase.shape == (1,)
     assert isinstance(phase.item(), float)
 
 
-def test_height_profile_phase_matches_height(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
+def test_height_profile_phase_matches_height(height_data, height_profile):
+    _, _, _, material_pre, material_post = height_data
 
     wavelength = be.array([1.0])
     px = be.array([0.5])
     py = be.array([0.25])
 
-    h = profile._interpolate_height(px, py)
-    phi = profile.get_phase(px, py, wavelength)
+    h = height_profile._interpolate_height(px, py)
+    phi = height_profile.get_phase(px, py, wavelength)
 
-    n = material.n(wavelength)
-    factor = 2 * be.pi / (wavelength * 1e-3) * (n - 1.0)
+    n_pre = material_pre.n(wavelength)
+    n_post = material_post.n(wavelength)
+    factor = 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre)
 
     assert_allclose(phi, factor * h, atol=1e-6)
 
 
-def test_height_profile_get_gradient(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
-
+def test_height_profile_get_gradient(height_profile):
     wavelength = be.array([1.0])
-    grad_x, grad_y, grad_z = profile.get_gradient(
+    grad_x, grad_y, grad_z = height_profile.get_gradient(
         be.array([0.0]), be.array([0.0]), wavelength
     )
 
@@ -72,53 +83,50 @@ def test_height_profile_get_gradient(height_data):
     assert_allclose(grad_z, be.zeros_like(grad_z), atol=1e-6)
 
 
-def test_height_profile_gradient_values(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
+def test_height_profile_gradient_values(height_data, height_profile):
+    _, _, _, material_pre, material_post = height_data
 
     wavelength = be.array([1.0])
-    grad_x, grad_y, grad_z = profile.get_gradient(
+    grad_x, grad_y, grad_z = height_profile.get_gradient(
         be.array([0.0]), be.array([0.0]), wavelength
     )
 
-    n = material.n(wavelength)
-    factor = 2 * be.pi / (wavelength * 1e-3) * (n - 1.0)
+    n_pre = material_pre.n(wavelength)
+    n_post = material_post.n(wavelength)
+    factor = 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre)
 
     assert_allclose(grad_x, factor, atol=1e-6)
     assert_allclose(grad_y, factor, atol=1e-6)
     assert_allclose(grad_z, be.zeros_like(grad_z), atol=1e-6)
 
 
-def test_height_profile_get_paraxial_gradient(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
-
+def test_height_profile_get_paraxial_gradient(height_profile):
     wavelength = be.array([1.0])
     y_vals = be.array([0.0, 0.5])
 
-    paraxial = profile.get_paraxial_gradient(y_vals, wavelength)
+    paraxial = height_profile.get_paraxial_gradient(y_vals, wavelength)
 
     assert paraxial.shape[0] == 2
 
 
-def test_height_profile_paraxial_value(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
+def test_height_profile_paraxial_value(height_data, height_profile):
+    _, _, _, material_pre, material_post = height_data
 
     wavelength = be.array([1.0])
     y_vals = be.array([0.0, 0.5, 1.0])
 
-    paraxial = profile.get_paraxial_gradient(y_vals, wavelength)
+    paraxial = height_profile.get_paraxial_gradient(y_vals, wavelength)
 
-    n = material.n(wavelength)
-    factor = 2 * be.pi / (wavelength * 1e-3) * (n - 1.0)
+    n_pre = material_pre.n(wavelength)
+    n_post = material_post.n(wavelength)
+    factor = 2 * be.pi / (wavelength * 1e-3) * (n_post - n_pre)
 
     assert_allclose(paraxial, factor * be.ones_like(y_vals), atol=1e-6)
 
 
 def test_height_profile_to_from_dict(height_data):
-    x, y, height_map, material = height_data
-    profile = HeightProfile(x, y, height_map, material)
+    x, y, height_map, _, _ = height_data
+    profile = HeightProfile(x, y, height_map)
 
     data = profile.to_dict()
 
@@ -131,7 +139,6 @@ def test_height_profile_to_from_dict(height_data):
         x_coords=be.array(data["x_coords"]),
         y_coords=be.array(data["y_coords"]),
         height_map=be.array(data["height_map"]),
-        material=material,
     )
 
     assert isinstance(new_profile, HeightProfile)


### PR DESCRIPTION
## Summary

This PR fixes the two bugs reported in #562: `HeightProfile` was using a direct material reference instead of the parent surface media, and `phase_profile` objects were not being deserialized correctly in interaction models. :contentReference[oaicite:0]{index=0}

## Changes

- remove the direct material dependency from `HeightProfile`
- make `HeightProfile` derive refractive behavior from `parent_surface.material_pre` and `parent_surface.material_post`
- fix `phase_profile` deserialization in interaction models
- keep phase-based systems loadable after serialization/deserialization :contentReference[oaicite:1]{index=1}

## Why

`HeightProfile` phase and gradient calculations should be based on the refractive index contrast across the surface, not on a material stored directly in the profile. The issue report notes that the previous behavior effectively acted like a fixed `(n - 1)` assumption instead of using the actual surface media. :contentReference[oaicite:2]{index=2}

The issue also reports that interaction models could fail to reconstruct `phase_profile` correctly when loading from dictionaries, which could break serialized phase-based optical systems or leave them partially reconstructed.

## Validation

- `pytest tests/test_height_profile_phase.py` passes locally after the fix :contentReference[oaicite:4]{index=4}

## Environment

- Optiland Version: `master @ 75859934`
- Python Version: `3.11`
- OS: `Linux`

## Related

Closes #562