### PR TITLE
Feat/material catalog registry

### DIFF
--- a/docs/api/api_materials.rst
+++ b/docs/api/api_materials.rst
@@ -22,6 +22,53 @@ This approach allows for accurate refractive index prediction across the visible
 
 For a detailed walkthrough of the model derivation and validation, please refer to the :doc:`Abbe Material Model Building <../references/AbbeMaterial_Model_Building>` notebook.
 
+Catalog-Scoped Lookup
+---------------------
+
+:class:`~optiland.materials.material.Material` accepts an optional ``catalog=``
+keyword (e.g. ``"schott"``, ``"ohara"``) to restrict lookup to a specific
+manufacturer.  The ``match_policy`` keyword controls fuzzy-match behavior:
+
+.. code-block:: python
+
+   from optiland.materials import Material, MatchPolicy
+
+   glass = Material("N-BK7", catalog="schott")              # exact-catalog lookup
+   glass = Material("N-BK7", match_policy=MatchPolicy.BEST) # silent fuzzy
+   glass = Material("N-BK7", catalog="schott",
+                    match_policy=MatchPolicy.STRICT)         # raise on non-exact
+
+Discovery and User Catalogs
+----------------------------
+
+:class:`~optiland.materials.catalog.MaterialCatalog` is a read-only view into
+any registered catalog:
+
+.. code-block:: python
+
+   from optiland.materials import MaterialCatalog
+
+   MaterialCatalog.available()              # list all catalogs
+   MaterialCatalog("schott").list()         # all Schott glass names
+   MaterialCatalog("schott").search("bk7") # fuzzy search within catalog
+   MaterialCatalog("schott").get("N-BK7")  # returns a Material instance
+
+:class:`~optiland.materials.registry.MaterialRegistry` is the global singleton
+that manages built-in and user-registered materials:
+
+.. code-block:: python
+
+   from optiland.materials import MaterialRegistry
+
+   reg = MaterialRegistry.instance()
+   reg.register("MyGlass", "internal", yaml_payload_dict)  # programmatic
+   reg.register_file("path/to/my_glass.yml")               # single YAML file
+   reg.load_catalog("~/.optiland/catalogs/my_company/")    # directory
+
+User YAML files must follow the `refractiveindex.info <https://refractiveindex.info>`_
+format.  Files placed under ``~/.optiland/catalogs/<catalog_name>/`` are
+auto-discovered on the first registry access.
+
 .. autosummary::
    :toctree: materials/
    :caption: Material Modules
@@ -30,3 +77,6 @@ For a detailed walkthrough of the model derivation and validation, please refer 
    materials.ideal
    materials.material_file
    materials.material
+   materials.material_spec
+   materials.catalog
+   materials.registry

--- a/docs/api/materials/materials.catalog.rst
+++ b/docs/api/materials/materials.catalog.rst
@@ -1,0 +1,11 @@
+materials.catalog
+=================
+
+.. automodule:: optiland.materials.catalog
+
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      MaterialCatalog

--- a/docs/api/materials/materials.material_spec.rst
+++ b/docs/api/materials/materials.material_spec.rst
@@ -1,0 +1,12 @@
+materials.material_spec
+=======================
+
+.. automodule:: optiland.materials.material_spec
+
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      MatchPolicy
+      MaterialSpec

--- a/docs/api/materials/materials.registry.rst
+++ b/docs/api/materials/materials.registry.rst
@@ -1,0 +1,11 @@
+materials.registry
+==================
+
+.. automodule:: optiland.materials.registry
+
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      MaterialRegistry

--- a/docs/examples/Tutorial_1d_Material_Database.ipynb
+++ b/docs/examples/Tutorial_1d_Material_Database.ipynb
@@ -372,9 +372,178 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion:\n",
+    "## 4. Catalog-Scoped Lookup (New in v2)\n",
     "\n",
-    "This tutorial showcased the key features of the Optiland material database. By leveraging `IdealMaterial`, `AbbeMaterial`, and `Material`, users can simulate a wide variety of optical systems with realistic material properties."
+    "Optiland now supports manufacturer-scoped material lookup via the catalog= keyword and a MatchPolicy enum. This eliminates ambiguity when the same glass name exists in multiple manufacturer databases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Schott N-BK7: Material(name='N-BK7', catalog='schott', λ=[0.30µm, 2.50µm])\n",
+      "n at 587.6 nm: 1.51680\n"
+     ]
+    }
+   ],
+   "source": [
+    "from optiland.materials import Material, MatchPolicy\n",
+    "\n",
+    "# Exact-catalog lookup � no fuzzy warning, deterministic result\n",
+    "nbk7_schott = Material(\"N-BK7\", catalog=\"schott\")\n",
+    "print(\"Schott N-BK7:\", nbk7_schott)\n",
+    "\n",
+    "# match_policy controls what happens on a fuzzy (non-exact) match:\n",
+    "# - MatchPolicy.WARN (default): emit OptilandMaterialWarning\n",
+    "# - MatchPolicy.BEST: silent best match\n",
+    "# - MatchPolicy.STRICT: raise ValueError\n",
+    "\n",
+    "nbk7_best = Material(\"N-BK7\", catalog=\"schott\", match_policy=MatchPolicy.BEST)\n",
+    "print(f\"n at 587.6 nm: {nbk7_best.n(0.5876).item():.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Catalog Discovery with MaterialCatalog\n",
+    "\n",
+    "The MaterialCatalog class provides a convenient discovery API: list all available catalogs, browse glass names, run fuzzy searches, and instantiate materials directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available catalogs (first 10): ['BGG', 'BK7', 'CaF', 'K108', 'SiO2', 'ZBLAN', 'ami', 'barberini', 'cdgm', 'corning']\n",
+      "Schott catalog: 158 glasses\n",
+      "First 10: ['BAFN6', 'BK7G18', 'F2', 'F2G12', 'F2HT', 'F5', 'FK3', 'FK5HTi', 'K10', 'K5G20']\n",
+      "Search 'bk7' in schott: ['BK7G18', 'N-BK7', 'N-BK7HT', 'N-BK7HTi', 'P-BK7']\n",
+      "N-BK7 refractive index at 550 nm: 1.51852\n"
+     ]
+    }
+   ],
+   "source": [
+    "from optiland.materials import MaterialCatalog\n",
+    "\n",
+    "# What manufacturer catalogs are available?\n",
+    "all_catalogs = MaterialCatalog.available()\n",
+    "print(\"Available catalogs (first 10):\", all_catalogs[:10])\n",
+    "\n",
+    "# List all glasses in the Schott catalog\n",
+    "schott = MaterialCatalog(\"schott\")\n",
+    "schott_glasses = schott.list()\n",
+    "print(f\"Schott catalog: {len(schott_glasses)} glasses\")\n",
+    "print(\"First 10:\", schott_glasses[:10])\n",
+    "\n",
+    "# Fuzzy search within the Schott catalog\n",
+    "results = schott.search(\"bk7\", n=5)\n",
+    "print(\"Search 'bk7' in schott:\", results)\n",
+    "\n",
+    "# Instantiate a glass directly from the catalog\n",
+    "glass = schott.get(\"N-BK7\")\n",
+    "print(f\"N-BK7 refractive index at 550 nm: {glass.n(0.55).item():.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Group-Based Discovery\n",
+    "\n",
+    "The refractiveindex.info database is organised into five top-level *groups*:\n",
+    "`glass` (manufacturer catalogs), `main` (elements and compounds), `organic` (polymers and organic\n",
+    "species), `other` (gases, alloys, minerals, …), and `3d` (metamaterials/plasmonics).\n",
+    "\n",
+    "`MaterialCatalog.available()` returns **glass manufacturer catalogs only** — the curated list that\n",
+    "optical designers actually browse. For the other groups, use\n",
+    "`MaterialRegistry.instance().list_catalogs(group=...)` directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. User-Defined Custom Materials\n",
+    "\n",
+    "Register your own materials — either programmatically for the current session, or persistently via YAML files placed under ~/.optiland/catalogs/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. User-Defined Custom Materials\n",
+    "\n",
+    "Register your own materials�either programmatically for the current session, or persistently via YAML files placed under ~/.optiland/catalogs/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. MaterialSpec — Type-Safe Material Specification\n",
+    "\n",
+    "MaterialSpec is a frozen, hashable dataclass that bundles all lookup parameters. Pass it to MaterialFactory or call to_material() directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. MaterialSpec � Type-Safe Material Specification\n",
+    "\n",
+    "MaterialSpec is a frozen, hashable dataclass that bundles all lookup parameters. Pass it to MaterialFactory or call to_material() directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This tutorial showcased the key features of the Optiland material database:\n",
+    "\n",
+    "- **IdealMaterial** — fixed refractive index and extinction coefficient.\n",
+    "- **AbbeMaterial** — dispersion models from Abbe number and nd.\n",
+    "- **Material** — lookup from the 3,200-entry refractiveindex.info database, now with:\n",
+    "  - `catalog=` for manufacturer-scoped lookup (schott, ohara, hikari, …)\n",
+    "  - `match_policy=` for fine-grained fuzzy-match control (BEST / WARN / STRICT)\n",
+    "  - `__repr__` showing resolved catalog and wavelength range\n",
+    "- **MaterialCatalog** — discovery API: `groups()` lists database groups; `available()` returns\n",
+    "  glass manufacturer catalogs only; `list()`, `search()`, and `get()` browse within a catalog.\n",
+    "- **MaterialRegistry** — global singleton; supports programmatic and file-based user catalogs;\n",
+    "  `list_catalogs(group=...)` enumerates species in non-glass groups.\n",
+    "- **MaterialSpec** — frozen, hashable parameter bundle for surface material assignment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "This tutorial showcased the key features of the Optiland material database:\n",
+    "\n",
+    "- **IdealMaterial** � fixed refractive index and extinction coefficient.\n",
+    "- **AbbeMaterial** � dispersion models from Abbe number and nd.\n",
+    "- **Material** � lookup from the 3,200-entry refractiveindex.info database, now with:\n",
+    "  - catalog= for manufacturer-scoped lookup (schott, ohara, hikari, �)\n",
+    "  - match_policy= for fine-grained fuzzy-match control (BEST / WARN / STRICT)\n",
+    "  - __repr__ showing resolved catalog and wavelength range\n",
+    "- **MaterialCatalog** � discovery API: list, search, and instantiate by catalog.\n",
+    "- **MaterialRegistry** � global singleton; supports programmatic and file-based user catalogs.\n",
+    "- **MaterialSpec** � frozen, hashable parameter bundle for surface material assignment.\n"
    ]
   }
  ],

--- a/docs/examples/Tutorial_1d_Material_Database.ipynb
+++ b/docs/examples/Tutorial_1d_Material_Database.ipynb
@@ -372,9 +372,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Catalog-Scoped Lookup (New in v2)\n",
+    "## 4. Catalog-Scoped Lookup\n",
     "\n",
