### PR TITLE
Fix non-zero Seidel aberrations for reflective systems (#347)

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -36,6 +36,7 @@ We sincerely appreciate the contributions of the following individuals, whose ef
 - **cyberstudio10** (`GitHub <https://github.com/cyberstudio10>`_)
 - **lutzerb** (`GitHub <https://github.com/lutzerb>`_)
 - **Jan-Willem Beenakker** (`GitHub <https://github.com/jwmbeenakker>`_)
+- **RayPragma** (`GitHub <https://github.com/RayPragma>`_)
 
 
 Your contributions, whether in the form of code, documentation, feedback, or discussions, are what make **Optiland** better for everyone.

--- a/optiland/aberrations.py
+++ b/optiland/aberrations.py
@@ -279,7 +279,7 @@ class Aberrations:
         )
 
         # Convert Wavefront Seidel Sum to Transverse Aberration contribution
-        return -S_conic / (2 * self._n[-1] * self._ua[-1])
+        return S_conic / (2 * self._n[-1] * self._ua[-1])
 
     def _compute_over_surfaces(self, term_func: Callable) -> BEArray:
         """
@@ -375,8 +375,7 @@ class Aberrations:
             * i_val**2
         )
         spherical = term / (2 * self._n[k] * self._n[-1] * self._ua[-1])
-        # Negate to match the Welford/Zemax convention
-        return -spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
+        return spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
 
     def _TSC_term(self, k: int) -> float:
         """
@@ -391,7 +390,7 @@ class Aberrations:
         if self._on_axis:
             return self._TSC_on_axis_term(k)
         spherical = self._B[k - 1] * self._i[k - 1] ** 2 * self._hp
-        return -spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
+        return spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
 
     def _CC_term(self, k: int) -> float:
         """
@@ -404,7 +403,7 @@ class Aberrations:
             Computed sagittal coma term.
         """
         spherical = self._B[k - 1] * self._i[k - 1] * self._ip[k - 1] * self._hp
-        return -spherical + self._get_conic_term(k, p_ya=3, p_yb=1)
+        return spherical + self._get_conic_term(k, p_ya=3, p_yb=1)
 
     def _TAC_term(self, k: int) -> float:
         """
@@ -417,7 +416,7 @@ class Aberrations:
             Computed transverse astigmatism term.
         """
         spherical = self._B[k - 1] * self._ip[k - 1] ** 2 * self._hp
-        return -spherical + self._get_conic_term(k, p_ya=2, p_yb=2)
+        return spherical + self._get_conic_term(k, p_ya=2, p_yb=2)
 
     def _TPC_term(self, k: int) -> BEArray:
         """
@@ -429,14 +428,13 @@ class Aberrations:
         Returns:
             Computed transverse Petzval sum term.
         """
