### PR TITLE
Tilted/Non-Planar Object Ray Tracing Support

### DIFF
--- a/optiland/fields/field_types/angle.py
+++ b/optiland/fields/field_types/angle.py
@@ -46,15 +46,32 @@ class AngleField(BaseFieldDefinition):
             y0 = be.array(Py) * EPD / 2 * be.array(vy) + y
             z0 = be.full_like(Px, z)
         else:
-            z0 = optic.surfaces.positions[0]
-            x0 = -be.tan(be.radians(field_x)) * (EPL - z0)
-            y0 = -be.tan(be.radians(field_y)) * (EPL - z0)
+            dist_to_ep = EPL - optic.surfaces.positions[0]
+            x_local = be.atleast_1d(be.array(-be.tan(be.radians(field_x)) * dist_to_ep))
+            y_local = be.atleast_1d(be.array(-be.tan(be.radians(field_y)) * dist_to_ep))
+            z_local = obj.geometry.sag(x_local, y_local)
+
+            # Globalize the local coordinates
+            eff_translation, eff_rot_mat = obj.geometry.cs.get_effective_transform()
+
+            points_local = be.stack([x_local, y_local, z_local], axis=0)
+            if len(be.shape(points_local)) == 1:
+                points_local = be.unsqueeze_last(points_local)
+
+            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
+                eff_translation, (3, 1)
+            )
+
+            x0 = be.ravel(points_global[0, :])
+            y0 = be.ravel(points_global[1, :])
+            z0 = be.ravel(points_global[2, :])
+
             if be.size(x0) == 1:
-                x0 = be.full_like(Px, x0)
+                x0 = be.full_like(be.atleast_1d(Px), x0)
             if be.size(y0) == 1:
-                y0 = be.full_like(Px, y0)
+                y0 = be.full_like(be.atleast_1d(Px), y0)
             if be.size(z0) == 1:
-                z0 = be.full_like(Px, z0)
+                z0 = be.full_like(be.atleast_1d(Px), z0)
         return x0, y0, z0
 
     def get_paraxial_object_position(self, optic, Hy, y1, EPL):

--- a/optiland/fields/field_types/angle.py
+++ b/optiland/fields/field_types/angle.py
@@ -6,6 +6,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import optiland.backend as be
+from optiland.utils import globalize_coordinates
 
 from .base import BaseFieldDefinition
 
@@ -52,19 +53,7 @@ class AngleField(BaseFieldDefinition):
             z_local = obj.geometry.sag(x_local, y_local)
 
             # Globalize the local coordinates
-            eff_translation, eff_rot_mat = obj.geometry.cs.get_effective_transform()
-
-            points_local = be.stack([x_local, y_local, z_local], axis=0)
-            if len(be.shape(points_local)) == 1:
-                points_local = be.unsqueeze_last(points_local)
-
-            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
-                eff_translation, (3, 1)
-            )
-
-            x0 = be.ravel(points_global[0, :])
-            y0 = be.ravel(points_global[1, :])
-            z0 = be.ravel(points_global[2, :])
+            x0, y0, z0 = globalize_coordinates(obj, x_local, y_local, z_local)
 
             if be.size(x0) == 1:
                 x0 = be.full_like(be.atleast_1d(Px), x0)

--- a/optiland/fields/field_types/object_height.py
+++ b/optiland/fields/field_types/object_height.py
@@ -36,11 +36,27 @@ class ObjectHeightField(BaseFieldDefinition):
         self._validate_object_infinite(optic)
         obj = optic.object_surface
         max_field = optic.fields.max_field
-        field_x = max_field * Hx
-        field_y = max_field * Hy
-        x0 = be.array(field_x)
-        y0 = be.array(field_y)
-        z0 = obj.geometry.sag(x0, y0) + obj.geometry.cs.z
+        x_local = be.atleast_1d(be.array(max_field * Hx))
+        y_local = be.atleast_1d(be.array(max_field * Hy))
+        z_local = obj.geometry.sag(x_local, y_local)
+
+        # Globalize the local coordinates
+        eff_translation, eff_rot_mat = obj.geometry.cs.get_effective_transform()
+
+        # Handle both scalar and array inputs for field coordinates
+        # and ensure the points are correctly transformed to the global system.
+        points_local = be.stack([x_local, y_local, z_local], axis=0)
+        if len(be.shape(points_local)) == 1:
+            points_local = be.unsqueeze_last(points_local)
+
+        points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
+            eff_translation, (3, 1)
+        )
+
+        x0 = be.ravel(points_global[0, :])
+        y0 = be.ravel(points_global[1, :])
+        z0 = be.ravel(points_global[2, :])
+
         return x0, y0, z0
 
     def get_paraxial_object_position(self, optic, Hy, y1, EPL):