-    "Optiland now supports manufacturer-scoped material lookup via the catalog= keyword and a MatchPolicy enum. This eliminates ambiguity when the same glass name exists in multiple manufacturer databases."
+    "Optiland now supports manufacturer-scoped material lookup via the `catalog=` keyword and a `MatchPolicy` enum. This eliminates ambiguity when the same glass name exists in multiple manufacturer databases."
    ]
   },
   {
@@ -394,7 +394,7 @@
    "source": [
     "from optiland.materials import Material, MatchPolicy\n",
     "\n",
-    "# Exact-catalog lookup � no fuzzy warning, deterministic result\n",
+    "# Exact-catalog lookup -- no fuzzy warning, deterministic result\n",
     "nbk7_schott = Material(\"N-BK7\", catalog=\"schott\")\n",
     "print(\"Schott N-BK7:\", nbk7_schott)\n",
     "\n",
@@ -425,9 +425,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Available catalogs (first 10): ['BGG', 'BK7', 'CaF', 'K108', 'SiO2', 'ZBLAN', 'ami', 'barberini', 'cdgm', 'corning']\n",
-      "Schott catalog: 158 glasses\n",
-      "First 10: ['BAFN6', 'BK7G18', 'F2', 'F2G12', 'F2HT', 'F5', 'FK3', 'FK5HTi', 'K10', 'K5G20']\n",
+      "Available catalogs (first 10): ['ami', 'barberini', 'cdgm', 'corning', 'hikari', 'hoya', 'lightpath', 'lzos', 'misc', 'nsg']\n",
+      "Schott catalog: 171 glasses\n",
+      "First 10: ['AF32ECO', 'B270', 'BAFN6', 'BK7G18', 'BOROFLOAT33', 'D263TECO', 'F2', 'F2G12', 'F2HT', 'F5']\n",
       "Search 'bk7' in schott: ['BK7G18', 'N-BK7', 'N-BK7HT', 'N-BK7HTi', 'P-BK7']\n",
       "N-BK7 refractive index at 550 nm: 1.51852\n"
      ]
@@ -465,9 +465,44 @@
     "`glass` (manufacturer catalogs), `main` (elements and compounds), `organic` (polymers and organic\n",
     "species), `other` (gases, alloys, minerals, …), and `3d` (metamaterials/plasmonics).\n",
     "\n",
-    "`MaterialCatalog.available()` returns **glass manufacturer catalogs only** — the curated list that\n",
+    "`MaterialCatalog.available()` returns **glass manufacturer catalogs only** - the curated list that\n",
     "optical designers actually browse. For the other groups, use\n",
     "`MaterialRegistry.instance().list_catalogs(group=...)` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Groups: ['3d', 'glass', 'main', 'organic', 'other']\n",
+      "Main group: 243 species (first 10): ['Ag', 'Ag3AsS3', 'AgBr', 'AgCl', 'AgGaS2', 'AgGaSe2', 'Al', 'Al2O3', 'AlAs', 'AlN']\n",
+      "Organic group: 61 species (first 10): ['(C10H8O4)n - polyethylene terephthalate', '(C16H14O3)n - polycarbonate', '(C2ClF3)n - polychlorotrifluoroethylene', '(C2H3Cl)n - polyvinyl chloride', '(C2H4)n - polyethylene', '(C2H4O)n - polyvinyl alcohol', '(C2H6OSi)n - polydimethylsiloxane', '(C37H24O6N2)n - polyetherimide', '(C3H4O2)n - polylactic acid', '(C5H8O2)n - poly(methyl methacrylate)']\n",
+      "Other group: 98 species (first 10): ['(C8H8)n-(C3H3N)m', '2D HOIP', '5CB', '5PCH', 'AgGaS2-AgInS2', 'Al-ZnO', 'AlAs-GaAs', 'AlN-Al2O3', 'AlSb-GaSb', 'Antheraea assamensis']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from optiland.materials import MaterialCatalog, MaterialRegistry\n",
+    "\n",
+    "# All top-level groups in the database\n",
+    "print(\"Groups:\", MaterialCatalog.groups())\n",
+    "\n",
+    "# Catalogs in the \"main\" group (elements and compounds)\n",
+    "main_cats = MaterialRegistry.instance().list_catalogs(group=\"main\")\n",
+    "print(f\"Main group: {len(main_cats)} species (first 10):\", main_cats[:10])\n",
+    "\n",
+    "# Catalogs in the \"organic\" group\n",
+    "org_cats = MaterialRegistry.instance().list_catalogs(group=\"organic\")\n",
+    "print(f\"Organic group: {len(org_cats)} species (first 10):\", org_cats[:10])\n",
+    "\n",
+    "# Catalogs in the \"other\" group\n",
+    "other_cats = MaterialRegistry.instance().list_catalogs(group=\"other\")\n",
+    "print(f\"Other group: {len(other_cats)} species (first 10):\", other_cats[:10])"
    ]
   },
   {
@@ -476,34 +511,99 @@
    "source": [
     "## 7. User-Defined Custom Materials\n",
     "\n",
-    "Register your own materials — either programmatically for the current session, or persistently via YAML files placed under ~/.optiland/catalogs/."
+    "Register your own materials, either programmatically for the current session, or persistently via YAML files placed under ~/.optiland/catalogs/."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LabGlass-A n at 550 nm: 1.5200\n",
+      "Custom catalog visible in list_catalogs: True\n"
+     ]
+    }
+   ],
    "source": [
-    "## 6. User-Defined Custom Materials\n",
+    "from optiland.materials import MaterialCatalog, MaterialRegistry, MatchPolicy\n",
     "\n",
-    "Register your own materials�either programmatically for the current session, or persistently via YAML files placed under ~/.optiland/catalogs/."
+    "# --- Programmatic registration (current session only) ---\n",
+    "custom_data = {\n",
+    "    \"REFERENCE\": \"My internal lab glass\",\n",
+    "    \"DATA\": [\n",
+    "        {\n",
+    "            \"type\": \"tabulated n\",\n",
+    "            \"data\": \"0.40 1.530\\n0.55 1.520\\n0.70 1.513\\n\",\n",
+    "        }\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "MaterialRegistry.instance().register(\"LabGlass-A\", \"internal\", custom_data)\n",
+    "lab_glass = MaterialCatalog(\"internal\").get(\"LabGlass-A\", match_policy=MatchPolicy.STRICT)\n",
+    "print(f\"LabGlass-A n at 550 nm: {lab_glass.n(0.55).item():.4f}\")\n",
+    "\n",
+    "# --- Persistent registration via YAML files ---\n",
+    "# Place YAML files under ~/.optiland/catalogs/<catalog_name>/<glass_name>.yml\n",
+    "# They are auto-discovered on the next process start.\n",
+    "in_list = 'internal' in MaterialRegistry.instance().list_catalogs()\n",
+    "print(\"Custom catalog visible in list_catalogs:\", in_list)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. MaterialSpec — Type-Safe Material Specification\n",
+    "## 8. MaterialSpec - Type-Safe Material Specification\n",
     "\n",
     "MaterialSpec is a frozen, hashable dataclass that bundles all lookup parameters. Pass it to MaterialFactory or call to_material() directly."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spec: MaterialSpec(name='N-BK7', catalog='schott', reference=None, match_policy=<MatchPolicy.BEST: 'best'>, min_wavelength=None, max_wavelength=None)\n",
+      "n at 550 nm: 1.51852\n",
+      "Serialized: {'name': 'N-BK7', 'catalog': 'schott', 'reference': None, 'match_policy': 'best', 'min_wavelength': None, 'max_wavelength': None}\n",
+      "Round-trip OK: MaterialSpec(name='N-BK7', catalog='schott', reference=None, match_policy=<MatchPolicy.BEST: 'best'>, min_wavelength=None, max_wavelength=None)\n",
+      "Spec set size: 2\n"
+     ]
+    }
+   ],
    "source": [
-    "## 7. MaterialSpec � Type-Safe Material Specification\n",
+    "from optiland.materials import MaterialSpec, MatchPolicy\n",
     "\n",
-    "MaterialSpec is a frozen, hashable dataclass that bundles all lookup parameters. Pass it to MaterialFactory or call to_material() directly."
+    "# Build a frozen, hashable spec -- use BEST to silently pick the best match\n",
+    "spec = MaterialSpec(\n",
+    "    name=\"N-BK7\",\n",
+    "    catalog=\"schott\",\n",
+    "    match_policy=MatchPolicy.BEST,\n",
+    ")\n",
+    "print(\"Spec:\", spec)\n",
+    "\n",
+    "# Resolve to a Material instance\n",
+    "mat = spec.to_material()\n",
+    "print(f\"n at 550 nm: {mat.n(0.55).item():.5f}\")\n",
+    "\n",
+    "# Serialize / deserialize round-trip\n",
+    "d = spec.to_dict()\n",
+    "print(\"Serialized:\", d)\n",
+    "spec2 = MaterialSpec.from_dict(d)\n",
+    "assert spec == spec2, \"Round-trip failed\"\n",
+    "print(\"Round-trip OK:\", spec2)\n",
+    "\n",
+    "# Specs are hashable -- safe to use as dict keys or in sets\n",
+    "spec_set = {spec, MaterialSpec(name=\"N-SF11\", catalog=\"schott\")}\n",
+    "print(f\"Spec set size: {len(spec_set)}\")"
    ]
   },
   {
@@ -525,25 +625,6 @@
     "- **MaterialRegistry** — global singleton; supports programmatic and file-based user catalogs;\n",
     "  `list_catalogs(group=...)` enumerates species in non-glass groups.\n",
     "- **MaterialSpec** — frozen, hashable parameter bundle for surface material assignment."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "This tutorial showcased the key features of the Optiland material database:\n",
-    "\n",
-    "- **IdealMaterial** � fixed refractive index and extinction coefficient.\n",
-    "- **AbbeMaterial** � dispersion models from Abbe number and nd.\n",
-    "- **Material** � lookup from the 3,200-entry refractiveindex.info database, now with:\n",
-    "  - catalog= for manufacturer-scoped lookup (schott, ohara, hikari, �)\n",
-    "  - match_policy= for fine-grained fuzzy-match control (BEST / WARN / STRICT)\n",
-    "  - __repr__ showing resolved catalog and wavelength range\n",
-    "- **MaterialCatalog** � discovery API: list, search, and instantiate by catalog.\n",
-    "- **MaterialRegistry** � global singleton; supports programmatic and file-based user catalogs.\n",
-    "- **MaterialSpec** � frozen, hashable parameter bundle for surface material assignment.\n"
    ]
   }
  ],

--- a/optiland/materials/__init__.py
+++ b/optiland/materials/__init__.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 from .abbe import AbbeMaterial, AbbeMaterialE
 from .base import BaseMaterial
+from .catalog import MaterialCatalog
 from .ideal import IdealMaterial
 from .material import Material
 from .material_file import MaterialFile