-        term = (
+        return (
             (self._n[k] - self._n[k - 1])
             * self._C[k]
             * self._hp
             * self._inv
             / (2 * self._n[k] * self._n[k - 1])
         )
-        return -term
 
     def _DC_term(self, k: int) -> BEArray:
         """
@@ -452,7 +450,7 @@ class Aberrations:
             self._Bp[k - 1] * self._i[k - 1] * self._ip[k - 1]
             + 0.5 * (self._ub[k] ** 2 - self._ub[k - 1] ** 2)
         )
-        return -spherical + self._get_conic_term(k, p_ya=1, p_yb=3)
+        return spherical + self._get_conic_term(k, p_ya=1, p_yb=3)
 
     def _TAchC_term(self, k: int) -> BEArray:
         """

--- a/optiland/aberrations.py
+++ b/optiland/aberrations.py
@@ -263,6 +263,24 @@ class Aberrations:
             n_signed.append(sign * be.abs(n_raw[k]))
         return be.array(n_signed)
 
+    def _get_conic_term(self, k: int, p_ya: int, p_yb: int) -> float:
+        """
+        Compute the transverse conic contribution for surface k.
+        """
+        dn = self._n[k] - self._n[k - 1]
+
+        # Conic Seidel sum: S_conic = dn * K * c^3 * ya^p_ya * yb^p_yb
+        S_conic = (
+            dn
+            * self._K[k]
+            * (self._C[k] ** 3)
+            * (self._ya[k] ** p_ya)
+            * (self._yb[k] ** p_yb)
+        )
+
+        # Convert Wavefront Seidel Sum to Transverse Aberration contribution
+        return -S_conic / (2 * self._n[-1] * self._ua[-1])
+
     def _compute_over_surfaces(self, term_func: Callable) -> BEArray:
         """
         Compute a given aberration term over all relevant surfaces.
@@ -286,21 +304,18 @@ class Aberrations:
         """
         self._inv: float = self.optic.paraxial.invariant()  # Lagrange invariant
         self._on_axis = be.isclose(self._inv, be.array(0.0))
-        # Refractive indices for all surfaces.
-        # For mirror systems we must use the Welford / Smith sign convention:
-        # after each reflection, the post-surface medium's refractive index
-        # flips sign. Without this, the Seidel third-order formulas reduce to
-        # zero on reflective surfaces because every (n[k] - n[k-1]) term
-        # vanishes — `surfaces.n()` returns magnitudes only. See upstream #347.
-        self._n: BEArray = self._signed_refractive_indices(
-            self.optic.primary_wavelength
-        )
+        self._n = self._signed_refractive_indices(self.optic.primary_wavelength)
+        n_F = self._signed_refractive_indices(0.4861)
+        n_C = self._signed_refractive_indices(0.6563)
+        self._dn = n_F - n_C
+
         self._N: int = self.optic.surfaces.num_surfaces
         self._C = 1 / self.optic.surfaces.radii
         self._ya, self._ua = self.optic.paraxial.marginal_ray()
         self._yb, self._ub = self.optic.paraxial.chief_ray()
         self._hp = self._inv / (self._n[-1] * self._ua[-1])
-        self._dn = self.optic.surfaces.n(0.4861) - self.optic.surfaces.n(0.6563)
+
+        self._K = self.optic.surfaces.conic
 
         i_list = []
         ip_list = []
@@ -359,7 +374,9 @@ class Aberrations:
             * (self._ua[k] + i_val)
             * i_val**2
         )
-        return term / (2 * self._n[k] * self._n[-1] * self._ua[-1])
+        spherical = term / (2 * self._n[k] * self._n[-1] * self._ua[-1])
+        # Negate to match the Welford/Zemax convention
+        return -spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
 
     def _TSC_term(self, k: int) -> float:
         """
@@ -373,7 +390,8 @@ class Aberrations:
         """
         if self._on_axis:
             return self._TSC_on_axis_term(k)
-        return self._B[k - 1] * self._i[k - 1] ** 2 * self._hp
+        spherical = self._B[k - 1] * self._i[k - 1] ** 2 * self._hp
+        return -spherical + self._get_conic_term(k, p_ya=4, p_yb=0)
 
     def _CC_term(self, k: int) -> float:
         """
@@ -385,7 +403,8 @@ class Aberrations:
         Returns:
             Computed sagittal coma term.
         """
-        return self._B[k - 1] * self._i[k - 1] * self._ip[k - 1] * self._hp
+        spherical = self._B[k - 1] * self._i[k - 1] * self._ip[k - 1] * self._hp
+        return -spherical + self._get_conic_term(k, p_ya=3, p_yb=1)
 
     def _TAC_term(self, k: int) -> float:
         """
@@ -397,7 +416,8 @@ class Aberrations:
         Returns:
             Computed transverse astigmatism term.
         """
-        return self._B[k - 1] * self._ip[k - 1] ** 2 * self._hp
+        spherical = self._B[k - 1] * self._ip[k - 1] ** 2 * self._hp
+        return -spherical + self._get_conic_term(k, p_ya=2, p_yb=2)
 
     def _TPC_term(self, k: int) -> BEArray:
         """
@@ -409,13 +429,14 @@ class Aberrations:
         Returns:
             Computed transverse Petzval sum term.
         """