--- a/optiland/fields/field_types/object_height.py
+++ b/optiland/fields/field_types/object_height.py
@@ -6,6 +6,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import optiland.backend as be
+from optiland.utils import globalize_coordinates
 
 from .base import BaseFieldDefinition
 
@@ -41,21 +42,7 @@ class ObjectHeightField(BaseFieldDefinition):
         z_local = obj.geometry.sag(x_local, y_local)
 
         # Globalize the local coordinates
-        eff_translation, eff_rot_mat = obj.geometry.cs.get_effective_transform()
-
-        # Handle both scalar and array inputs for field coordinates
-        # and ensure the points are correctly transformed to the global system.
-        points_local = be.stack([x_local, y_local, z_local], axis=0)
-        if len(be.shape(points_local)) == 1:
-            points_local = be.unsqueeze_last(points_local)
-
-        points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
-            eff_translation, (3, 1)
-        )
-
-        x0 = be.ravel(points_global[0, :])
-        y0 = be.ravel(points_global[1, :])
-        z0 = be.ravel(points_global[2, :])
+        x0, y0, z0 = globalize_coordinates(obj, x_local, y_local, z_local)
 
         return x0, y0, z0
 

--- a/optiland/fields/field_types/paraxial_image_height.py
+++ b/optiland/fields/field_types/paraxial_image_height.py
@@ -6,6 +6,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import optiland.backend as be
+from optiland.utils import globalize_coordinates
 
 from .base import BaseFieldDefinition
 
@@ -61,21 +62,9 @@ class ParaxialImageHeightField(BaseFieldDefinition):
             z_local = optic.object_surface.geometry.sag(x_local, y_local)
 
             # Globalize the local coordinates
-            eff_translation, eff_rot_mat = (
-                optic.object_surface.geometry.cs.get_effective_transform()
+            x0, y0, z0 = globalize_coordinates(
+                optic.object_surface, x_local, y_local, z_local
             )
-
-            points_local = be.stack([x_local, y_local, z_local], axis=0)
-            if len(be.shape(points_local)) == 1:
-                points_local = be.unsqueeze_last(points_local)
-
-            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
-                eff_translation, (3, 1)
-            )
-
-            x0 = be.ravel(points_global[0, :])
-            y0 = be.ravel(points_global[1, :])
-            z0 = be.ravel(points_global[2, :])
 
             if be.size(x0) == 1:
                 x0 = be.full_like(be.atleast_1d(Px), x0)

--- a/optiland/fields/field_types/paraxial_image_height.py
+++ b/optiland/fields/field_types/paraxial_image_height.py
@@ -56,18 +56,33 @@ class ParaxialImageHeightField(BaseFieldDefinition):
         else:
             y_obj = y_obj_unit * (y_img_target / y_img_unit)
             x_obj = y_obj_unit * (x_img_target / y_img_unit)
-            x0 = x_obj
-            y0 = y_obj
-            z0 = (
-                optic.object_surface.geometry.sag(x0, y0)
-                + optic.object_surface.geometry.cs.z
+            x_local = be.atleast_1d(be.array(x_obj))
+            y_local = be.atleast_1d(be.array(y_obj))
+            z_local = optic.object_surface.geometry.sag(x_local, y_local)
+
+            # Globalize the local coordinates
+            eff_translation, eff_rot_mat = (
+                optic.object_surface.geometry.cs.get_effective_transform()
             )
+
+            points_local = be.stack([x_local, y_local, z_local], axis=0)
+            if len(be.shape(points_local)) == 1:
+                points_local = be.unsqueeze_last(points_local)
+
+            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
+                eff_translation, (3, 1)
+            )
+
+            x0 = be.ravel(points_global[0, :])
+            y0 = be.ravel(points_global[1, :])
+            z0 = be.ravel(points_global[2, :])
+
             if be.size(x0) == 1:
-                x0 = be.full_like(Px, x0)
+                x0 = be.full_like(be.atleast_1d(Px), x0)
             if be.size(y0) == 1:
-                y0 = be.full_like(Px, y0)
+                y0 = be.full_like(be.atleast_1d(Px), y0)
             if be.size(z0) == 1:
-                z0 = be.full_like(Px, z0)
+                z0 = be.full_like(be.atleast_1d(Px), z0)
         return x0, y0, z0
 
     def get_paraxial_object_position(self, optic, Hy, y1, EPL):

--- a/optiland/fields/field_types/real_image_height.py
+++ b/optiland/fields/field_types/real_image_height.py
@@ -6,6 +6,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import optiland.backend as be
+from optiland.utils import globalize_coordinates
 
 from .base import BaseFieldDefinition
 from .paraxial_image_height import ParaxialImageHeightField
@@ -199,21 +200,9 @@ class RealImageHeightField(BaseFieldDefinition):
             z_local = optic.object_surface.geometry.sag(x_local, y_local)
 
             # Globalize the local coordinates
