### PR TITLE
fix: force XCB on Linux

### DIFF
--- a/optiland_gui/run_gui.py
+++ b/optiland_gui/run_gui.py
@@ -11,6 +11,7 @@ Authors:
 from __future__ import annotations
 
 import ctypes
+import os
 import sys
 
 from PySide6.QtCore import QLocale, QSize, Qt
@@ -27,6 +28,12 @@ def main() -> None:
     if sys.platform == "win32":
         myappid = f"{ORGANIZATION_NAME}.{APPLICATION_NAME}.1.0"
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+
+    # Force XCB (X11) on Linux to avoid BadWindow / X_ConfigureWindow crashes
+    # caused by incompatibility between the VTK/OpenGL render pipeline and the
+    # Qt Wayland backend.  This must be set before QApplication is created.
+    if sys.platform.startswith("linux"):
+        os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
     app = QApplication(sys.argv)
     app.setWindowIcon(QIcon(OPTILAND_ICON_PATH))


### PR DESCRIPTION
## Description
This PR resolves a critical GUI crash affecting Linux users on Wayland-based display servers (e.g., NixOS, Ubuntu 24.04).

The crash was identified as a protocol mismatch between the Qt Wayland backend and the VTK/OpenGL rendering pipeline, resulting in a `BadWindow (invalid Window parameter)` error during `X_ConfigureWindow` requests. 

This change programmatically forces the `xcb` (X11) platform abstraction layer when running on Linux. This ensures the GUI utilizes XWayland, which provides a stable environment for the current rendering stack while maintaining compatibility across modern Linux distributions.

## Changes
- **`optiland_gui/run_gui.py`**: Added logic to detect Linux environments and explicitly set `QT_QPA_PLATFORM=xcb` before the `QApplication` instance is initialized.

**Closes: #556**