-        return (
+        term = (
             (self._n[k] - self._n[k - 1])
             * self._C[k]
             * self._hp
             * self._inv
             / (2 * self._n[k] * self._n[k - 1])
         )
+        return -term
 
     def _DC_term(self, k: int) -> BEArray:
         """
@@ -427,10 +448,11 @@ class Aberrations:
         Returns:
             Computed distortion term.
         """
-        return self._hp * (
+        spherical = self._hp * (
             self._Bp[k - 1] * self._i[k - 1] * self._ip[k - 1]
             + 0.5 * (self._ub[k] ** 2 - self._ub[k - 1] ** 2)
         )
+        return -spherical + self._get_conic_term(k, p_ya=1, p_yb=3)
 
     def _TAchC_term(self, k: int) -> BEArray:
         """

--- a/optiland/aberrations.py
+++ b/optiland/aberrations.py
@@ -233,6 +233,36 @@ class Aberrations:
         self._precalculations()
         return self._compute_over_surfaces(self._TchC_term).flatten()
 
+    def _signed_refractive_indices(self, wavelength: float) -> BEArray:
+        """Return signed refractive indices following the Welford convention.
+
+        For Seidel third-order aberration formulas to be valid in systems
+        containing mirrors, the post-mirror medium is treated as having a
+        sign-flipped refractive index. Each reflection toggles the sign for
+        all subsequent surfaces — so a two-mirror system ends with the
+        original sign, a three-mirror system with the flipped sign, etc.
+
+        ``surfaces.n()`` itself returns magnitudes only (materials don't
+        carry direction), which is why the Seidel formulas previously
+        evaluated to zero on every reflective surface.
+
+        Args:
+            wavelength: Wavelength at which to evaluate the indices.
+
+        Returns:
+            Array of signed refractive indices, one per surface.
+        """
+        n_raw = self.optic.surfaces.n(wavelength)
+        n_signed = []
+        sign = 1.0
+        for k, surf in enumerate(self.optic.surfaces):
+            if getattr(surf.interaction_model, "is_reflective", False):
+                sign = -sign
+            # ``be.abs`` because the underlying material may already report a
+            # signed n on some backends; we standardize on magnitude × sign.
+            n_signed.append(sign * be.abs(n_raw[k]))
+        return be.array(n_signed)
+
     def _compute_over_surfaces(self, term_func: Callable) -> BEArray:
         """
         Compute a given aberration term over all relevant surfaces.
@@ -256,8 +286,15 @@ class Aberrations:
         """
         self._inv: float = self.optic.paraxial.invariant()  # Lagrange invariant
         self._on_axis = be.isclose(self._inv, be.array(0.0))
-        # Refractive indices for all surfaces
-        self._n: BEArray = self.optic.surfaces.n(self.optic.primary_wavelength)
+        # Refractive indices for all surfaces.
+        # For mirror systems we must use the Welford / Smith sign convention:
+        # after each reflection, the post-surface medium's refractive index
+        # flips sign. Without this, the Seidel third-order formulas reduce to
+        # zero on reflective surfaces because every (n[k] - n[k-1]) term
+        # vanishes — `surfaces.n()` returns magnitudes only. See upstream #347.
+        self._n: BEArray = self._signed_refractive_indices(
+            self.optic.primary_wavelength
+        )
         self._N: int = self.optic.surfaces.num_surfaces
         self._C = 1 / self.optic.surfaces.radii
         self._ya, self._ua = self.optic.paraxial.marginal_ray()

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -269,17 +269,30 @@ class TestReflectiveSystemSeidels:
     `(n[k] - n[k-1])` term in the Seidel formulas evaluates to zero across
     reflective surfaces, collapsing the first four Seidel sums to zero — even
     though mirrors do contribute aberrations.
+
+    This also captures the addition of the conic constants to the Seidel
+    aberrations via the `_get_conic_term` method.
+
+    These values were compared to analytical solution derived by hand. Comparison
+    to ZOS shows a sign difference (expected due to convention) and small
+    deviation for spherical only. This is likely due to numerical methods used
+    in ZOS, but further investigation required to confirm this.
+
+    TODO: Add another test using a system with larger aberrations. Consider
+    adding an objective test using an independent ray tracer.
     """
 
     def test_hubble_seidels_are_not_all_zero(self, set_test_backend):
         from optiland.samples.telescopes import HubbleTelescope
 
         S = HubbleTelescope().aberrations.seidels()
-        # A two-mirror Cassegrain has nontrivial third-order aberrations at
-        # all five Seidel terms (the conic constants are tuned to balance
-        # spherical + coma but residuals exist; field curvature and
-        # distortion vary across the field). All five must be nonzero.
-        for idx in range(5):
-            assert not be.isclose(S[idx], be.array(0.0)), (
-                f"Hubble Seidel S[{idx}]=0 — issue #347 not fixed"
-            )
+        assert_allclose(
+            S,
+            [
+                -2.80642537e-06,
+                3.37323248e-04,
+                -1.45177194e-03,
+                -1.28411858e-02,
+                7.59541065e-04,
+            ],
+        )

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -259,3 +259,27 @@ class TestSimpleSinglet:
 
         # Other Seidel coefficients are expected to be zero for on-axis field
         assert_allclose(S[1:], [0, 0, 0, 0], atol=1e-8)
+
+
+class TestReflectiveSystemSeidels:
+    """Regression test for upstream issue #347.
+
+    For systems containing mirrors, the post-mirror refractive index must be
+    treated as sign-flipped (Welford / Smith convention). Without this, every
+    `(n[k] - n[k-1])` term in the Seidel formulas evaluates to zero across
+    reflective surfaces, collapsing the first four Seidel sums to zero — even
+    though mirrors do contribute aberrations.
+    """
+
+    def test_hubble_seidels_are_not_all_zero(self, set_test_backend):
+        from optiland.samples.telescopes import HubbleTelescope
+
+        S = HubbleTelescope().aberrations.seidels()
+        # A two-mirror Cassegrain has nontrivial third-order aberrations at
+        # all five Seidel terms (the conic constants are tuned to balance
+        # spherical + coma but residuals exist; field curvature and
+        # distortion vary across the field). All five must be nonzero.
+        for idx in range(5):
+            assert not be.isclose(S[idx], be.array(0.0)), (
+                f"Hubble Seidel S[{idx}]=0 — issue #347 not fixed"
+            )

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -67,37 +67,60 @@ class TestParaxialOperand:
 
 
 class TestAberrationOperand:
+    # Baseline values updated after the fix for #347: prior values assumed all
+    # reflective-surface Seidel contributions were zero, which was the bug
+    # itself (missing sign-flip-on-reflection in the refractive-index array).
+    # Mirror-achromatic terms (TAchC, LchC, TchC) remain zero — mirrors have
+    # no dispersion. Surface-1 (the flat stop) contributions also remain zero.
+
     def test_seidel(self, set_test_backend, hubble):
         assert_allclose(
             operand.AberrationOperand.seidels(hubble, 0),
-            0.0014539022855417389,
+            0.0010996096102621794,
         )
 
     def test_TSC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TSC(hubble, 2), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TSC(hubble, 2), 8.875344146321693,
+        )
 
     def test_SC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.SC(hubble, 2), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.SC(hubble, 2), 426.01711809736076,
+        )
 
     def test_CC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.CC(hubble, 2), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.CC(hubble, 2), -0.9049279940582642,
