### PR TITLE
Fix Torch autograd for Zernike surface optimization

### DIFF
--- a/optiland/geometries/zernike.py
+++ b/optiland/geometries/zernike.py
@@ -167,15 +167,29 @@ class ZernikePolynomialGeometry(NewtonRaphsonGeometry):
         self._validate_inputs(x_norm, y_norm)
 
         # Convert to local polar
-        rho = be.sqrt(x_norm**2 + y_norm**2)
-        phi = be.arctan2(y_norm, x_norm)
+        rho2 = x_norm**2 + y_norm**2
+        center = rho2 == 0
+
+        safe_rho2 = be.where(center, be.ones_like(rho2), rho2)
+        safe_rho = be.sqrt(safe_rho2)
+        rho = be.where(center, be.zeros_like(safe_rho), safe_rho)
+
+        x_phi = be.where(center, be.ones_like(x_norm), x_norm)
+        y_phi = be.where(center, be.zeros_like(y_norm), y_norm)
+        phi = be.arctan2(y_phi, x_phi)
 
         # Base conic
         r2 = x**2 + y**2
-        z = r2 / (self.radius * (1 + be.sqrt(1 - (1 + self.k) * r2 / self.radius**2)))
+
+        if bool(be.all(be.isinf(self.radius))):
+            z = be.zeros_like(x)
+        else:
+            z = r2 / (
+                self.radius * (1 + be.sqrt(1 - (1 + self.k) * r2 / self.radius**2))
+            )
 
         # Add Zernike polynomial contributions
-        z += self.zernike.poly(rho, phi)
+        z = z + self.zernike.poly(rho, phi)
 
         return z
 
@@ -197,54 +211,83 @@ class ZernikePolynomialGeometry(NewtonRaphsonGeometry):
         """
         # Conic partial derivatives:
         r2 = x**2 + y**2
-        denominator = self.radius * be.sqrt(1 - (1 + self.k) * r2 / self.radius**2)
-        dzdx = x / denominator
-        dzdy = y / denominator
 
-        # Protect against divide-by-zero for r=0
-        # or handle small r if needed
-        eps = 1e-14
-        denominator = be.where(be.abs(denominator) < eps, eps, denominator)
+        if bool(be.all(be.isinf(self.radius))):
+            dzdx = be.zeros_like(x)
+            dzdy = be.zeros_like(y)
+        else:
+            denominator = self.radius * be.sqrt(1 - (1 + self.k) * r2 / self.radius**2)
+
+            valid_denominator = be.abs(denominator) > 0
+            safe_denominator = be.where(
+                valid_denominator,
+                denominator,
+                be.ones_like(denominator),
+            )
+
+            dzdx = be.where(
+                valid_denominator,
+                x / safe_denominator,
+                be.zeros_like(x),
+            )
+            dzdy = be.where(
+                valid_denominator,
+                y / safe_denominator,
+                be.zeros_like(y),
+            )
 
         # Now add partial derivatives from the Zernike expansions
         x_norm = x / self.norm_radius
         y_norm = y / self.norm_radius
-        rho = be.sqrt(x_norm**2 + y_norm**2)
-        phi = be.arctan2(y_norm, x_norm)
+
+        rho2 = x_norm**2 + y_norm**2
+        center = rho2 == 0
+
+        safe_rho2 = be.where(center, be.ones_like(rho2), rho2)
+        safe_rho = be.sqrt(safe_rho2)
+        rho = be.where(center, be.zeros_like(safe_rho), safe_rho)
+
+        x_phi = be.where(center, be.ones_like(x_norm), x_norm)
+        y_phi = be.where(center, be.zeros_like(y_norm), y_norm)
+        phi = be.arctan2(y_phi, x_phi)
 
         # Chain rule:
         # dZ/dx = dZ/drho * d(rho)/dx + dZ/dphi * d(phi)/dx
         # We'll define the partials of (rho,phi) wrt x:
         #   drho/dx    = x / (norm_x^2 * rho)
         #   dphi/dx  = - y / (rho^2 * norm_y * norm_x)
-        drho_dx = (
-            be.zeros_like(x)
-            if be.all(rho == 0)
-            else ((x / (self.norm_radius**2)) / (rho + eps))
+        drho_dx = be.where(
+            center,
+            be.zeros_like(x),
+            (x / (self.norm_radius**2)) / safe_rho,
         )
-        drho_dy = (
-            be.zeros_like(y)
-            if be.all(rho == 0)
-            else ((y / (self.norm_radius**2)) / (rho + eps))
+        drho_dy = be.where(
+            center,
+            be.zeros_like(y),
+            (y / (self.norm_radius**2)) / safe_rho,
         )
-        dphi_dx = -(y_norm) / (rho**2 + eps) * (1.0 / self.norm_radius)
-        dphi_dy = +(x_norm) / (rho**2 + eps) * (1.0 / self.norm_radius)
+        dphi_dx = be.where(
+            center,
+            be.zeros_like(x),
+            -(y_norm) / safe_rho2 * (1.0 / self.norm_radius),
+        )
+        dphi_dy = be.where(
+            center,
+            be.zeros_like(y),
+            +(x_norm) / safe_rho2 * (1.0 / self.norm_radius),
+        )
 
         for (n, m), c in zip(self.zernike.indices, self.zernike.coeffs, strict=True):
-            if c == 0:
-                continue
-
             dZdrho, dZdphi = self.zernike.get_derivative(n, m, rho, phi)
             # Partial derivatives w.r.t. x and y
-            dzdx += c * (dZdrho * drho_dx + dZdphi * dphi_dx)
-            dzdy += c * (dZdrho * drho_dy + dZdphi * dphi_dy)
+            dzdx = dzdx + c * (dZdrho * drho_dx + dZdphi * dphi_dx)
+            dzdy = dzdy + c * (dZdrho * drho_dy + dZdphi * dphi_dy)
 
         # Surface normal vector in cartesian coords: (-dzdx, -dzdy, 1)
         # normalized. Check sign conventions!
         nx = +dzdx
         ny = +dzdy
         norm = be.sqrt(nx**2 + ny**2 + 1)
-        norm = be.where(norm < eps, 1.0, norm)  # Avoid division by zero
         nx = nx / norm
         ny = ny / norm
         nz = -be.ones_like(x) / norm

--- a/optiland/optimization/variable/zernike_coeff.py
+++ b/optiland/optimization/variable/zernike_coeff.py
@@ -11,8 +11,7 @@ drpaprika, 2025
 
 from __future__ import annotations
 
-import numpy as np
-
+import optiland.backend as be
 from optiland.optimization.scaling.identity import IdentityScaler
 from optiland.optimization.variable.polynomial_coeff import PolynomialCoeffVariable
 
@@ -50,48 +49,38 @@ class ZernikeCoeffVariable(PolynomialCoeffVariable):
 
         Returns:
             float: The current value of the Zernike coefficient.
-
         """
         surf = self._surfaces[self.surface_number]
         i = self.coeff_index
