### PR TITLE
feat(zemax-reader): support PARAXIAL surfaces in the converter

### DIFF
--- a/optiland/fileio/zemax/reader/converter.py
+++ b/optiland/fileio/zemax/reader/converter.py
@@ -150,6 +150,9 @@ class ZemaxToOpticConverter(BaseOpticReader):
             if surf.get("aperture") is not None:
                 surface_params["aperture"] = surf["aperture"]
 
+            if surf["type"] == "paraxial":
+                surface_params["f"] = float(surf.get("param_0", 0.0))
+
             if surf["type"] == "toroidal":
                 surface_params["radius_y"] = surf["radius"]
                 surface_params["toroidal_coeffs_poly_y"] = coeffs
@@ -211,6 +214,9 @@ class ZemaxToOpticConverter(BaseOpticReader):
         if data.get("aperture") is not None:
             surface_params["aperture"] = data["aperture"]
 
+        if data["type"] == "paraxial":
+            surface_params["f"] = float(data.get("param_0", 0.0))
+
         if data["type"] == "toroidal":
             surface_params["toroidal_coeffs_poly_y"] = coefficients
         else:
@@ -251,7 +257,7 @@ class ZemaxToOpticConverter(BaseOpticReader):
             ValueError: If the surface type is not recognised.
         """
         surf_type = data["type"]
-        if surf_type in ("standard", "coordinate_break"):
+        if surf_type in ("standard", "coordinate_break", "paraxial"):
             return None
 
         if surf_type in ("even_asphere", "odd_asphere", "toroidal"):

--- a/tests/test_fileio/test_zemax_reader.py
+++ b/tests/test_fileio/test_zemax_reader.py
@@ -296,6 +296,57 @@ class TestZemaxToOpticConverterExtended:
         assert surf.geometry.R_yz == 50.0
         assert surf.geometry.R_rot == 60.0
 
+    def test_configure_surfaces_paraxial(self):
+        # PARAXIAL surface in zemax → 'paraxial' surface_type in Optiland.
+        # PARM 1 carries the focal length (Zemax convention).
+        zemax_data = {
+            "surfaces": {
+                0: {
+                    "type": "standard",
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "conic": 0.0,
+                    "material": "Air",
+                },
+                1: {
+                    "type": "paraxial",
+                    "radius": be.inf,
+                    "thickness": 100.0,
+                    "conic": 0.0,
+                    "param_0": 100.0,  # focal length
+                    "is_stop": True,
+                    "material": "Air",
+                },
+                2: {
+                    "type": "standard",
+                    "radius": be.inf,
+                    "thickness": 0.0,
+                    "conic": 0.0,
+                    "material": "Air",
+                },
+            },
+            "aperture": {"EPD": 10},
+            "fields": {"type": "angle", "x": [0], "y": [0]},
+            "wavelengths": {"primary_index": 0, "data": [0.55]},
+        }
+        optic = ZemaxToOpticConverter(zemax_data).convert()
+        # Surface 1 should be paraxial with f=100
+        paraxial_surf = optic.surfaces[1]
+        assert paraxial_surf.surface_type == "paraxial"
+        assert paraxial_surf.interaction_model.f == 100.0
+        # Paraxial EFL must trace to 100 mm
+        efl = float(optic.paraxial.f2())
+        assert_allclose(efl, 100.0, rtol=1e-6)
+
+    def test_configure_surface_coefficients_paraxial_returns_none(self):
+        converter = ZemaxToOpticConverter({
+            "surfaces": {},
+            "aperture": {"EPD": 10},
+            "fields": {"type": "angle", "x": [0], "y": [0]},
+            "wavelengths": {"primary_index": 0, "data": [0.55]},
+        })
+        assert converter._configure_surface_coefficients({"type": "paraxial"}) is None
+
     def test_configure_surfaces_infinity_thickness(self):
         zemax_data = {
             "surfaces": {

--- a/tests/test_fileio/test_zemax_reader.py
+++ b/tests/test_fileio/test_zemax_reader.py
@@ -338,6 +338,57 @@ class TestZemaxToOpticConverterExtended:
         efl = float(optic.paraxial.f2())
         assert_allclose(efl, 100.0, rtol=1e-6)
 
+    def test_configure_surfaces_paraxial_with_coordinate_break(self):
+        # A coordinate_break anywhere in the surface list forces the CB code
+        # path inside _configure_surfaces, which has its own paraxial f-injection
+        # block. Exercise it explicitly.
+        zemax_data = {
+            "surfaces": {
+                0: {
+                    "type": "standard",
+                    "radius": be.inf,
+                    "thickness": be.inf,
+                    "conic": 0.0,
+                    "material": "Air",
+                },
+                1: {
+                    "type": "coordinate_break",
+                    "param_0": 0.0,
+                    "param_1": 0.0,
+                    "thickness": 0.0,
+                    "param_2": 0.0,
+                    "param_3": 0.0,
+                    "param_4": 0.0,
+                    "conic": 0.0,
+                },
+                2: {
+                    "type": "paraxial",
+                    "radius": be.inf,
+                    "thickness": 50.0,
+                    "conic": 0.0,
+                    "param_0": 50.0,
+                    "is_stop": True,
+                    "material": "Air",
+                },
+                3: {
+                    "type": "standard",
+                    "radius": be.inf,
+                    "thickness": 0.0,
+                    "conic": 0.0,
+                    "material": "Air",
+                },
+            },
+            "aperture": {"EPD": 10},
+            "fields": {"type": "angle", "x": [0], "y": [0]},
+            "wavelengths": {"primary_index": 0, "data": [0.55]},
+        }
+        optic = ZemaxToOpticConverter(zemax_data).convert()
+        # Surface 1 in the resulting Optic corresponds to the paraxial element
+        # (surface 0 is the object plane, the coordinate_break is consumed).
+        paraxial_surf = optic.surfaces[1]
+        assert paraxial_surf.surface_type == "paraxial"
+        assert paraxial_surf.interaction_model.f == 50.0
+
     def test_configure_surface_coefficients_paraxial_returns_none(self):
         converter = ZemaxToOpticConverter({
             "surfaces": {},


### PR DESCRIPTION
## Summary

The Zemax parser already reads `PARAXIAL` surfaces and forwards them to the converter as `surface_type='paraxial'`, but `_configure_surface_coefficients` only whitelists `{standard, even_asphere, odd_asphere, coordinate_break, toroidal}` and raises:

```
ValueError: Unsupported Zemax surface type: paraxial
```

This aborts the entire `.zmx` load even when `PARAXIAL` is the only unsupported element — a common case in legacy / educational designs where a paraxial surface is used as a dummy stop or relay.

Optiland's `SurfaceFactory` + `GeometryFactory` already understand `'paraxial'` (thin-lens interaction model on a planar geometry, see #514); only the zmx-reader wasn't wired up.

## Changes

Three small additions in `optiland/fileio/zemax/reader/converter.py`:

1. `_configure_surface_coefficients`: `paraxial` joins the no-coefficient whitelist alongside `standard` / `coordinate_break` — it returns `None` instead of raising.
2. `_configure_surface` (non-CB path) and `_configure_surfaces` (CB path): inject `f = float(data['param_0'])` into `surface_params`. In Zemax, `PARM 1` on a `PARAXIAL` surface carries the focal length (paraxial convention).

## Test plan
- [x] Existing zmx-reader suite (30/30) still passes
- [x] New `test_configure_surface_coefficients_paraxial_returns_none` — defensive guard
- [x] New `test_configure_surfaces_paraxial` — end-to-end build of a `[plano, PARAXIAL f=100, image]` system, asserts `optic.paraxial.f2() == 100.0`