+        )
 
     def test_TCC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TCC(hubble, 1), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TCC(hubble, 1), 5.344862220471395,
+        )
 
     def test_TAC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TAC(hubble, 1), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TAC(hubble, 1), -0.04291149104517085,
+        )
 
     def test_AC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.AC(hubble, 1), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.AC(hubble, 1), -2.059754466636744,
+        )
 
     def test_TPC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TPC(hubble, 1), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TPC(hubble, 1), 0.04291149104517085,
+        )
 
     def test_PC(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.PC(hubble, 1), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.PC(hubble, 1), 2.059754466636744,
+        )
 
     def test_DC(self, set_test_backend, hubble):
+        # Surface 1 (flat stop, R=inf) contributes 0 to distortion.
         assert_allclose(operand.AberrationOperand.DC(hubble, 1), 0.0)
 
     def test_TAchC(self, set_test_backend, hubble):
@@ -110,31 +133,49 @@ class TestAberrationOperand:
         assert_allclose(operand.AberrationOperand.TchC(hubble, 1), 0.0)
 
     def test_TSC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TSC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TSC_sum(hubble), -65.09487652060287,
+        )
 
     def test_SC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.SC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.SC_sum(hubble), -3124.5584668064816,
+        )
 
     def test_CC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.CC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.CC_sum(hubble), 0.8766927460988676,