-            eff_translation, eff_rot_mat = (
-                optic.object_surface.geometry.cs.get_effective_transform()
+            x0, y0, z0 = globalize_coordinates(
+                optic.object_surface, x_local, y_local, z_local
             )
-
-            points_local = be.stack([x_local, y_local, z_local], axis=0)
-            if len(be.shape(points_local)) == 1:
-                points_local = be.unsqueeze_last(points_local)
-
-            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
-                eff_translation, (3, 1)
-            )
-
-            x0 = be.ravel(points_global[0, :])
-            y0 = be.ravel(points_global[1, :])
-            z0 = be.ravel(points_global[2, :])
         return x0, y0, z0
 
     def get_paraxial_object_position(self, optic, Hy, y1, EPL):

--- a/optiland/fields/field_types/real_image_height.py
+++ b/optiland/fields/field_types/real_image_height.py
@@ -187,19 +187,33 @@ class RealImageHeightField(BaseFieldDefinition):
             z0 = be.full_like(Px, z)
         else:
             # val_x, val_y are object heights
-            x0 = val_x
-            y0 = val_y
+            x_local = be.atleast_1d(be.array(val_x))
+            y_local = be.atleast_1d(be.array(val_y))
 
             # Ensure correct shape
-            if be.size(x0) == 1:
-                x0 = be.full_like(Px, x0)
-            if be.size(y0) == 1:
-                y0 = be.full_like(Px, y0)
+            if be.size(x_local) == 1:
+                x_local = be.full_like(be.atleast_1d(Px), x_local)
+            if be.size(y_local) == 1:
+                y_local = be.full_like(be.atleast_1d(Px), y_local)
 
-            z0 = (
-                optic.object_surface.geometry.sag(x0, y0)
-                + optic.object_surface.geometry.cs.z
+            z_local = optic.object_surface.geometry.sag(x_local, y_local)
+
+            # Globalize the local coordinates
+            eff_translation, eff_rot_mat = (
+                optic.object_surface.geometry.cs.get_effective_transform()
             )
+
+            points_local = be.stack([x_local, y_local, z_local], axis=0)
+            if len(be.shape(points_local)) == 1:
+                points_local = be.unsqueeze_last(points_local)
+
+            points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
+                eff_translation, (3, 1)
+            )
+
+            x0 = be.ravel(points_global[0, :])
+            y0 = be.ravel(points_global[1, :])
+            z0 = be.ravel(points_global[2, :])
         return x0, y0, z0
 
     def get_paraxial_object_position(self, optic, Hy, y1, EPL):

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -321,3 +321,33 @@ def set_attr_by_path(obj: Any, path: str, value: Any) -> None:
         container[int(index)] = value
     else:
         setattr(current_obj, final_attr, value)
+
+
+def globalize_coordinates(surface, x_local, y_local, z_local):
+    """Transform local surface coordinates to global coordinates.
+
+    Args:
+        surface: The surface whose coordinate system is used for the
+            transformation.
+        x_local (BEArray): The local x-coordinates.
+        y_local (BEArray): The local y-coordinates.
+        z_local (BEArray): The local z-coordinates.
+
+    Returns:
+        tuple: (x_global, y_global, z_global) as flattened backend arrays.
+    """
+    eff_translation, eff_rot_mat = surface.geometry.cs.get_effective_transform()
+
+    points_local = be.stack([x_local, y_local, z_local], axis=0)
+    if len(be.shape(points_local)) == 1:
+        points_local = be.unsqueeze_last(points_local)
+
+    points_global = be.matmul(eff_rot_mat, points_local) + be.reshape(
+        eff_translation, (3, 1)
+    )
+
+    x_global = be.ravel(points_global[0, :])
+    y_global = be.ravel(points_global[1, :])
+    z_global = be.ravel(points_global[2, :])
+
+    return x_global, y_global, z_global

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -262,3 +262,67 @@ def test_get_starting_z_offset(set_test_backend):
 
     # check that the z offset is correct
     assert_allclose(z_offset, optic.paraxial.EPD())