+from .material_spec import MatchPolicy, MaterialSpec
 from .material_utils import (
     downsample_glass_map,
     find_closest_glass,
@@ -18,6 +20,8 @@ from .material_utils import (
     plot_glass_map,
     plot_nk,
 )
+from .registry import MaterialRegistry
+from .warnings import OptilandMaterialWarning
 
 __all__ = [
     # From abbe.py
@@ -31,6 +35,11 @@ __all__ = [
     "Material",
     # From material_file.py
     "MaterialFile",
+    # From catalog.py
+    "MaterialCatalog",
+    # From material_spec.py
+    "MatchPolicy",
+    "MaterialSpec",
     # From material_utils.py
     "downsample_glass_map",
     "get_nd_vd",
@@ -39,4 +48,8 @@ __all__ = [
     "plot_glass_map",
     "plot_nk",
     find_closest_glass,
+    # From registry.py
+    "MaterialRegistry",
+    # From warnings.py
+    "OptilandMaterialWarning",
 ]

--- a/optiland/materials/catalog.py
+++ b/optiland/materials/catalog.py
@@ -7,6 +7,9 @@ Kramer Harrison, 2025
 
 from __future__ import annotations
 
+import pathlib
+from importlib import resources
+
 from optiland.materials.material_spec import MatchPolicy
 from optiland.materials.registry import MaterialRegistry
 
@@ -48,13 +51,16 @@ class MaterialCatalog:
     def available(cls) -> list[str]:
         """Return sorted list of glass manufacturer catalog names.
 
-        Only the ``'glass'`` group is returned — these are the manufacturer
-        books (Schott, Ohara, Hikari, etc.) that optical designers typically
-        browse.  To list species in other groups use
-        :meth:`~optiland.materials.registry.MaterialRegistry.list_catalogs`
+        The list is derived directly from the subdirectory names under the
+        built-in ``data-nk/glass/`` directory, which is the authoritative
+        source of manufacturer catalogs.  To list species in non-glass groups
+        use :meth:`~optiland.materials.registry.MaterialRegistry.list_catalogs`
         directly with ``group='main'``, ``'organic'``, or ``'other'``.
         """
-        return MaterialRegistry.instance().list_catalogs(group="glass")
+        glass_dir = pathlib.Path(
+            str(resources.files("optiland.database").joinpath("data-nk/glass"))
+        )
+        return sorted(d.name for d in glass_dir.iterdir() if d.is_dir())
 
     def list(self) -> list[str]:
         """Return sorted list of material names in this catalog."""

--- a/optiland/materials/catalog.py
+++ b/optiland/materials/catalog.py
@@ -1,0 +1,94 @@
+"""MaterialCatalog — read-only view into one catalog within the MaterialRegistry.
+
+Provides discovery and search UX for a specific manufacturer catalog.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+from optiland.materials.material_spec import MatchPolicy
+from optiland.materials.registry import MaterialRegistry
+
+
+class MaterialCatalog:
+    """Read-only view into one glass manufacturer catalog.
+
+    Usage::
+
+        MaterialCatalog.groups()  # ['3d', 'glass', 'main', 'organic', 'other']
+        MaterialCatalog.available()  # glass manufacturers only
+        MaterialCatalog("schott").list()  # glass names in catalog
+        MaterialCatalog("schott").search("bk7")  # substring search
+        MaterialCatalog("schott").get("N-BK7")  # instantiate material
+
+    Args:
+        catalog: Glass manufacturer catalog name (e.g. ``"schott"``, ``"ohara"``).
+    """
+
+    def __init__(self, catalog: str) -> None:
+        self._catalog = catalog
+
+    @classmethod
+    def groups(cls) -> list[str]:
+        """Return sorted list of all group names in the database.
+
+        Groups reflect the top-level organisation of the refractiveindex.info
+        database: ``'glass'`` (manufacturer catalogs), ``'main'`` (elements and
+        compounds), ``'organic'`` (organic species), ``'other'`` (miscellaneous),
+        and ``'3d'`` (metamaterials/plasmonics).
+
+        Non-glass groups are not exposed through :class:`MaterialCatalog`; use
+        :meth:`~optiland.materials.registry.MaterialRegistry.list_catalogs` with
+        a ``group`` argument to enumerate them.
+        """
+        return MaterialRegistry.instance().list_groups()
+
+    @classmethod
+    def available(cls) -> list[str]:
+        """Return sorted list of glass manufacturer catalog names.
+
+        Only the ``'glass'`` group is returned — these are the manufacturer
+        books (Schott, Ohara, Hikari, etc.) that optical designers typically
+        browse.  To list species in other groups use
+        :meth:`~optiland.materials.registry.MaterialRegistry.list_catalogs`
+        directly with ``group='main'``, ``'organic'``, or ``'other'``.
+        """
+        return MaterialRegistry.instance().list_catalogs(group="glass")
+
+    def list(self) -> list[str]:
+        """Return sorted list of material names in this catalog."""
+        return MaterialRegistry.instance().list_materials(self._catalog)
+
+    def search(self, query: str, n: int | None = None) -> list[str]:
+        """Return material names whose name contains ``query`` (case-insensitive).
+
+        Args:
+            query: Substring to search for within glass names.
+            n: Maximum number of results to return.  ``None`` returns all
+                matches.
+
+        Returns:
+            Sorted list of matching material names.
+        """
+        q = query.lower()
+        matches = [name for name in self.list() if q in name.lower()]
+        return matches[:n] if n is not None else matches
+
+    def get(self, name: str, match_policy: MatchPolicy = MatchPolicy.WARN) -> object:
+        """Instantiate a :class:`~optiland.materials.material.Material` from this
+        catalog.
+
+        Args:
+            name: Exact (or close) material name.
+            match_policy: Controls fuzzy-match behavior.
+
+        Returns:
+            A :class:`~optiland.materials.material.Material` instance.
+        """
+        from optiland.materials.material import Material
+
+        return Material(name, catalog=self._catalog, match_policy=match_policy)
+
+    def __repr__(self) -> str:
+        return f"MaterialCatalog('{self._catalog}')"

--- a/optiland/materials/material.py
+++ b/optiland/materials/material.py
@@ -18,6 +18,8 @@ from importlib import resources
 import pandas as pd
 
 from optiland.materials.material_file import MaterialFile
+from optiland.materials.material_spec import MatchPolicy
+from optiland.materials.registry import MaterialRegistry
 
 
 class Material(MaterialFile):
@@ -36,14 +38,20 @@ class Material(MaterialFile):
         reference (str, optional): The reference for the material, typically
             the manufacturer or author name. This helps disambiguate materials
             with similar names. Defaults to None.
-        robust_search (bool, optional): If True, the search attempts to find the
-            closest match even if an exact match isn't found, and returns the
-            first one based on similarity scoring. If False, an error is raised
-            if multiple close matches are found. Defaults to True.
+        robust_search (bool | None, optional): Deprecated. Use ``match_policy``
+            instead.  ``True`` maps to ``MatchPolicy.BEST``; ``False`` maps to
+            ``MatchPolicy.STRICT``.  Passing this argument emits a
+            ``DeprecationWarning``.  Defaults to None.
         min_wavelength (float, optional): Minimum wavelength in microns for
             filtering materials based on their valid range. Defaults to None.
         max_wavelength (float, optional): Maximum wavelength in microns for
             filtering materials based on their valid range. Defaults to None.
+        catalog (str, optional): Manufacturer catalog to restrict lookup to
+            (e.g. ``"schott"``, ``"ohara"``).  Keyword-only.  Defaults to None.
+        match_policy (MatchPolicy, optional): Controls fuzzy-match behavior.
+            ``"warn"`` (default) emits ``OptilandMaterialWarning`` on fuzzy
+            match; ``"best"`` silently takes the best match; ``"strict"``
+            raises ``ValueError`` on any non-exact match.  Keyword-only.
 
     Attributes:
         name (str): The name of the material.
@@ -56,27 +64,43 @@ class Material(MaterialFile):
 
     def __init__(
         self,
-        name,
-        reference=None,
-        robust_search=True,
-        min_wavelength=None,
-        max_wavelength=None,
+        name: str,
+        reference: str | None = None,
+        robust_search: bool | None = None,
+        min_wavelength: float | None = None,
+        max_wavelength: float | None = None,
         propagation_model=None,
-    ):
+        *,
+        catalog: str | None = None,
+        match_policy: MatchPolicy = MatchPolicy.WARN,
+    ) -> None:
         self.name = name
         self.reference = reference
-        self.robust = robust_search
         self.min_wavelength = min_wavelength
         self.max_wavelength = max_wavelength
+        self._catalog = catalog
+
+        # Handle deprecated robust_search parameter
+        if robust_search is not None:
+            warnings.warn(
+                "robust_search is deprecated; use match_policy='strict' or "
+                "match_policy='best'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            match_policy = MatchPolicy.BEST if robust_search else MatchPolicy.STRICT
+
+        self._match_policy = match_policy
+        # Keep self.robust for backward compatibility
+        self.robust = match_policy != MatchPolicy.STRICT
+
         file, self.material_data = self._retrieve_file()
         super().__init__(file, propagation_model=propagation_model)
 
     @classmethod
     def _load_dataframe(cls):
-        """Load the DataFrame if not yet loaded."""
-        if cls._df is None:
-            cls._df = pd.read_csv(cls._filename)
-        return cls._df
+        """Load the catalog DataFrame (delegates to MaterialRegistry)."""
+        return MaterialRegistry.instance().built_in_df
 
     @staticmethod
     def _levenshtein_distance(s1, s2):
@@ -176,15 +200,6 @@ class Material(MaterialFile):
         # Sort by similarity score in ascending order
         dfi = dfi.sort_values(by="similarity_score").reset_index(drop=True)
 
-        # Warning if no exact matches found
-        if dfi["similarity_score"].iloc[0] > 0:
-            warnings.warn(
-                f"No exact matches found for material {self.name}. "
-                "Material may be invalid.",
-                UserWarning,
-                stacklevel=2,
-            )
-
         return dfi
 
     def _raise_material_error(self, no_matches=False, multiple_matches=False):
@@ -210,14 +225,33 @@ class Material(MaterialFile):
         if self.reference:
             message += f" with reference {self.reference}"
 
+        if self._catalog:
+            message += f" in catalog '{self._catalog}'"
+
         if self.min_wavelength or self.max_wavelength:
             wavelength_range = f"({self.min_wavelength}, {self.max_wavelength}) µm"
             message += f" within wavelength range {wavelength_range}"
 
         raise ValueError(message)
 
+    @staticmethod
+    def _catalog_from_filename(filename: str) -> str:
+        """Extract the manufacturer catalog name from a material filename path.
+
+        The filename follows the pattern ``group/catalog/name.yml``, so the
+        manufacturer catalog is the second-to-last path segment.
+
+        Args:
+            filename: The filename string from the catalog DataFrame.
+
+        Returns:
+            str: The catalog name, or an empty string if not determinable.
+        """
+        parts = filename.split("/")
+        return parts[-2] if len(parts) >= 3 else ""
+
     def _retrieve_file(self):
-        """Retrieves the file path for the material based on the given criteria.
+        """Retrieve the file path for the material by delegating to MaterialRegistry.
 
         Returns:
             tuple[str, dict]: A tuple containing:
@@ -226,26 +260,17 @@ class Material(MaterialFile):
 
         Raises:
             ValueError: If no matches are found for the material.
-            ValueError: If multiple matches are found for the material.
+            ValueError: If match_policy is STRICT and the match is not exact.
 
         """
-        df = self._load_dataframe()
-        filtered_df = self._find_material_matches(df)
-
-        if filtered_df.empty:
-            self._raise_material_error(no_matches=True)
-
-        if len(filtered_df) > 1 and not self.robust:
-            self._raise_material_error(multiple_matches=True)
-
-        material_data = filtered_df.loc[0].to_dict()
-        filename = filtered_df.loc[0, "filename"]
-
-        full_filename = str(
-            resources.files("optiland.database").joinpath("data-nk", filename),
+        return MaterialRegistry.instance()._resolve_with_row(
+            self.name,
+            self._catalog,
+            self.reference,
+            self._match_policy,
+            self.min_wavelength,
+            self.max_wavelength,
         )
-
-        return full_filename, material_data
 
     def to_dict(self):
         """Converts the material to a dictionary.
@@ -260,7 +285,9 @@ class Material(MaterialFile):
             {
                 "name": self.name,
                 "reference": self.reference,
-                "robust_search": self.robust,
+                "catalog": self._catalog,
+                "match_policy": self._match_policy.value,
+                "robust_search": None,
                 "min_wavelength": self.min_wavelength,
                 "max_wavelength": self.max_wavelength,
             },
@@ -282,11 +309,42 @@ class Material(MaterialFile):
         if "name" not in data:
             raise ValueError("Missing required key: name")
 
+        # Warn when loading a file that has no catalog field (legacy format).
+        if "catalog" not in data or data["catalog"] is None:
+            warnings.warn(
+                f"Material '{data['name']}' loaded from file has no 'catalog' "
+                "field. Re-save the lens file to record catalog information. "
+                "Lookup will fall back to fuzzy search.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # Translate legacy robust_search to match_policy without triggering
+        # the deprecation warning — from_dict is the known old-format handler.
+        if "robust_search" in data and data["robust_search"] is not None:
+            rs = data["robust_search"]
+            match_policy = MatchPolicy.BEST if rs else MatchPolicy.STRICT
+        else:
+            mp_value = data.get("match_policy", MatchPolicy.WARN.value)
+            match_policy = MatchPolicy(mp_value)
+
         return cls(
             data["name"],
             data.get("reference", None),
-            data.get("robust_search", True),
+            None,  # robust_search=None avoids re-triggering DeprecationWarning
             data.get("min_wavelength", None),
             data.get("max_wavelength", None),
-            # propagation_model is handled by MaterialFile.from_dict
+            catalog=data.get("catalog", None),
+            match_policy=match_policy,
         )
+
+    def __repr__(self) -> str:
+        catalog_str = f", catalog='{self._catalog}'" if self._catalog else ""
+        wl_range = ""
+        md = getattr(self, "material_data", None)
+        if md:
+            min_wl = md.get("min_wavelength")
+            max_wl = md.get("max_wavelength")
+            if min_wl is not None and max_wl is not None:
+                wl_range = f", λ=[{min_wl:.2f}µm, {max_wl:.2f}µm]"
+        return f"Material(name='{self.name}'{catalog_str}{wl_range})"

--- a/optiland/materials/material_spec.py
+++ b/optiland/materials/material_spec.py
@@ -1,0 +1,97 @@
+"""MaterialSpec and MatchPolicy for the Optiland materials system.
+
+Provides the canonical type-safe spec for surface material assignment and a
+three-value enum controlling fuzzy-match behavior.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from optiland.materials.material import Material
+
+
+class MatchPolicy(str, enum.Enum):
+    """Controls how Material resolves ambiguous name matches.
+
+    Attributes:
+        BEST: Silent best-match; no warning emitted.
+        WARN: Warn when fuzzy match is used (edit distance > 0). Default.
+        STRICT: Raise ValueError on any non-exact or ambiguous match.
+    """
+
+    BEST = "best"
+    WARN = "warn"
+    STRICT = "strict"
+
+
+@dataclasses.dataclass(frozen=True)
+class MaterialSpec:
+    """Canonical, type-safe specification for a surface material.
+
+    Instances are frozen (hashable) and safe to cache.  Pass to
+    ``MaterialFactory.create()`` or call ``.to_material()`` directly.
+
+    Args:
+        name: Glass or material name (e.g. ``"N-BK7"``).
+        catalog: Manufacturer catalog to restrict lookup to (e.g. ``"schott"``).
+        reference: Citation string (passed through to ``Material``).
+        match_policy: Controls fuzzy-match warnings/errors.
+        min_wavelength: Minimum wavelength filter in microns.
+        max_wavelength: Maximum wavelength filter in microns.
+    """
+
+    name: str
+    catalog: str | None = None
+    reference: str | None = None
+    match_policy: MatchPolicy = MatchPolicy.WARN
+    min_wavelength: float | None = None
+    max_wavelength: float | None = None
+
+    def to_material(self) -> Material:
+        """Resolve this spec to a concrete Material instance."""
+        from optiland.materials.material import Material
+
+        return Material(
+            self.name,
+            reference=self.reference,
+            min_wavelength=self.min_wavelength,
+            max_wavelength=self.max_wavelength,
+            catalog=self.catalog,
+            match_policy=self.match_policy,
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize this spec to a plain dictionary."""
+        return {
+            "name": self.name,
+            "catalog": self.catalog,
+            "reference": self.reference,
+            "match_policy": self.match_policy.value,
+            "min_wavelength": self.min_wavelength,
+            "max_wavelength": self.max_wavelength,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> MaterialSpec:
+        """Deserialize a MaterialSpec from a plain dictionary.
+
+        Args:
+            data: Dictionary with at least a ``"name"`` key.
+
+        Returns:
+            MaterialSpec instance.
+        """
+        return cls(
+            name=data["name"],
+            catalog=data.get("catalog"),
+            reference=data.get("reference"),
+            match_policy=MatchPolicy(data.get("match_policy", MatchPolicy.WARN.value)),
+            min_wavelength=data.get("min_wavelength"),
+            max_wavelength=data.get("max_wavelength"),
+        )

--- a/optiland/materials/registry.py
+++ b/optiland/materials/registry.py
@@ -440,10 +440,12 @@ class MaterialRegistry:
         )
         mask = ~built_in.apply(
             lambda r: (
-                r["filename_no_ext"].lower(),
-                r.get("catalog_dir", "").lower(),
-            )
-            in shadow_keys,
+                (
+                    r["filename_no_ext"].lower(),
+                    r.get("catalog_dir", "").lower(),
+                )
+                in shadow_keys
+            ),
             axis=1,
         )
         self._combined_cache = pd.concat([built_in[mask], user_df], ignore_index=True)

--- a/optiland/materials/registry.py
+++ b/optiland/materials/registry.py
@@ -46,13 +46,17 @@ def _levenshtein(s1: str, s2: str) -> int:
     return dist[-1][-1]
 
 
-def _catalog_dir_from_filename(filename: str) -> str:
+def _catalog_dir_from_filename(filename: str, group: str = "") -> str:
     """Extract the manufacturer catalog name from a filename path.
 
-    Built-in filenames follow ``group/catalog/name.yml``; the catalog is the
-    second-to-last path segment.
+    For glass entries whose path starts with ``glass/``, the manufacturer is
+    always the second path segment (``glass/{manufacturer}/...``), regardless
+    of nesting depth.  For all other entries the species name is the
+    second-to-last segment.
     """
     parts = filename.replace("\\", "/").split("/")
+    if group.lower() == "glass" and parts[0].lower() == "glass" and len(parts) >= 3:
+        return parts[1]
     return parts[-2] if len(parts) >= 3 else ""
 
 
@@ -415,7 +419,10 @@ class MaterialRegistry:
             return self._combined_cache
 
         built_in = self.built_in_df.copy()
-        built_in["catalog_dir"] = built_in["filename"].apply(_catalog_dir_from_filename)
+        built_in["catalog_dir"] = built_in.apply(
+            lambda r: _catalog_dir_from_filename(r["filename"], r.get("group", "")),
+            axis=1,
+        )
 
         if not self._user_entries:
             self._combined_cache = built_in
@@ -505,7 +512,10 @@ class MaterialRegistry:
 
         # Check built-in
         bi = self.built_in_df
-        bi_catalog_dirs = bi["filename"].apply(_catalog_dir_from_filename).str.lower()
+        bi_catalog_dirs = bi.apply(
+            lambda r: _catalog_dir_from_filename(r["filename"], r.get("group", "")),
+            axis=1,
+        ).str.lower()
         if (
             (bi["filename_no_ext"].str.lower() == name_lower)
             & (bi_catalog_dirs == catalog_lower)

--- a/optiland/materials/registry.py
+++ b/optiland/materials/registry.py
@@ -1,0 +1,550 @@
+"""MaterialRegistry — global singleton for material lookup.
+
+Owns the complete lookup table for both built-in and user-registered materials.
+Wraps the existing ``catalog_nk.csv`` load and adds user catalog state.
+
+The hot path (built-in CSV lookup) adds zero overhead compared to PR1: the
+built-in DataFrame is lazy-loaded once per process and cached, exactly as before.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+import contextlib
+import pathlib
+import tempfile
+import warnings
+from importlib import resources
+
+import pandas as pd
+import yaml
+
+from optiland.materials.material_spec import MatchPolicy
+from optiland.materials.warnings import OptilandMaterialWarning
+
+_CATALOG_CSV = str(resources.files("optiland.database").joinpath("catalog_nk.csv"))
+_DATA_NK_DIR = str(resources.files("optiland.database").joinpath("data-nk"))
+
+
+def _levenshtein(s1: str, s2: str) -> int:
+    """Compute the Levenshtein edit distance between two strings."""
+    rows, cols = len(s1) + 1, len(s2) + 1
+    dist = [[0] * cols for _ in range(rows)]
+    for i in range(1, rows):
+        dist[i][0] = i
+    for j in range(1, cols):
+        dist[0][j] = j
+    for i in range(1, rows):
+        for j in range(1, cols):
+            cost = 0 if s1[i - 1] == s2[j - 1] else 1
+            dist[i][j] = min(
+                dist[i - 1][j] + 1,
+                dist[i][j - 1] + 1,
+                dist[i - 1][j - 1] + cost,
+            )
+    return dist[-1][-1]
+
+
+def _catalog_dir_from_filename(filename: str) -> str:
+    """Extract the manufacturer catalog name from a filename path.
+
+    Built-in filenames follow ``group/catalog/name.yml``; the catalog is the
+    second-to-last path segment.
+    """
+    parts = filename.replace("\\", "/").split("/")
+    return parts[-2] if len(parts) >= 3 else ""
+
+
+def _extract_wavelength_range(data: dict) -> tuple[float, float]:
+    """Extract min/max wavelength (µm) from a refractiveindex.info YAML payload."""
+    for item in data.get("DATA", []):
+        raw = item.get("data", "")
+        if not raw:
+            continue
+        wls: list[float] = []
+        for line in raw.strip().splitlines():
+            parts = line.split()
+            if parts:
+                with contextlib.suppress(ValueError):
+                    wls.append(float(parts[0]))
+        if wls:
+            return min(wls), max(wls)
+        # Formula entries may have a wavelength_range field
+        wl_range = item.get("wavelength_range", "")
+        if wl_range:
+            parts = str(wl_range).split()
+            if len(parts) >= 2:
+                try:
+                    return float(parts[0]), float(parts[1])
+                except ValueError:
+                    pass
+    return 0.0, 100.0
+
+
+class MaterialRegistry:
+    """Global singleton owning all material lookup state (built-in + user).
+
+    Access via :meth:`MaterialRegistry.instance`.  All methods are safe to
+    call from any thread after the first :meth:`instance` call completes.
+
+    On the first call to :meth:`instance` the registry checks for
+    ``~/.optiland/catalogs/``.  Each subdirectory there is ingested via
+    :meth:`load_catalog` as a best-effort operation; failures emit
+    :class:`~optiland.materials.warnings.OptilandMaterialWarning` and are
+    skipped, never raising.
+
+    Args:
+        None — instantiate via :meth:`instance`.
+    """
+
+    _instance: MaterialRegistry | None = None
+
+    def __init__(self) -> None:
+        self.__built_in_df: pd.DataFrame | None = None
+        self._user_entries: list[dict] = []
+        self._user_temp_files: list[str] = []
+        self._combined_cache: pd.DataFrame | None = None
+
+    @classmethod
+    def instance(cls) -> MaterialRegistry:
+        """Return the process-wide singleton, creating it on first call."""
+        if cls._instance is None:
+            obj = object.__new__(cls)
+            obj.__init__()  # type: ignore[misc]
+            cls._instance = obj
+            cls._instance._auto_discover()
+        return cls._instance
+
+    # ------------------------------------------------------------------
+    # Built-in catalog
+    # ------------------------------------------------------------------
+
+    @property
+    def built_in_df(self) -> pd.DataFrame:
+        """Lazy-loaded, cached built-in catalog DataFrame."""
+        if self.__built_in_df is None:
+            self.__built_in_df = pd.read_csv(_CATALOG_CSV)
+        return self.__built_in_df
+
+    # ------------------------------------------------------------------
+    # User catalog
+    # ------------------------------------------------------------------
+
+    def register(self, name: str, catalog: str, data: dict) -> None:
+        """Register a material programmatically.
+
+        The ``data`` dict must follow the refractiveindex.info YAML schema.
+        If a built-in or previously-registered entry with the same
+        ``(name, catalog)`` key exists, it is shadowed and a warning is
+        emitted.
+
+        Args:
+            name: Material name (used for lookup).
+            catalog: Catalog name (e.g. ``"internal"``).
+            data: refractiveindex.info YAML payload as a Python dict.
+        """
+        # Write data to a named temp file so MaterialFile can read it.
+        # NamedTemporaryFile with delete=False is used so the path persists
+        # after close; SIM115 does not apply here because we need tmp.name.
+        tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            delete=False,
+            suffix=".yml",
+            prefix=f"{name}_",
+            mode="w",
+            encoding="utf-8",
+        )
+        yaml.dump(data, tmp)
+        tmp.flush()
+        tmp.close()
+        self._user_temp_files.append(tmp.name)
+
+        min_wl, max_wl = _extract_wavelength_range(data)
+        reference = data.get("REFERENCE", catalog)
+
+        entry = {
+            "group": "user",
+            "category_name": catalog,
+            "category_name_full": catalog,
+            "reference": reference,
+            "name": name,
+            "filename": tmp.name,
+            "min_wavelength": min_wl,
+            "max_wavelength": max_wl,
+            "filename_no_ext": name,
+            "catalog_dir": catalog.lower(),
+        }
+
+        self._warn_if_shadow(name, catalog)
+        self._user_entries.append(entry)
+        self._combined_cache = None  # invalidate cache
+
+    def register_file(self, path: str | pathlib.Path) -> None:
+        """Load a single refractiveindex.info-format YAML file.
+
+        The catalog name is inferred from the parent directory name.  The
+        material name is the filename stem (without extension).
+
+        Args:
+            path: Path to a refractiveindex.info YAML file.
+        """
+        p = pathlib.Path(path)
+        name = p.stem
+        catalog = p.parent.name
+
+        with open(p, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        reference = data.get("REFERENCE", catalog) if data else catalog
+        min_wl, max_wl = _extract_wavelength_range(data or {})
+
+        entry = {
+            "group": "user",
+            "category_name": catalog,
+            "category_name_full": catalog,
+            "reference": reference,
+            "name": name,
+            "filename": str(p.resolve()),
+            "min_wavelength": min_wl,
+            "max_wavelength": max_wl,
+            "filename_no_ext": name,
+            "catalog_dir": catalog.lower(),
+        }
+
+        self._warn_if_shadow(name, catalog)
+        self._user_entries.append(entry)
+        self._combined_cache = None
+
+    def load_catalog(self, directory: str | pathlib.Path) -> None:
+        """Load all YAML files found in ``directory``.
+
+        If a ``catalog.csv`` index exists (same schema as the built-in
+        ``catalog_nk.csv``), it is used directly.  Otherwise each ``.yml``
+        file is registered via :meth:`register_file`.
+
+        Args:
+            directory: Path to a directory of refractiveindex.info YAML files.
+        """
+        d = pathlib.Path(directory)
+        if not d.is_dir():
+            return
+
+        index_csv = d / "catalog.csv"
+        if index_csv.exists():
+            extra_df = pd.read_csv(index_csv)
+            catalog_name = d.name.lower()
+            if "catalog_dir" not in extra_df.columns:
+                extra_df["catalog_dir"] = catalog_name
+
+            # Resolve relative filenames against the directory
+            def _resolve_fn(fn: str) -> str:
+                if pathlib.Path(fn).is_absolute():
+                    return fn
+                return str((d / fn).resolve())
+
+            extra_df["filename"] = extra_df["filename"].apply(_resolve_fn)
+            for _, row in extra_df.iterrows():
+                self._warn_if_shadow(row.get("name", ""), row.get("catalog_dir", ""))
+            self._user_entries.extend(extra_df.to_dict("records"))
+            self._combined_cache = None
+        else:
+            for yml_file in sorted(d.glob("*.yml")):
+                try:
+                    self.register_file(yml_file)
+                except Exception as exc:
+                    warnings.warn(
+                        f"Failed to load material file '{yml_file}': {exc}",
+                        OptilandMaterialWarning,
+                        stacklevel=2,
+                    )
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        name: str,
+        catalog: str | None = None,
+        reference: str | None = None,
+        match_policy: MatchPolicy = MatchPolicy.WARN,
+        min_wavelength: float | None = None,
+        max_wavelength: float | None = None,
+    ) -> str:
+        """Return the absolute path to the resolved YAML data file.
+
+        Args:
+            name: Material name to search for.
+            catalog: Manufacturer catalog to restrict lookup to.
+            reference: Citation string for further disambiguation.
+            match_policy: Controls fuzzy-match warnings/errors.
+            min_wavelength: Minimum wavelength filter (µm).
+            max_wavelength: Maximum wavelength filter (µm).
+
+        Returns:
+            Absolute path to the resolved YAML data file.
+
+        Raises:
+            ValueError: If no match found, or if ``match_policy='strict'``
+                and the match is not exact / is ambiguous.
+        """
+        path, _ = self._resolve_with_row(
+            name, catalog, reference, match_policy, min_wavelength, max_wavelength
+        )
+        return path
+
+    def _resolve_with_row(
+        self,
+        name: str,
+        catalog: str | None,
+        reference: str | None,
+        match_policy: MatchPolicy,
+        min_wavelength: float | None,
+        max_wavelength: float | None,
+    ) -> tuple[str, dict]:
+        """Resolve a material and return ``(path, metadata_row_dict)``."""
+        df = self._get_combined_df()
+
+        # If catalog given, pre-filter to that manufacturer
+        if catalog is not None:
+            catalog_lower = catalog.lower()
+            df = df[df["catalog_dir"].str.lower() == catalog_lower].copy()
+            if df.empty:
+                raise ValueError(f"No catalog '{catalog}' found in material database.")
+
+        filtered_df = self._find_matches(
+            df, name, reference, min_wavelength, max_wavelength
+        )
+
+        if filtered_df.empty:
+            msg = f"No matches found for material '{name}'"
+            if catalog:
+                msg += f" in catalog '{catalog}'"
+            if reference:
+                msg += f" with reference '{reference}'"
+            raise ValueError(msg)
+
+        best_score = filtered_df["similarity_score"].iloc[0]
+        n_exact = int((filtered_df["similarity_score"] == 0).sum())
+        ambiguous_exact = best_score == 0 and n_exact > 1
+
+        if best_score > 0 or ambiguous_exact:
+            if catalog is not None:
+                if match_policy == MatchPolicy.STRICT:
+                    raise ValueError(
+                        f"No exact match for '{name}' in catalog '{catalog}'. "
+                        "Use the exact name or a less strict match_policy."
+                    )
+                if best_score > 0:
+                    resolved = filtered_df.iloc[0]["name"]
+                    warnings.warn(
+                        f"No exact match for '{name}' in catalog '{catalog}'; "
+                        f"resolved to '{resolved}'. Use exact name to silence.",
+                        OptilandMaterialWarning,
+                        stacklevel=4,
+                    )
+            else:
+                if match_policy == MatchPolicy.STRICT:
+                    top = filtered_df.head(5)["name"].tolist()
+                    raise ValueError(
+                        f"No exact match for material '{name}'. "
+                        f"Top candidates: {top}. "
+                        "Use match_policy='warn' or 'best' for fuzzy matching."
+                    )
+                if match_policy == MatchPolicy.WARN and best_score > 0:
+                    resolved = filtered_df.iloc[0]["name"]
+                    warnings.warn(
+                        f"Material '{name}' resolved to '{resolved}' via fuzzy match.",
+                        OptilandMaterialWarning,
+                        stacklevel=4,
+                    )
+
+        row = filtered_df.iloc[0].to_dict()
+        filename = row["filename"]
+
+        # Built-in filenames are relative paths stored in CSV; resolve them.
+        if not pathlib.Path(filename).is_absolute():
+            full_path = str(pathlib.Path(_DATA_NK_DIR) / filename)
+        else:
+            full_path = filename
+
+        return full_path, row
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def list_groups(self) -> list[str]:
+        """Return sorted unique group names (built-in + user-registered)."""
+        df = self._get_combined_df()
+        return sorted(df["group"].dropna().unique().tolist())
+
+    def list_catalogs(self, group: str | None = None) -> list[str]:
+        """Return sorted unique catalog names, optionally filtered by group.
+
+        Args:
+            group: If given, restrict results to this group (e.g. ``'glass'``,
+                ``'main'``, ``'organic'``, ``'other'``, ``'3d'``).
+        """
+        df = self._get_combined_df()
+        if group is not None:
+            df = df[df["group"].str.lower() == group.lower()]
+        return sorted(df["catalog_dir"].dropna().unique().tolist())
+
+    def list_materials(self, catalog: str | None = None) -> list[str]:
+        """Return sorted material names, optionally filtered to one catalog.
+
+        Args:
+            catalog: If given, restrict results to this catalog name.
+
+        Returns:
+            Sorted list of material ``filename_no_ext`` values.
+        """
+        df = self._get_combined_df()
+        if catalog is not None:
+            df = df[df["catalog_dir"].str.lower() == catalog.lower()]
+        return sorted(df["filename_no_ext"].dropna().unique().tolist())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_combined_df(self) -> pd.DataFrame:
+        """Return built-in + user entries as a single DataFrame (cached)."""
+        if self._combined_cache is not None:
+            return self._combined_cache
+
+        built_in = self.built_in_df.copy()
+        built_in["catalog_dir"] = built_in["filename"].apply(_catalog_dir_from_filename)
+
+        if not self._user_entries:
+            self._combined_cache = built_in
+            return self._combined_cache
+
+        user_df = pd.DataFrame(self._user_entries)
+
+        # User entries shadow built-ins with the same (filename_no_ext, catalog_dir)
+        shadow_keys = set(
+            zip(
+                user_df["filename_no_ext"].str.lower(),
+                user_df["catalog_dir"].str.lower(),
+                strict=False,
+            )
+        )
+        mask = ~built_in.apply(
+            lambda r: (
+                r["filename_no_ext"].lower(),
+                r.get("catalog_dir", "").lower(),
+            )
+            in shadow_keys,
+            axis=1,
+        )
+        self._combined_cache = pd.concat([built_in[mask], user_df], ignore_index=True)
+        return self._combined_cache
+
+    def _find_matches(
+        self,
+        df: pd.DataFrame,
+        name: str,
+        reference: str | None,
+        min_wavelength: float | None,
+        max_wavelength: float | None,
+    ) -> pd.DataFrame:
+        """Find and score candidate rows for the given name."""
+        name_lower = name.lower()
+
+        dfi = df[
+            df["category_name"].str.lower().str.contains(name_lower, na=False)
+            | df["name"].str.lower().str.contains(name_lower, na=False)
+            | df["filename_no_ext"].str.lower().str.contains(name_lower, na=False)
+        ].copy()
+
+        if reference:
+            ref_lower = reference.lower()
+            dfi = dfi[
+                dfi["category_name"].str.lower().str.contains(ref_lower, na=False)
+                | dfi["category_name_full"]
+                .str.lower()
+                .str.contains(  # noqa: E501
+                    ref_lower, na=False
+                )
+                | dfi["reference"].str.lower().str.contains(ref_lower, na=False)
+                | dfi["name"].str.lower().str.contains(ref_lower, na=False)
+                | dfi["filename"].str.lower().str.contains(ref_lower, na=False)
+            ]
+
+        if min_wavelength is not None:
+            dfi = dfi[
+                (dfi["min_wavelength"] <= min_wavelength)
+                & (dfi["max_wavelength"] >= min_wavelength)
+            ]
+        if max_wavelength is not None:
+            dfi = dfi[
+                (dfi["min_wavelength"] <= max_wavelength)
+                & (dfi["max_wavelength"] >= max_wavelength)
+            ]
+
+        if dfi.empty:
+            return pd.DataFrame()
+
+        dfi["similarity_score"] = dfi.apply(
+            lambda row: min(
+                _levenshtein(name_lower, row["category_name"].lower()),
+                _levenshtein(name_lower, row["name"].lower()),
+                _levenshtein(name_lower, row["filename_no_ext"].lower()),
+            ),
+            axis=1,
+        )
+
+        return dfi.sort_values("similarity_score").reset_index(drop=True)
+
+    def _warn_if_shadow(self, name: str, catalog: str) -> None:
+        """Emit a warning if (name, catalog) shadows an existing entry."""
+        name_lower = name.lower()
+        catalog_lower = catalog.lower()
+
+        # Check built-in
+        bi = self.built_in_df
+        bi_catalog_dirs = bi["filename"].apply(_catalog_dir_from_filename).str.lower()
+        if (
+            (bi["filename_no_ext"].str.lower() == name_lower)
+            & (bi_catalog_dirs == catalog_lower)
+        ).any():
+            warnings.warn(
+                f"User-registered material '{name}' (catalog='{catalog}') "
+                "shadows a built-in entry.",
+                OptilandMaterialWarning,
+                stacklevel=3,
+            )
+            return
+
+        # Check existing user entries
+        for entry in self._user_entries:
+            if (
+                entry.get("filename_no_ext", "").lower() == name_lower
+                and entry.get("catalog_dir", "").lower() == catalog_lower
+            ):
+                warnings.warn(
+                    f"User-registered material '{name}' (catalog='{catalog}') "
+                    "overwrites a previously registered user entry.",
+                    OptilandMaterialWarning,
+                    stacklevel=3,
+                )
+                return
+
+    def _auto_discover(self) -> None:
+        """Check ~/.optiland/catalogs/ and ingest any subdirectories found."""
+        user_catalogs = pathlib.Path.home() / ".optiland" / "catalogs"
+        if not user_catalogs.is_dir():
+            return
+        for subdir in sorted(user_catalogs.iterdir()):
+            if subdir.is_dir():
+                try:
+                    self.load_catalog(subdir)
+                except Exception as exc:
+                    warnings.warn(
+                        f"Auto-discovery: failed to load catalog "
+                        f"'{subdir.name}': {exc}",
+                        OptilandMaterialWarning,
+                        stacklevel=1,
+                    )

--- a/optiland/materials/warnings.py
+++ b/optiland/materials/warnings.py
@@ -1,0 +1,12 @@
+"""Material warnings module.
+
+Defines custom warning classes for the Optiland materials system.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+
+class OptilandMaterialWarning(UserWarning):
+    """Emitted when a material lookup resolves via fuzzy match or has ambiguity."""

--- a/optiland/surfaces/factories/material_factory.py
+++ b/optiland/surfaces/factories/material_factory.py
@@ -11,6 +11,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 from optiland.materials import BaseMaterial, IdealMaterial, Material
+from optiland.materials.material_spec import MaterialSpec
 
 
 class MaterialFactory:
@@ -28,7 +29,8 @@ class MaterialFactory:
 
         Args:
             index (int): The index of the surface within the surface group.
-            material_spec (BaseMaterial | tuple | str): The material specification.
+            material_spec (BaseMaterial | MaterialSpec | tuple | str | dict):
+                The material specification.
             surface_group (SurfaceGroup): The surface group containing the surfaces.
 
         Returns:
@@ -60,12 +62,17 @@ class MaterialFactory:
         """Creates a post-surface material instance based on the given specification.
 
         Args:
-            material_spec (BaseMaterial | tuple | str): The material specification.
-                - If an instance of `BaseMaterial`, it is returned as-is.
-                - If a tuple, it is expected to contain (name, reference) and will
-                  be used to create a `Material` instance.
-                - If a string, it is interpreted as a material name, with special
-                  handling for 'air' and 'mirror'.
+            material_spec (BaseMaterial | MaterialSpec | tuple | str | dict):
+                The material specification.
+                - ``BaseMaterial`` instance: used directly.
+                - ``MaterialSpec`` dataclass: resolved via ``spec.to_material()``.
+                - ``dict``: deserialized via ``MaterialSpec.from_dict``.
+                - 2-tuple ``(name, reference)``: creates a ``Material``.
+                - 3-tuple ``(name, reference, catalog)``: creates a ``Material``
+                  with the given catalog.
+                - ``str`` ``"air"``: returns ``IdealMaterial(1.0, 0.0)``.
+                - ``str`` ``"mirror"``: returns ``None`` (handled upstream).
+                - ``str`` other: creates ``Material(name)``.
 
         Returns:
             BaseMaterial: The created material instance.
@@ -76,8 +83,24 @@ class MaterialFactory:
         if isinstance(material_spec, BaseMaterial):
             return material_spec
 
+        if isinstance(material_spec, MaterialSpec):
+            return material_spec.to_material()
+
+        if isinstance(material_spec, dict):
+            return MaterialSpec.from_dict(material_spec).to_material()
+
         if isinstance(material_spec, tuple):
-            return Material(name=material_spec[0], reference=material_spec[1])
+            if len(material_spec) == 2:
+                return Material(name=material_spec[0], reference=material_spec[1])
+            if len(material_spec) == 3:
+                return Material(
+                    name=material_spec[0],
+                    reference=material_spec[1],
+                    catalog=material_spec[2],
+                )
+            raise ValueError(
+                f"Material tuple must have 2 or 3 elements, got {len(material_spec)}"
+            )
 
         if isinstance(material_spec, str):
             if material_spec.lower() == "air":

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import warnings
 from importlib import resources
 from unittest.mock import MagicMock
 
@@ -626,13 +627,15 @@ class TestMaterial:
             )
 
     def test_non_robust_failure(self, set_test_backend):
-        # There are many materials matches for BK7. Without robust search,
-        # this should fail.
+        # There are many materials matches for BK7. Without robust search
+        # (now STRICT), multiple ambiguous exact matches raise ValueError.
         with pytest.raises(ValueError):
             materials.Material("BK7", robust_search=False)
 
-        # There are also many materials matches for BK7 with schott reference.
-        with pytest.raises(ValueError):
+        # With reference="schott", only one exact match remains (N-BK7), so
+        # STRICT policy resolves successfully — no longer raises.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             materials.Material("BK7", reference="schott", robust_search=False)
 
     def test_min_wavelength_filtering(self, set_test_backend):
@@ -671,7 +674,9 @@ class TestMaterial:
             "filename": material.filename,
             "name": "SF11",
             "reference": None,
-            "robust_search": True,
+            "catalog": None,
+            "match_policy": "warn",
+            "robust_search": None,
             "min_wavelength": None,
             "max_wavelength": None,
             "propagation_model": {"class": "HomogeneousPropagation"},

--- a/tests/test_materials_pr1.py
+++ b/tests/test_materials_pr1.py
@@ -1,0 +1,383 @@
+"""Tests for PR1 material system foundation:
+- catalog= kwarg on Material
+- MatchPolicy enum
+- robust_search deprecation
+- MaterialSpec dataclass
+- MaterialFactory extensions (MaterialSpec, 3-tuple, dict)
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from optiland.materials import (
+    Material,
+    MaterialSpec,
+    MatchPolicy,
+    OptilandMaterialWarning,
+)
+from optiland.surfaces.factories.material_factory import MaterialFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_factory():
+    """Return a fresh MaterialFactory with a minimal stub surface_group."""
+
+    class _FakeSurface:
+        material_post = Material("N-BK7", match_policy=MatchPolicy.BEST)
+
+    class _FakeSurfaceGroup:
+        num_surfaces = 2
+        surfaces = [_FakeSurface(), _FakeSurface()]
+
+    return MaterialFactory(), _FakeSurfaceGroup()
+
+
+# ---------------------------------------------------------------------------
+# catalog= kwarg
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogKwarg:
+    def test_material_catalog_kwarg_resolves(self):
+        """Material('N-BK7', catalog='schott') resolves without error."""
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        assert m.n(0.55) > 1.4
+
+    def test_material_catalog_exact_match_no_warning(self):
+        """Exact catalog match emits no OptilandMaterialWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK7", catalog="schott", match_policy=MatchPolicy.WARN)
+        material_warnings = [
+            x for x in w if issubclass(x.category, OptilandMaterialWarning)
+        ]
+        assert len(material_warnings) == 0
+
+    def test_material_catalog_invalid_raises(self):
+        """Unknown catalog raises ValueError."""
+        with pytest.raises(ValueError, match="No catalog"):
+            Material("N-BK7", catalog="nonexistent_catalog_xyz")
+
+    def test_material_catalog_ohara_resolves(self):
+        """catalog='ohara' restricts to Ohara glasses."""
+        m = Material("S-BSM2", catalog="ohara", match_policy=MatchPolicy.BEST)
+        assert m.n(0.55) > 1.0
+
+    def test_material_catalog_stored_as_attribute(self):
+        """The catalog value is stored on the instance."""
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        assert m._catalog == "schott"
+
+
+# ---------------------------------------------------------------------------
+# catalog fuzzy fallback warning
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogFuzzyWarning:
+    def test_material_catalog_fuzzy_warning_emitted(self):
+        """Fuzzy match within a catalog always emits OptilandMaterialWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # "N-BK" is not an exact match for "N-BK7" → fuzzy fallback
+            Material("N-BK", catalog="schott", match_policy=MatchPolicy.WARN)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) >= 1
+
+    def test_material_catalog_fuzzy_strict_raises(self):
+        """match_policy='strict' raises on fuzzy-within-catalog."""
+        with pytest.raises(ValueError, match="No exact match"):
+            Material("N-BK", catalog="schott", match_policy=MatchPolicy.STRICT)
+
+
+# ---------------------------------------------------------------------------
+# MatchPolicy without catalog
+# ---------------------------------------------------------------------------
+
+
+class TestMatchPolicy:
+    def test_match_policy_best_no_warning(self):
+        """match_policy='best' suppresses OptilandMaterialWarning on fuzzy match."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK", match_policy=MatchPolicy.BEST)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 0
+
+    def test_match_policy_warn_emits_warning(self):
+        """match_policy='warn' emits OptilandMaterialWarning on fuzzy match."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK", match_policy=MatchPolicy.WARN)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) >= 1
+
+    def test_match_policy_strict_raises(self):
+        """match_policy='strict' raises ValueError on fuzzy match."""
+        with pytest.raises(ValueError, match="No exact match"):
+            Material("N-BK", match_policy=MatchPolicy.STRICT)
+
+    def test_match_policy_string_values_accepted(self):
+        """MatchPolicy accepts string values ('best', 'warn', 'strict')."""
+        assert MatchPolicy("best") == MatchPolicy.BEST
+        assert MatchPolicy("warn") == MatchPolicy.WARN
+        assert MatchPolicy("strict") == MatchPolicy.STRICT
+
+    def test_exact_match_no_warning_default_policy(self):
+        """Exact name match never emits OptilandMaterialWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK7")
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 0
+
+
+# ---------------------------------------------------------------------------
+# robust_search deprecation
+# ---------------------------------------------------------------------------
+
+
+class TestRobustSearchDeprecated:
+    def test_robust_search_true_emits_deprecation(self):
+        """Passing robust_search=True emits DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK7", robust_search=True)
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) == 1
+        assert "robust_search" in str(dep_warns[0].message)
+
+    def test_robust_search_false_emits_deprecation(self):
+        """Passing robust_search=False emits DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # DeprecationWarning emitted before resolution; ValueError may also
+            # be raised for ambiguous matches under STRICT — ignore it here.
+            try:
+                Material("N-BK7", robust_search=False)
+            except ValueError:
+                pass
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) == 1
+
+    def test_robust_search_true_maps_to_best(self):
+        """robust_search=True maps to MatchPolicy.BEST (silent fuzzy)."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK", robust_search=True)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 0
+
+    def test_robust_search_false_maps_to_strict(self):
+        """robust_search=False maps to MatchPolicy.STRICT."""
+        with pytest.raises(ValueError, match="No exact match"):
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                Material("N-BK", robust_search=False)
+
+    def test_robust_search_none_no_deprecation(self):
+        """robust_search=None (default) does not emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("N-BK7")
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) == 0
+
+
+# ---------------------------------------------------------------------------
+# from_dict backward compat
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictCompat:
+    def test_from_dict_robust_search_true(self):
+        """Old dict with robust_search=True: no robust_search DeprecationWarning,
+        but a catalog DeprecationWarning is expected (PR2 behavior)."""
+        data = {
+            "type": "Material",
+            "name": "N-BK7",
+            "reference": None,
+            "robust_search": True,
+            "min_wavelength": None,
+            "max_wavelength": None,
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m = Material.from_dict(data)
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        # One DeprecationWarning for missing catalog field (PR2); none for robust_search
+        assert all("catalog" in str(dw.message) for dw in dep_warns)
+        assert m.n(0.55) > 1.4
+
+    def test_from_dict_robust_search_false(self):
+        """Old dict with robust_search=False loads as STRICT policy."""
+        # Use a glass with a unique exact match so STRICT doesn't raise here.
+        data = {
+            "type": "Material",
+            "name": "ZERODUR",
+            "reference": None,
+            "robust_search": False,
+            "min_wavelength": None,
+            "max_wavelength": None,
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m = Material.from_dict(data)
+        assert m._match_policy == MatchPolicy.STRICT
+
+    def test_from_dict_match_policy_field(self):
+        """New dict with match_policy and catalog fields loads without warnings."""
+        data = {
+            "type": "Material",
+            "name": "N-BK7",
+            "catalog": "schott",
+            "reference": None,
+            "match_policy": "best",
+            "min_wavelength": None,
+            "max_wavelength": None,
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m = Material.from_dict(data)
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) == 0
+        assert m._match_policy == MatchPolicy.BEST
+
+    def test_from_dict_catalog_field(self):
+        """New dict with catalog field loads correctly."""
+        data = {
+            "type": "Material",
+            "name": "N-BK7",
+            "catalog": "schott",
+            "reference": None,
+            "match_policy": "warn",
+            "min_wavelength": None,
+            "max_wavelength": None,
+        }
+        m = Material.from_dict(data)
+        assert m._catalog == "schott"
+
+
+# ---------------------------------------------------------------------------
+# MaterialSpec
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialSpec:
+    def test_material_spec_to_material_returns_material(self):
+        """MaterialSpec.to_material() returns a Material instance."""
+        spec = MaterialSpec(name="N-BK7", catalog="schott")
+        m = spec.to_material()
+        assert isinstance(m, Material)
+
+    def test_material_spec_to_material_correct_index(self):
+        """MaterialSpec.to_material() resolves to correct glass."""
+        spec = MaterialSpec(name="N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        m = spec.to_material()
+        assert abs(m.n(0.5876) - 1.5168) < 0.001
+
+    def test_material_spec_frozen(self):
+        """MaterialSpec is immutable (frozen dataclass)."""
+        spec = MaterialSpec(name="N-BK7")
+        with pytest.raises((AttributeError, TypeError)):
+            spec.name = "other"  # type: ignore[misc]
+
+    def test_material_spec_hashable(self):
+        """MaterialSpec can be used as a dict key / in a set."""
+        spec1 = MaterialSpec(name="N-BK7", catalog="schott")
+        spec2 = MaterialSpec(name="N-BK7", catalog="schott")
+        assert hash(spec1) == hash(spec2)
+        s = {spec1, spec2}
+        assert len(s) == 1
+
+    def test_material_spec_to_dict(self):
+        """MaterialSpec.to_dict() round-trips correctly."""
+        spec = MaterialSpec(
+            name="N-BK7",
+            catalog="schott",
+            match_policy=MatchPolicy.BEST,
+        )
+        d = spec.to_dict()
+        assert d["name"] == "N-BK7"
+        assert d["catalog"] == "schott"
+        assert d["match_policy"] == "best"
+
+    def test_material_spec_from_dict(self):
+        """MaterialSpec.from_dict() deserializes correctly."""
+        d = {
+            "name": "N-BK7",
+            "catalog": "schott",
+            "match_policy": "warn",
+        }
+        spec = MaterialSpec.from_dict(d)
+        assert spec.name == "N-BK7"
+        assert spec.catalog == "schott"
+        assert spec.match_policy == MatchPolicy.WARN
+
+    def test_material_spec_from_dict_defaults(self):
+        """MaterialSpec.from_dict() applies sensible defaults for missing keys."""
+        spec = MaterialSpec.from_dict({"name": "N-BK7"})
+        assert spec.catalog is None
+        assert spec.match_policy == MatchPolicy.WARN
+
+
+# ---------------------------------------------------------------------------
+# MaterialFactory extensions
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialFactoryExtensions:
+    def test_factory_accepts_material_spec(self):
+        """MaterialFactory accepts MaterialSpec input."""
+        factory, sg = _make_factory()
+        spec = MaterialSpec(name="N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        mat_pre, mat_post = factory.create(1, spec, sg)
+        assert mat_post is not None
+        assert mat_post.n(0.55) > 1.4
+
+    def test_factory_accepts_3_tuple(self):
+        """MaterialFactory accepts (name, reference, catalog) 3-tuple."""
+        factory, sg = _make_factory()
+        mat_pre, mat_post = factory.create(1, ("N-BK7", None, "schott"), sg)
+        assert mat_post is not None
+        assert mat_post.n(0.55) > 1.4
+
+    def test_factory_accepts_2_tuple_unchanged(self):
+        """Existing 2-tuple (name, reference) still works."""
+        factory, sg = _make_factory()
+        mat_pre, mat_post = factory.create(1, ("N-BK7", None), sg)
+        assert mat_post is not None
+
+    def test_factory_accepts_dict(self):
+        """MaterialFactory accepts a dict (MaterialSpec.from_dict path)."""
+        factory, sg = _make_factory()
+        spec_dict = {
+            "name": "N-BK7",
+            "catalog": "schott",
+            "match_policy": "best",
+        }
+        mat_pre, mat_post = factory.create(1, spec_dict, sg)
+        assert mat_post is not None
+        assert mat_post.n(0.55) > 1.4
+
+    def test_factory_3_tuple_invalid_length_raises(self):
+        """MaterialFactory raises on a tuple with invalid length."""
+        factory, sg = _make_factory()
+        with pytest.raises(ValueError, match="2 or 3 elements"):
+            factory.create(1, ("a", "b", "c", "d"), sg)
+
+    def test_factory_accepts_material_spec_instance_directly(self):
+        """MaterialFactory uses BaseMaterial instance directly."""
+        from optiland.materials import IdealMaterial
+
+        factory, sg = _make_factory()
+        ideal = IdealMaterial(n=1.5, k=0.0)
+        mat_pre, mat_post = factory.create(1, ideal, sg)
+        assert mat_post is ideal

--- a/tests/test_materials_pr2.py
+++ b/tests/test_materials_pr2.py
@@ -1,0 +1,458 @@
+"""Tests for PR2 material system features:
+- MaterialRegistry singleton, list_catalogs, list_materials
+- Programmatic registration (register / register_file / load_catalog)
+- Conflict / shadow warnings
+- MaterialCatalog discovery UX
+- Serialization: to_dict includes catalog/match_policy; from_dict warns on missing catalog
+- Round-trip serialize → deserialize
+- Material.__repr__
+"""
+
+from __future__ import annotations
+
+import pathlib
+import textwrap
+import warnings
+
+import pytest
+import yaml
+
+from optiland.materials import (
+    Material,
+    MaterialCatalog,
+    MaterialRegistry,
+    MatchPolicy,
+    OptilandMaterialWarning,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_registry() -> MaterialRegistry:
+    """Return a new, isolated registry instance for test isolation."""
+    reg = object.__new__(MaterialRegistry)
+    reg.__init__()  # type: ignore[misc]
+    return reg
+
+
+def _minimal_yaml_data(name: str = "TestGlass") -> dict:
+    """Minimal refractiveindex.info-format YAML payload (tabulated n)."""
+    return {
+        "REFERENCE": f"Test reference for {name}",
+        "DATA": [
+            {
+                "type": "tabulated n",
+                "data": textwrap.dedent(
+                    """\
+                    0.4 1.52
+                    0.55 1.51
+                    0.7 1.505
+                    """
+                ),
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registry — singleton
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySingleton:
+    def test_instance_returns_same_object(self):
+        """Repeated .instance() calls return the same registry."""
+        r1 = MaterialRegistry.instance()
+        r2 = MaterialRegistry.instance()
+        assert r1 is r2
+
+    def test_built_in_df_non_empty(self):
+        """built_in_df contains the built-in catalog entries."""
+        df = MaterialRegistry.instance().built_in_df
+        assert len(df) > 1000
+
+    def test_built_in_df_has_expected_columns(self):
+        """built_in_df has the expected schema columns."""
+        df = MaterialRegistry.instance().built_in_df
+        for col in ["name", "filename", "filename_no_ext", "category_name", "reference"]:
+            assert col in df.columns
+
+
+# ---------------------------------------------------------------------------
+# Registry — list_catalogs / list_materials
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryDiscovery:
+    def test_list_catalogs_non_empty(self):
+        """list_catalogs returns a non-empty sorted list."""
+        cats = MaterialRegistry.instance().list_catalogs()
+        assert isinstance(cats, list)
+        assert len(cats) > 0
+
+    def test_list_catalogs_includes_expected(self):
+        """list_catalogs includes well-known manufacturer catalogs."""
+        cats = MaterialRegistry.instance().list_catalogs()
+        for expected in ("schott", "ohara", "hikari"):
+            assert expected in cats, f"Missing catalog: {expected}"
+
+    def test_list_catalogs_sorted(self):
+        """list_catalogs returns values in sorted order."""
+        cats = MaterialRegistry.instance().list_catalogs()
+        assert cats == sorted(cats)
+
+    def test_list_materials_no_filter(self):
+        """list_materials() with no filter returns all materials."""
+        mats = MaterialRegistry.instance().list_materials()
+        assert len(mats) > 1000
+
+    def test_list_materials_filtered(self):
+        """list_materials('schott') returns only Schott glasses."""
+        mats = MaterialRegistry.instance().list_materials("schott")
+        assert len(mats) > 10
+        assert "N-BK7" in mats
+
+    def test_list_materials_sorted(self):
+        """list_materials returns values in sorted order."""
+        mats = MaterialRegistry.instance().list_materials("schott")
+        assert mats == sorted(mats)
+
+
+# ---------------------------------------------------------------------------
+# Registry — programmatic registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryProgrammatic:
+    def test_register_resolves(self):
+        """Programmatically registered material resolves via resolve()."""
+        reg = _fresh_registry()
+        data = _minimal_yaml_data("MyGlass")
+        reg.register("MyGlass", "internal", data)
+        path = reg.resolve("MyGlass", catalog="internal", match_policy=MatchPolicy.STRICT)
+        assert pathlib.Path(path).exists()
+
+    def test_register_material_returns_correct_n(self):
+        """Programmatically registered material yields correct refractive index."""
+        reg = _fresh_registry()
+        data = _minimal_yaml_data("FlatGlass")
+        reg.register("FlatGlass", "internal", data)
+
+        path, _ = reg._resolve_with_row(
+            "FlatGlass", "internal", None, MatchPolicy.STRICT, None, None
+        )
+        from optiland.materials.material_file import MaterialFile
+        mf = MaterialFile(path)
+        n = mf.n(0.55)
+        assert abs(float(n) - 1.51) < 0.01
+
+    def test_register_shadow_builtin_warns(self):
+        """Shadowing a built-in entry emits OptilandMaterialWarning at register time."""
+        reg = _fresh_registry()
+        data = _minimal_yaml_data("N-BK7")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg.register("N-BK7", "schott", data)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 1
+        assert "shadows" in str(mat_warns[0].message).lower()
+
+    def test_register_shadow_user_warns(self):
+        """Overwriting an existing user entry emits OptilandMaterialWarning."""
+        reg = _fresh_registry()
+        data = _minimal_yaml_data("MyGlass")
+        reg.register("MyGlass", "internal", data)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg.register("MyGlass", "internal", data)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 1
+
+    def test_same_name_different_catalog_no_conflict(self):
+        """Same name in different catalogs coexist without warnings."""
+        reg = _fresh_registry()
+        data = _minimal_yaml_data("SharedName")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg.register("SharedName", "cat1", data)
+            reg.register("SharedName", "cat2", data)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry — register_file
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryRegisterFile:
+    def test_register_file_resolves(self, tmp_path):
+        """register_file() loads a YAML file and makes it resolvable."""
+        catalog_dir = tmp_path / "my_catalog"
+        catalog_dir.mkdir()
+        glass_file = catalog_dir / "TestGlass.yml"
+        glass_file.write_text(
+            yaml.dump(_minimal_yaml_data("TestGlass")), encoding="utf-8"
+        )
+
+        reg = _fresh_registry()
+        reg.register_file(glass_file)
+        path = reg.resolve("TestGlass", catalog="my_catalog", match_policy=MatchPolicy.STRICT)
+        assert pathlib.Path(path).exists()
+
+    def test_register_file_catalog_from_parent_dir(self, tmp_path):
+        """Catalog name is inferred from the parent directory of the YAML file."""
+        catalog_dir = tmp_path / "special_cat"
+        catalog_dir.mkdir()
+        glass_file = catalog_dir / "GlassX.yml"
+        glass_file.write_text(yaml.dump(_minimal_yaml_data("GlassX")), encoding="utf-8")
+
+        reg = _fresh_registry()
+        reg.register_file(glass_file)
+        assert "special_cat" in reg.list_catalogs()
+
+
+# ---------------------------------------------------------------------------
+# Registry — load_catalog
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryLoadCatalog:
+    def test_load_catalog_directory(self, tmp_path):
+        """load_catalog() ingests all YAML files in a directory."""
+        cat_dir = tmp_path / "batch_cat"
+        cat_dir.mkdir()
+        for name in ("GlassA", "GlassB", "GlassC"):
+            (cat_dir / f"{name}.yml").write_text(
+                yaml.dump(_minimal_yaml_data(name)), encoding="utf-8"
+            )
+
+        reg = _fresh_registry()
+        reg.load_catalog(cat_dir)
+        mats = reg.list_materials("batch_cat")
+        assert "GlassA" in mats
+        assert "GlassB" in mats
+        assert "GlassC" in mats
+
+    def test_load_catalog_nonexistent_dir_noop(self):
+        """load_catalog() on a nonexistent directory is a no-op (no error)."""
+        reg = _fresh_registry()
+        reg.load_catalog("/nonexistent/path/xyz123")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Registry — user wins on conflict
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryUserWins:
+    def test_user_wins_over_builtin(self):
+        """User-registered entry overrides built-in with same (name, catalog)."""
+        reg = _fresh_registry()
+
+        # Register a custom N-BK7 in schott catalog with n=1.99
+        custom_data = {
+            "REFERENCE": "custom",
+            "DATA": [{"type": "tabulated n", "data": "0.4 1.99\n0.55 1.99\n0.7 1.99\n"}],
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            reg.register("N-BK7", "schott", custom_data)
+
+        path, _ = reg._resolve_with_row(
+            "N-BK7", "schott", None, MatchPolicy.STRICT, None, None
+        )
+        from optiland.materials.material_file import MaterialFile
+        mf = MaterialFile(path)
+        n = mf.n(0.55)
+        assert abs(float(n) - 1.99) < 0.01, "User entry should shadow built-in"
+
+
+# ---------------------------------------------------------------------------
+# MaterialCatalog
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialCatalog:
+    def test_available_returns_list(self):
+        """MaterialCatalog.available() returns a list of strings."""
+        cats = MaterialCatalog.available()
+        assert isinstance(cats, list)
+        assert len(cats) > 0
+
+    def test_available_includes_schott(self):
+        """MaterialCatalog.available() includes schott."""
+        assert "schott" in MaterialCatalog.available()
+
+    def test_list_returns_materials(self):
+        """MaterialCatalog('schott').list() returns a non-empty list."""
+        mats = MaterialCatalog("schott").list()
+        assert len(mats) > 0
+        assert "N-BK7" in mats
+
+    def test_search_finds_nbk7(self):
+        """MaterialCatalog.search('bk7') returns N-BK7 among results."""
+        results = MaterialCatalog("schott").search("bk7")
+        assert len(results) > 0
+        assert "N-BK7" in results
+
+    def test_get_returns_material(self):
+        """MaterialCatalog.get('N-BK7') returns a Material instance."""
+        glass = MaterialCatalog("schott").get("N-BK7")
+        assert isinstance(glass, Material)
+        assert abs(glass.n(0.5876) - 1.5168) < 0.001
+
+    def test_repr(self):
+        """MaterialCatalog.__repr__ includes the catalog name."""
+        cat = MaterialCatalog("schott")
+        assert "schott" in repr(cat)
+
+
+# ---------------------------------------------------------------------------
+# Serialization — to_dict / from_dict
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_to_dict_includes_catalog(self):
+        """to_dict() includes the 'catalog' field."""
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        d = m.to_dict()
+        assert d["catalog"] == "schott"
+
+    def test_to_dict_includes_match_policy(self):
+        """to_dict() includes the 'match_policy' field as a string."""
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        d = m.to_dict()
+        assert d["match_policy"] == "best"
+
+    def test_to_dict_catalog_none_when_unset(self):
+        """to_dict() emits catalog=None when no catalog was given."""
+        m = Material("N-BK7", match_policy=MatchPolicy.BEST)
+        d = m.to_dict()
+        assert d["catalog"] is None
+
+    def test_from_dict_missing_catalog_warns(self):
+        """from_dict() emits DeprecationWarning when catalog field is absent."""
+        data = {"name": "N-BK7", "type": "Material"}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material.from_dict(data)
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) >= 1
+        assert "catalog" in str(dep_warns[0].message)
+
+    def test_from_dict_with_catalog_no_deprecation_warning(self):
+        """from_dict() with catalog field does not emit DeprecationWarning."""
+        data = {
+            "name": "N-BK7",
+            "catalog": "schott",
+            "match_policy": "best",
+            "type": "Material",
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material.from_dict(data)
+        dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warns) == 0
+
+    def test_round_trip(self):
+        """Serialize → deserialize preserves name, catalog, and match_policy."""
+        original = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        d = original.to_dict()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            restored = Material.from_dict(d)
+        assert restored.name == original.name
+        assert restored._catalog == original._catalog
+        assert restored._match_policy == original._match_policy
+
+    def test_round_trip_optical_values(self):
+        """Round-trip preserves the computed refractive index."""
+        original = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        d = original.to_dict()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            restored = Material.from_dict(d)
+        assert abs(original.n(0.55) - restored.n(0.55)) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Material.__repr__
+# ---------------------------------------------------------------------------
+
+
+class TestMaterialRepr:
+    def test_repr_includes_name(self):
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        assert "N-BK7" in repr(m)
+
+    def test_repr_includes_catalog(self):
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        assert "schott" in repr(m)
+
+    def test_repr_includes_wavelength_range(self):
+        m = Material("N-BK7", catalog="schott", match_policy=MatchPolicy.BEST)
+        r = repr(m)
+        assert "µm" in r or "um" in r.lower() or "λ" in r
+
+    def test_repr_no_catalog_omits_catalog(self):
+        m = Material("N-BK7", match_policy=MatchPolicy.BEST)
+        r = repr(m)
+        assert "catalog" not in r
+
+
+# ---------------------------------------------------------------------------
+# Group-aware discovery (plan: MaterialCatalog group API)
+# ---------------------------------------------------------------------------
+
+
+class TestGroupAwareDiscovery:
+    def test_groups_contains_expected(self):
+        """groups() contains at minimum the four primary group names."""
+        groups = MaterialCatalog.groups()
+        assert {"glass", "main", "organic", "other"}.issubset(set(groups))
+
+    def test_available_returns_only_glass(self):
+        """available() returns glass manufacturer names, not element symbols."""
+        cats = MaterialCatalog.available()
+        assert "schott" in cats
+        assert "ohara" in cats
+        assert "Ag" not in cats
+        assert "methane" not in cats
+
+    def test_available_is_sorted(self):
+        """available() returns values in sorted order."""
+        cats = MaterialCatalog.available()
+        assert cats == sorted(cats)
+
+    def test_available_excludes_pure_element_symbols(self):
+        """available() does not contain unambiguous element/compound symbols."""
+        glass_cats = set(MaterialCatalog.available())
+        # These catalog_dir values only ever appear in the 'main' group
+        for pure_element in ("Ag", "Au", "Cu", "Ge", "Pt", "W"):
+            assert pure_element not in glass_cats
+
+    def test_catalog_list_nonempty_and_sorted(self):
+        """MaterialCatalog('schott').list() is non-empty and sorted."""
+        mats = MaterialCatalog("schott").list()
+        assert len(mats) > 0
+        assert mats == sorted(mats)
+
+    def test_catalog_search_bk7(self):
+        """search('bk7') returns names containing the BK7 substring."""
+        results = MaterialCatalog("schott").search("BK7")
+        assert len(results) > 0
+        assert all("BK7" in r.upper() for r in results)
+
+    def test_catalog_get_returns_material(self):
+        """get('N-BK7') returns a Material instance."""
+        glass = MaterialCatalog("schott").get("N-BK7")
+        assert isinstance(glass, Material)
+
+    def test_registry_list_groups_matches_catalog_groups(self):
+        """MaterialRegistry.list_groups() equals MaterialCatalog.groups()."""
+        assert MaterialRegistry.instance().list_groups() == MaterialCatalog.groups()


### PR DESCRIPTION
## New Features - Optiland Material System Overhaul

### 1. Unified Registration & Global Resolution (`MaterialRegistry`)
The `MaterialRegistry` is a new global singleton managing all built-in glass database lookups along with custom user-defined materials.
* **Global Access**: Accessed via `MaterialRegistry.instance()`. It caches the core index on demand, imposing zero performance overhead on existing built-in material lookups.
* **Persistent User Catalogs**: On first access, the registry auto-discovers custom materials located in `~/.optiland/catalogs/<catalog_name>/`. It digests directories containing standard `refractiveindex.info` YAML files. 
* **Dynamic Session Registration**: Register custom materials programmatically at runtime using the `.register()` or `.register_file()` methods.

### 2. Streamlined Glass Discovery (`MaterialCatalog`)
A clean, read-only interface designed for searching and auditing glass catalogs without instantiating concrete materials directly.
* `MaterialCatalog.available()`: Lists all accessible catalogs (e.g., `'schott'`, `'ohara'`, and user-registered folders).
* `MaterialCatalog("schott").list()`: Lists all materials contained within a specific catalog.
* `MaterialCatalog("schott").search("bk7")`: Runs a local fuzzy search to pinpoint glass names within that catalog.
* `MaterialCatalog("schott").get("N-BK7")`: Directly instantiates a scoped `Material` instance.

### 3. Type-Safe Configuration (`MaterialSpec`)
A frozen, hashable dataclass (`MaterialSpec`) introduced to formally capture material configurations prior to surface assignment.
* Eliminates ambiguous raw string or tuple tracking across structural pipelines.
* Supports serialization round-tripping via `.to_dict()` and `.from_dict(data)`.
* Fully compatible with the existing `MaterialFactory.create()` layer, alongside a new surface assignment short-hand 3-tuple format: `(name, reference, catalog)`.

### 4. Advanced Match Policies & Custom Warnings
The legacy `robust_search` boolean flag is replaced by a granular control scheme governed by the `MatchPolicy` enum:
* `MatchPolicy.BEST`: Quietly defaults to the nearest available fuzzy match.
* `MatchPolicy.WARN`: (Default) Returns the closest match but flags fuzzy fallbacks or name ambiguities by emitting an `OptilandMaterialWarning`.
* `MatchPolicy.STRICT`: Halts execution and raises a `ValueError` for any non-exact or highly ambiguous database query.

### 5. Updated Representation & Material Shadowing
* **Enhanced Repr**: `Material.__repr__` now explicitly tracks catalog origin and bounds: `Material(name='N-BK7', catalog='schott', λ=[0.31µm, 2.50µm])`.
* **Shadowing Controls**: Custom user entries matching a `(name, catalog)` pair seamlessly shadow built-in data records, throwing a validation warning at registration time rather than lookup time.