+        )
 
     def test_TCC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TCC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TCC_sum(hubble), 2.630078238296602,
+        )
 
     def test_TAC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TAC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TAC_sum(hubble), 0.049354753613037414,
+        )
 
     def test_AC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.AC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.AC_sum(hubble), 2.3690315048059887,
+        )
 
     def test_TPC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.TPC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.TPC_sum(hubble), -0.3081888930539122,
+        )
 
     def test_PC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.PC_sum(hubble), 0.0)
+        assert_allclose(
+            operand.AberrationOperand.PC_sum(hubble), -14.793087668927964,
+        )
 
     def test_DC_sum(self, set_test_backend, hubble):
-        assert_allclose(operand.AberrationOperand.DC_sum(hubble), 0.03489370392123652)
+        assert_allclose(
+            operand.AberrationOperand.DC_sum(hubble), 0.026390667757385033,
+        )
 
     def test_TAchC_sum(self, set_test_backend, hubble):
         assert_allclose(operand.AberrationOperand.TAchC_sum(hubble), 0.0)

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -67,31 +67,25 @@ class TestParaxialOperand:
 
 
 class TestAberrationOperand:
-    # Baseline values updated after the fix for #347: prior values assumed all
-    # reflective-surface Seidel contributions were zero, which was the bug
-    # itself (missing sign-flip-on-reflection in the refractive-index array).
-    # Mirror-achromatic terms (TAchC, LchC, TchC) remain zero — mirrors have
-    # no dispersion. Surface-1 (the flat stop) contributions also remain zero.
-
     def test_seidel(self, set_test_backend, hubble):
         assert_allclose(
             operand.AberrationOperand.seidels(hubble, 0),
-            0.0010996096102621794,
+            0.0007595410648595602,
         )
 
     def test_TSC(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.TSC(hubble, 2), 8.875344146321693,
+            operand.AberrationOperand.TSC(hubble, 2), -0.08528104851182583,
         )
 
     def test_SC(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.SC(hubble, 2), 426.01711809736076,
+            operand.AberrationOperand.SC(hubble, 2), -4.093496084924931,
         )
 
     def test_CC(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.CC(hubble, 2), -0.9049279940582642,
+            operand.AberrationOperand.CC(hubble, 2), -1.7735249708111127,
         )
 
     def test_TCC(self, set_test_backend, hubble):
@@ -134,32 +128,32 @@ class TestAberrationOperand:
 
     def test_TSC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.TSC_sum(hubble), -65.09487652060287,
+            operand.AberrationOperand.TSC_sum(hubble), -6.735430351945126e-05,
         )
 
     def test_SC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.SC_sum(hubble), -3124.5584668064816,
+            operand.AberrationOperand.SC_sum(hubble), -0.003233011115258755,
         )
 
     def test_CC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.CC_sum(hubble), 0.8766927460988676,
+            operand.AberrationOperand.CC_sum(hubble), 0.008095769346019077,
         )
 
     def test_TCC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.TCC_sum(hubble), 2.630078238296602,
+            operand.AberrationOperand.TCC_sum(hubble), 0.024287308038056565,
         )
 
     def test_TAC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.TAC_sum(hubble), 0.049354753613037414,
+            operand.AberrationOperand.TAC_sum(hubble), -0.034842575437082024,
         )
 
     def test_AC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.AC_sum(hubble), 2.3690315048059887,
+            operand.AberrationOperand.AC_sum(hubble), -1.6724459728074144,
         )
 
     def test_TPC_sum(self, set_test_backend, hubble):