+
+
+def test_tilted_object_origins(set_test_backend):
+    """Test ray origins for a tilted object surface across field types."""
+    import numpy as np
+
+    optic = Optic()
+    # 45 deg tilt around x-axis
+    rx = 45 * np.pi / 180
+    optic.surfaces.add(index=0, thickness=60, rx=rx)
+    optic.surfaces.add(index=1, thickness=10, is_stop=True)
+    optic.surfaces.add(index=2)
+
+    optic.set_aperture("EPD", 10)
+    optic.wavelengths.add(0.58756, is_primary=True)
+
+    # 1. Test ObjectHeightField
+    optic.fields.set_type("object_height")
+    optic.fields.add(y=10)
+
+    origins = optic.fields.field_definition.get_ray_origins(
+        optic, Hx=0, Hy=1, Px=0, Py=0, vx=0, vy=0
+    )
+
+    # Expected: y_global = 10 * cos(45), z_global = -60 + 10 * sin(45)
+    assert_allclose(origins[0], [0.0])
+    assert_allclose(origins[1], [10 * np.cos(rx)])
+    assert_allclose(origins[2], [-60 + 10 * np.sin(rx)])
+
+    # 2. Test AngleField (finite)
+    optic.fields.set_type("angle")
+    # dist_to_ep = EPL - pos[0] = 0 - (-60) = 60
+    # y_local = -tan(field_y) * 60.
+    # To get y_local = 10, we need tan(field_y) = -10/60 => field_y = arctan(-10/60)
+    angle_deg = np.degrees(np.arctan(-10/60))
+    optic.fields.fields = []
+    optic.fields.add(y=angle_deg)
+
+    origins = optic.fields.field_definition.get_ray_origins(
+        optic, Hx=0, Hy=-1, Px=0, Py=0, vx=0, vy=0
+    )
+    # y_local should be 10. y_global = 10 * cos(45), z_global = -60 + 10 * sin(45)
+    assert_allclose(origins[1], [10 * np.cos(rx)], atol=1e-7)
+    assert_allclose(origins[2], [-60 + 10 * np.sin(rx)], atol=1e-7)
+
+    # 3. Test ParaxialImageHeightField (finite)
+    optic.fields.set_type("paraxial_image_height")
+    # We set a field height that should correspond to some y_obj.
+    optic.fields.fields = []
+    optic.fields.add(y=10)
+
+    # Add a lens to make ParaxialImageHeightField happy
+    optic.surfaces.add(index=1, radius=50, thickness=5, material="N-BK7", is_stop=True)
+
+    origins = optic.fields.field_definition.get_ray_origins(
+        optic, Hx=0, Hy=1, Px=0, Py=0, vx=0, vy=0
+    )
+    # y0, z0 should reflect the tilt.
+    # We verify that (y0, z0) correctly maps back to a point with local z=0
+    # after rotating back by 45 degrees.
+    y_global = be.to_numpy(origins[1])
+    z_global = be.to_numpy(origins[2])
+    z_local = -(y_global) * np.sin(rx) + (z_global + 60) * np.cos(rx)
+    assert_allclose(z_local, [0.0], atol=1e-7)

--- a/tests/test_real_image_height.py
+++ b/tests/test_real_image_height.py
@@ -25,9 +25,9 @@ def create_simple_lens(infinite=True):
     optic.wavelengths.add(0.55)
 
     if infinite:
-        optic.object_surface.geometry.cs.z = -float("inf")
+        optic.object_surface.geometry.cs.z = be.array(-float("inf"))
     else:
-        optic.object_surface.geometry.cs.z = -200.0
+        optic.object_surface.geometry.cs.z = be.array(-200.0)
 
     optic.fields.set_type("real_image_height")
     optic.fields.add(y=5.0, x=0.0)  # Sets max_field to 5.0


### PR DESCRIPTION
### Tilted/Non-Planar Object Ray Tracing Support

This update introduces support for tilted, decentered, and non-planar object surfaces during ray generation. Key improvements include:

*   **Global Coordinate Transformation**: Ray origins are now accurately mapped from the local object surface geometry (including sag) to the global coordinate system using the surface's effective rotation and translation.
*   **Multi-Field Type Compatibility**: Transformation logic is integrated across `ObjectHeightField`, `AngleField`, `ParaxialImageHeightField`, and `RealImageHeightField`.
*   **Robust Backend Handling**: Implemented backend-agnostic dimension management to ensure consistent behavior across both NumPy and PyTorch execution paths.
*   **DRY Refactoring**: Centralized coordinate globalization logic into `optiland.utils.globalize_coordinates` for improved maintainability.
*   **Regression Coverage**: Added targeted unit tests verifying ray origin accuracy for tilted systems in `tests/test_field_types.py`.

Example:

```python
import numpy as np
from optiland.optic import Optic

lens = Optic()

lens.surfaces.add(index=0, thickness=60, rx = 45*np.pi/180, radius=50)
lens.surfaces.add(index=1, thickness=7, radius=50, material="N-SF6", is_stop=True)
lens.surfaces.add(index=2, thickness=50, radius=-50)
lens.surfaces.add(index=3)

lens.set_aperture(aperture_type="EPD", value=15)
lens.fields.set_type(field_type="object_height")
lens.fields.add(y=0)
lens.fields.add(y=10)

lens.wavelengths.add(value=0.55, is_primary=True)

# Visualize the system with tilted and non-planar object plane
lens.draw()
``` 
<img width="844" height="164" alt="image" src="https://github.com/user-attachments/assets/c3872b30-be7a-4136-85ec-b241a2ed0a01" />

