### PR TITLE
Fix Torch autograd for multiple thickness variables (#569)

### DIFF
--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -82,19 +82,27 @@ class OpticUpdater:
             # No need to shift other surfaces as they are relative to S1 at z=0
             return
 
-        positions = self.optic.surfaces.positions
-        # Detach positions used as reference points to prevent stale computation
-        # graphs (from prior iterations) from being pulled into the current graph.
-        if hasattr(positions, "detach"):
-            positions = positions.detach()
-        delta_t = value - positions[surface_number + 1] + positions[surface_number]
-        positions = be.copy(positions)  # required to avoid in-place modification
-        positions[surface_number + 1 :] = positions[surface_number + 1 :] + delta_t
-        positions = positions - positions[1]  # force surface 1 to be at zero
-        for k, surface in enumerate(self.optic.surfaces):
-            surface.geometry.cs.z = be.array(positions[k])
-        if surface_number < len(self.optic.surfaces):
-            self.optic.surfaces[surface_number].thickness = value
+        # Source of truth for downstream positions is each surface's `.thickness`
+        # attribute. Update the requested one first, then rebuild every cs.z
+        # downstream from those thickness values (rather than incrementally
+        # mutating cs.z). This keeps every current-iteration thickness tensor
+        # in the autograd graph — the prior incremental form needed `detach()`
+        # to drop stale graphs from earlier iterations, but that also severed
+        # in-iteration grad paths when multiple thickness variables were
+        # updated sequentially (only the last one kept its gradient). See #569.
+        surfaces = self.optic.surfaces
+        n = len(surfaces)
+        if surface_number < n:
+            surfaces[surface_number].thickness = value
+
+        # Surface 1 anchored at z=0; cs.z[k] = sum of upstream thicknesses.
+        if n >= 2:
+            z = be.array(0.0)
+            surfaces[1].geometry.cs.z = be.array(z)
+            for k in range(2, n):
+                t_prev = surfaces[k - 1].thickness
+                z = z + (t_prev if hasattr(t_prev, "detach") else be.array(t_prev))
+                surfaces[k].geometry.cs.z = be.array(z)
 
     def set_index(self, value: float, surface_number: int) -> None:
         """Set the index of refraction of a surface.

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -184,3 +184,63 @@ class TestOpticalSystemModule:
 
         loss = module.forward()
         assert be.isclose(loss, torch.tensor(123.45, dtype=torch.float64))
+
+    def test_multiple_thickness_variables_all_get_gradients(self):
+        """
+        Regression test for issue #569: when more than one thickness variable
+        is optimized simultaneously, every thickness must receive a non-zero
+        gradient. Previously only the last thickness variable's gradient
+        survived because ``set_thickness`` called ``positions.detach()`` on
+        every invocation, which also severed the in-iteration gradient path
+        introduced by earlier thickness updates in the same forward pass.
+        """
+        from optiland import optic
+
+        be.grad_mode.enable()
+        lens = optic.Optic()
+        lens.surfaces.add(index=0, thickness=be.inf)
+        lens.surfaces.add(
+            index=1, thickness=7, radius=1000, material="N-SF11", is_stop=True,
+        )
+        lens.surfaces.add(index=2, thickness=30, radius=-1000)
+        lens.surfaces.add(index=3)
+        lens.set_aperture(aperture_type="EPD", value=15)
+        lens.fields.set_type(field_type="angle")
+        lens.fields.add(y=0)
+        lens.wavelengths.add(value=0.55, is_primary=True)
+
+        problem = OptimizationProblem()
+        input_data = {
+            "optic": lens,
+            "surface_number": -1,
+            "Hx": 0, "Hy": 0,
+            "num_rays": 5,
+            "wavelength": 0.55,
+            "distribution": "hexapolar",
+        }
+        problem.add_operand(
+            "rms_spot_size", target=0, weight=1, input_data=input_data,
+        )
+        problem.add_variable(lens, "radius", surface_number=1)
+        problem.add_variable(lens, "thickness", surface_number=1)
+        problem.add_variable(lens, "radius", surface_number=2)
+        problem.add_variable(lens, "thickness", surface_number=2)
+
+        module = OpticalSystemModule(lens, problem)
+        params = list(module.parameters())
+        # Ordering matches add_variable above.
+        thick1_param = params[1]
+        thick2_param = params[3]
+
+        loss = module()
+        loss.backward()
+
+        # Both thickness gradients must exist and be non-zero.
+        assert thick1_param.grad is not None, (
+            "thickness1 grad is None — issue #569 not fixed"
+        )
+        assert thick2_param.grad is not None
+        assert thick1_param.grad.item() != 0.0, (
+            "thickness1 grad is zero — issue #569 not fixed"
+        )
+        assert thick2_param.grad.item() != 0.0


### PR DESCRIPTION
## Summary

Fixes #569.

When optimizing more than one thickness variable simultaneously under the torch backend, only the **last** thickness in the update sequence received a non-zero gradient — earlier ones got `None`/zero. Radius, conic, and aspheric variables were unaffected.

## Root cause

`OpticUpdater.set_thickness` read `surfaces.positions` (current `cs.z`), called `positions.detach()` to drop stale graphs from prior iterations, then wrote new `cs.z` values incrementally.

The detach is necessary across iteration boundaries — but within a single forward pass, after the *first* thickness variable was updated, `cs.z` already encoded a dependency on that thickness tensor. The detach on the *next* update severed it, leaving only the last thickness tensor in the autograd graph.

The original report (#569) contains an excellent walk-through; this PR implements an alternative, less invasive fix than the one suggested there.

## Fix

Stop reading `cs.z` back and applying deltas. Treat each surface's `.thickness` attribute as the source of truth and rebuild every downstream `cs.z` from those thickness values:

```
cs.z[1] = 0  # anchor
cs.z[k] = cs.z[k-1] + surfaces[k-1].thickness   for k >= 2
```

This keeps every current-iteration thickness tensor connected to the output graph, and the explicit overwrite of `cs.z` from each rebuild naturally drops references to prior-iteration tensors — equivalent to the old `detach()` for cross-iteration cleanup, but without severing in-iteration grad paths. No changes to `OpticalSystemModule` or any callers needed.

## Verification

### Minimal repro from the issue, before / after

```
   name |          value |             grad (before)  →   (after)
-------------------------------------------------------------------
radius1 |              9 |         0.169545             0.169545
 thick1 |           -0.3 |             None       →    -0.273316   ← fixed
radius2 |            -11 |        -0.150307            -0.150307
 thick2 |              2 |         -1.00153            -1.00153
```

### Test plan

- [x] New regression test `test_multiple_thickness_variables_all_get_gradients` in `tests/test_ml.py`, derived from the original report — asserts both thickness gradients are non-`None` and non-zero after one forward/backward
- [x] Full local test suite passes: **6050 passed, 9 skipped** (2 pre-existing `test_formula_4` failures unrelated — Windows GBK encoding when reading a yaml material file)
- [x] `ruff check optiland/optic/optic_updater.py` clean