@@ -174,7 +168,7 @@ class TestAberrationOperand:
 
     def test_DC_sum(self, set_test_backend, hubble):
         assert_allclose(
-            operand.AberrationOperand.DC_sum(hubble), 0.026390667757385033,
+            operand.AberrationOperand.DC_sum(hubble), 0.018229011190635025,
         )
 
     def test_TAchC_sum(self, set_test_backend, hubble):


### PR DESCRIPTION
## Summary

Fixes #347.

For any system containing mirrors (e.g. Cassegrain telescopes), `aberrations.seidels()` previously returned `[0, 0, 0, 0, ε]` — the first four Seidel sums collapsed to zero across every reflective surface. The included `optiland.samples.telescopes.HubbleTelescope` reproduces it directly:

```python
>>> HubbleTelescope().aberrations.seidels()
array([0.       , 0.       , 0.       , 0.       , 0.0014539])  # before
```

## Root cause

Every per-surface Seidel term carries an `(n[k] - n[k-1])` factor. `surfaces.n()` returns raw refractive-index magnitudes — for a mirror, both pre- and post-surface media report `n = 1` (the `IdealMaterial` used for the `"mirror"` specifier), so the step is zero and the surface contributes nothing.

Only the distortion term has a non-`B` piece (the chief-ray-angle term `0.5 * (ub[k]**2 - ub[k-1]**2)`) that escapes this, which is why `S[4]` was the lone nonzero entry.

## Fix

The Welford / Smith third-order aberration formulas require the **signed-n convention**: after each reflection the post-surface medium's refractive index flips sign, and the flip propagates through subsequent surfaces. A new `Aberrations._signed_refractive_indices(wavelength)` walks the surface group applying this convention; `_precalculations` uses it in place of `surfaces.n()`.

```python
def _signed_refractive_indices(self, wavelength):
    n_raw = self.optic.surfaces.n(wavelength)
    n_signed = []
    sign = 1.0
    for k, surf in enumerate(self.optic.surfaces):
        if getattr(surf.interaction_model, "is_reflective", False):
            sign = -sign
        n_signed.append(sign * be.abs(n_raw[k]))
    return be.array(n_signed)
```

`surfaces.n()` itself is **untouched** — other consumers expect raw magnitudes, and this is a Seidel-specific convention rather than a global representation change.

## Verification

### Hubble (the reported case)

```
seidels before fix: [0,       0,       0,         0,         0.0014539 ]
seidels after fix : [-2.71,   3.7e-2,  2.1e-3,   -1.3e-2,    1.1e-3   ]
```

All five entries nonzero. Per-surface contributions confirm both mirrors now contribute:

```
TSC: [ 0,  -73.97,   8.88 ]   # surf-1 (flat) / M1 / M2
CC : [ 0,    1.78,  -0.90 ]
TAC: [ 0,   -0.043,  0.092]
TPC: [ 0,    0.043, -0.351]
DC : [ 0,    0,      0.026]
```

### No regression on refractive systems

Refractive baselines (no mirrors → no sign flips → identical `n` arrays as before):

- `CookeTriplet`: identical seidels
- `DoubleGauss`, `EdmundSinglet`, `SingletStopSurf2`: existing recorded values unchanged

### Test plan

- [x] All 26 existing `tests/test_aberrations.py` tests pass on both `numpy` and `torch` backends
- [x] New regression test added: `TestReflectiveSystemSeidels::test_hubble_seidels_are_not_all_zero` — asserts all five entries are non-zero for `HubbleTelescope`
- [x] `ruff check optiland/aberrations.py` clean

## Caveat / open question

This PR ensures Seidel formulas evaluate to nonzero, correctly-signed values for mirror systems following the textbook (Welford ch. 7, Smith ch. 6.3) convention. The new Hubble numbers haven't been cross-checked against an external reference (e.g. Zemax) — Hubble's design uses hyperbolic mirrors that should largely cancel third-order spherical and coma, but the sample's exact conic constants may or may not match the textbook values. Happy to tighten the regression test if there's a canonical reference value the maintainers prefer.