-        try:
-            value = surf.geometry.coefficients[i]
-        except IndexError:
-            pad_width_i = max(0, i + 1)
-            c_new = np.pad(
-                surf.geometry.coefficients,
-                pad_width=(0, pad_width_i),
-                mode="constant",
-                constant_values=0,
-            )
-            surf.geometry.coefficients = c_new
-            value = 0
-        return value
+        coeffs = surf.geometry.coefficients
+
+        if i < len(coeffs):
+            return coeffs[i]
+
+        pad_width = i + 1 - len(coeffs)
+        padding = be.array([0.0] * pad_width)
+        surf.geometry.coefficients = be.concatenate([coeffs, padding])
+
+        return surf.geometry.coefficients[i]
 
     def update_value(self, new_value):
         """Update the value of the Zernike coefficient.
 
         Args:
             new_value (float): The new value of the Zernike coefficient.
-
         """
         surf = self.optic.surfaces[self.surface_number]
         i = self.coeff_index
+        coeffs = surf.geometry.coefficients
 
-        if i < len(surf.geometry.coefficients):
-            # If the coefficient already exists, update it
-            surf.geometry.coefficients[i] = new_value
-        else:
-            # If the coefficient does not exist, pad the array and set the value
-            pad_width_i = max(0, i + 1)
-            new_coefficients = np.pad(
-                surf.geometry.coefficients,
-                pad_width=(0, pad_width_i),
-                mode="constant",
-                constant_values=0,
-            )
-            new_coefficients[i] = new_value
-            surf.geometry.coefficients = new_coefficients
+        if i >= len(coeffs):
+            pad_width = i + 1 - len(coeffs)
+            padding = be.array([0.0] * pad_width)
+            coeffs = be.concatenate([coeffs, padding])
+
+        surf.geometry.coefficients = be.stack(
+            [new_value if j == i else coeff for j, coeff in enumerate(coeffs)]
+        )
 
     def __str__(self):
         """Return a string representation of the variable.

--- a/optiland/zernike/base.py
+++ b/optiland/zernike/base.py
@@ -215,11 +215,10 @@ class BaseZernike(ABC):
     @staticmethod
     def _radial_term(n, m, r):
         """Calculate the radial term of the Zernike polynomial."""
-        s_max = (n - abs(m)) // 2 + 1
+        n = int(n)
+        m_abs = abs(int(m))
 
-        n = be.array(n)
-        m = be.array(m)
-        m_abs = be.abs(m)
+        s_max = (n - m_abs) // 2 + 1
         r = be.array(r)
 
         # Initialize value with correct backend
@@ -272,10 +271,10 @@ class BaseZernike(ABC):
         Returns:
             float: The calculated value of the radial derivative.
         """
-        s_max = (n - abs(m)) // 2 + 1
+        n = int(n)
+        m = abs(int(m))
 
-        n = be.array(n)
-        m = be.array(m)
+        s_max = (n - m) // 2 + 1
         r = be.array(r)
 
         # Initialize value with correct backend


### PR DESCRIPTION
This PR fixes Torch autograd failures when optimizing Zernike surface coefficients.

Fixes #575.

Changes:
- Keep Zernike indices `n` and `m` as Python integers to avoid `aten::floor_divide` in the Torch graph.
- Handle polar-coordinate singularities at the pupil center.
- Handle infinite-radius Zernike surfaces before conic sag and normal calculations.
- Avoid in-place tensor updates when syncing Zernike coefficients.

Testing:
I tested the fix with a minimal Torch optimization using `OptimizationProblem`, `OpticalSystemModule`, `zernike_coeff`, and `rms_spot_size`.

Before this patch, the example failed during `loss.backward()` with:

    RuntimeError: derivative for aten::floor_divide is not implemented

After this patch, it runs successfully:

    Step 0000 | loss = 1.322814941406e+01
    Step 0010 | loss = 5.923573374748e-01
    Step 0020 | loss = 2.538904547691e-01
    Step 0030 | loss = 3.330281376839e-01
    Step 0040 | loss = 2.452862821519e-02

Final coefficients:

    tensor([0.0000, 0.0000, 0.0000, 0.7369, 0.0000], grad_fn=<StackBackward0>)