### PR TITLE
fix(forbes): trim trailing-zero Q coefficients and pad Clenshaw

### DIFF
--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -23,6 +23,48 @@ def kronecker(i: int, j: int) -> int:
     return 1 if i == j else 0
 
 
+def _trim_trailing_zeros(coefs):
+    """Drop trailing exact-zero entries from a coefficient sequence.
+
+    Only *trailing* exact-zero entries are removed;
+    interior zeros are preserved. Returns an empty list when all entries
+    are zero or the input is empty/``None``.
+
+    Args:
+        coefs: A sequence of scalar coefficients.
+
+    Returns:
+        list: A list of coefficients with trailing zeros removed.
+    """
+    if coefs is None:
+        return []
+    try:
+        n = len(coefs)
+    except TypeError:
+        # Scalar (or 0-d tensor) — wrap in a single-element list, trimming
+        # if it is zero.
+        try:
+            return [] if bool(coefs == 0) else [coefs]
+        except Exception:
+            return [coefs]
+    while n > 0:
+        v = coefs[n - 1]
+        try:
+            is_zero = bool(v == 0)
+        except Exception:
+            is_zero = False
+        if not is_zero:
+            break
+        n -= 1
+    if n == 0:
+        return []
+    if isinstance(coefs, (list, tuple)):
+        return list(coefs[:n])
+    # NumPy array or Torch tensor — keep entries by reference so that any
+    # autograd graph attached to surviving entries is preserved.
+    return [coefs[i] for i in range(n)]
+
+
 @cache
 def gamma_func(n: int, m: int) -> float:
     """Recursive gamma function for Q2D polynomials."""
@@ -87,7 +129,12 @@ def f_qbfs(n: int) -> float:
 def change_basis_qbfs_to_pn(cs: list[float]) -> be.array:
     """
     Changes the basis of Q-BFS coefficients to orthonormal Pn coefficients.
+
+    Trailing exact-zero entries are removed before basis conversion;
+    they would not contribute to the polynomial sum, and keeping them
+    drives the Clenshaw recurrence to needlessly high order.
     """
+    cs = _trim_trailing_zeros(cs)
     m = len(cs) - 1
     if m < 0:
         return be.array(cs)
@@ -116,10 +163,12 @@ def change_basis_qbfs_to_pn(cs: list[float]) -> be.array:
 
 
 def _initialize_alphas_q(cs, x, alphas, j=0):
-    """Initializes the alpha array for Clenshaw's algorithm."""
+    """Initializes the alpha array for Clenshaw's algorithm.
+    """
     if alphas is not None:
         return alphas
-    shape = (len(cs), *be.shape(x)) if hasattr(x, "shape") else (len(cs),)
+    n_modes = max(len(cs), 2)
+    shape = (n_modes, *be.shape(x)) if hasattr(x, "shape") else (n_modes,)
     if j != 0:
         shape = (j + 1, *shape)
     zeros = be.zeros(shape)
@@ -144,7 +193,11 @@ def _clenshaw_qbfs_recurrence(bs, usq, alphas):
 
 
 def clenshaw_qbfs(cs: list[float], usq: be.array, alphas: be.array = None):
-    """Computes the sum of Q-BFS polynomials using Clenshaw's algorithm."""
+    """Computes the sum of Q-BFS polynomials using Clenshaw's algorithm.
+
+    Trailing exact-zero coefficients are trimmed before evaluation.
+    """
+    cs = _trim_trailing_zeros(cs)
     bs = change_basis_qbfs_to_pn(cs)
     m = len(bs) - 1
     if m < 0:
@@ -183,7 +236,13 @@ def _clenshaw_qbfs_functional(bs, usq):
 
 
 def clenshaw_qbfs_der(cs, usq, j=1, alphas=None):
-    """Computes derivatives of Q-BFS polynomials using Clenshaw's method."""
+    """Computes derivatives of Q-BFS polynomials using Clenshaw's method.
+
+    Trailing exact-zero coefficients are trimmed before evaluation. When
+    the derivative order ``j`` exceeds the trimmed polynomial degree the
+    higher-order alpha tables are returned as zero.
+    """
+    cs = _trim_trailing_zeros(cs)
     if be.get_backend() == "torch":
         return _clenshaw_qbfs_der_functional(cs, usq, j)
 
@@ -265,8 +324,10 @@ def _clenshaw_qbfs_der_functional(cs, usq, j=1):
 def compute_z_zprime_qbfs(
     coefs: list[float], u: be.array, usq: be.array
 ) -> tuple[be.array, be.array]:
-    """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u."""
-    if coefs is None or len(coefs) == 0:
+    """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u.
+    """
+    coefs = _trim_trailing_zeros(coefs)
+    if len(coefs) == 0:
         zeros = be.zeros_like(u)
         return zeros, zeros
 
@@ -356,6 +417,7 @@ def change_basis_q2d_to_pnm(cns: list[float], m: int) -> be.array:
     """
     Changes the basis of Q2D coefficients to orthonormal Pnm coefficients.
     """
+    cns = _trim_trailing_zeros(cns)
     m = abs(m)
     n_max = len(cns) - 1
     if n_max < 0:
@@ -404,10 +466,14 @@ def q2d_sum_from_alphas(alphas: be.array, m: int, num_coeffs: int) -> be.array:
     """
     Computes the final sum from the alpha coefficients returned by Clenshaw's
     method, applying the special summation rule for m=1.
+
+    The m==1 correction reads ``alphas[3]``; the read is also guarded by
+    the actual alpha-table length, so a caller passing a stale
+    ``num_coeffs`` does not over-index.
     """
     s = 0.5 * alphas[0]
     # special case for m=1, as in Forbes' papers
-    if m == 1 and num_coeffs - 1 > 2:
+    if m == 1 and num_coeffs - 1 > 2 and be.shape(alphas)[0] > 3:
         s -= 2 / 5 * alphas[3]
     return s
 
@@ -427,6 +493,12 @@ def _compute_m_gt0_components(ams, bms, u, t, usq):
 
     for m_idx, (a_coef, b_coef) in enumerate(zip(ams, bms, strict=False)):
         m = m_idx + 1
+        # Trim trailing zeros independently per family so the m==1 special
+        # case in q2d_sum_from_alphas reads a correctly sized alpha table
+        # and does not over index when the user supplied vector ends in
+        # zeros.
+        a_coef = _trim_trailing_zeros(a_coef)
+        b_coef = _trim_trailing_zeros(b_coef)
 
         s_a, s_b, s_prime_a, s_prime_b = 0, 0, 0, 0
         if a_coef:
@@ -460,10 +532,12 @@ def _compute_m_gt0_components(ams, bms, u, t, usq):
 
 
 def compute_z_zprime_q2d(cm0, ams, bms, u, t):
-    """Computes the polynomial sum components for a Q2D surface."""
+    """Computes the polynomial sum components for a Q2D surface.
+    """
     usq = u * u
     zeros = be.zeros_like(u)
 
+    cm0 = _trim_trailing_zeros(cm0)
     poly_sum_m0, d_poly_sum_m0_du = zeros, zeros
     if cm0:
         poly_sum_m0, d_poly_sum_m0_du = compute_z_zprime_qbfs(cm0, u, usq)
@@ -505,6 +579,9 @@ def q2d_nm_coeffs_to_ams_bms(nms: list[tuple[int, int]], coefs: list[float]):
 
 
 def clenshaw_q2d(cns, m, usq, alphas=None):
+    """Evaluates the Q2D Clenshaw alpha table for azimuthal order ``m``.
+    """
+    cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
         ds = change_basis_q2d_to_pnm(cns, m)
         all_alphas_list = _clenshaw_q2d_functional(ds, m, usq)
@@ -558,7 +635,9 @@ def _clenshaw_q2d_functional(ds, m, usq):
 
 
 def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None):
-    """Computes derivatives of Q-2D polynomials using Clenshaw's method."""
+    """Computes derivatives of Q-2D polynomials using Clenshaw's method.
+    """
+    cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
         return _clenshaw_q2d_der_functional(cns, m, usq, j)
 

--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -163,8 +163,7 @@ def change_basis_qbfs_to_pn(cs: list[float]) -> be.array:
 
 
 def _initialize_alphas_q(cs, x, alphas, j=0):
-    """Initializes the alpha array for Clenshaw's algorithm.
-    """
+    """Initializes the alpha array for Clenshaw's algorithm."""
     if alphas is not None:
         return alphas
     n_modes = max(len(cs), 2)
@@ -324,8 +323,7 @@ def _clenshaw_qbfs_der_functional(cs, usq, j=1):
 def compute_z_zprime_qbfs(
     coefs: list[float], u: be.array, usq: be.array
 ) -> tuple[be.array, be.array]:
-    """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u.
-    """
+    """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u."""
     coefs = _trim_trailing_zeros(coefs)
     if len(coefs) == 0:
         zeros = be.zeros_like(u)
@@ -532,8 +530,7 @@ def _compute_m_gt0_components(ams, bms, u, t, usq):
 
 
 def compute_z_zprime_q2d(cm0, ams, bms, u, t):
-    """Computes the polynomial sum components for a Q2D surface.
-    """
+    """Computes the polynomial sum components for a Q2D surface."""
     usq = u * u
     zeros = be.zeros_like(u)
 
@@ -579,8 +576,7 @@ def q2d_nm_coeffs_to_ams_bms(nms: list[tuple[int, int]], coefs: list[float]):
 
 
 def clenshaw_q2d(cns, m, usq, alphas=None):
-    """Evaluates the Q2D Clenshaw alpha table for azimuthal order ``m``.
-    """
+    """Evaluates the Q2D Clenshaw alpha table for azimuthal order ``m``."""
     cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
         ds = change_basis_q2d_to_pnm(cns, m)
@@ -635,8 +631,7 @@ def _clenshaw_q2d_functional(ds, m, usq):
 
 
 def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None):
-    """Computes derivatives of Q-2D polynomials using Clenshaw's method.
-    """
+    """Computes derivatives of Q-2D polynomials using Clenshaw's method."""
     cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
         return _clenshaw_q2d_der_functional(cns, m, usq, j)

--- a/tests/test_forbes_qpoly.py
+++ b/tests/test_forbes_qpoly.py
@@ -1,0 +1,309 @@
+"""Tests for the qpoly module's coefficient trimming and Clenshaw edge cases.
+
+These tests target PR 1 of the Forbes Q-polynomial downstreaming work
+(issue #617): robust handling of empty, single-coefficient, and
+trailing-zero coefficient vectors plus derivative orders larger than the
+polynomial degree.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.geometries.forbes.qpoly import (
+    _trim_trailing_zeros,
+    change_basis_q2d_to_pnm,
+    change_basis_qbfs_to_pn,
+    clenshaw_q2d,
+    clenshaw_q2d_der,
+    clenshaw_qbfs,
+    clenshaw_qbfs_der,
+    compute_z_zprime_q2d,
+    compute_z_zprime_qbfs,
+    q2d_nm_coeffs_to_ams_bms,
+    q2d_sum_from_alphas,
+)
+
+from .utils import assert_allclose
+
+# ---------------------------------------------------------------------------
+# _trim_trailing_zeros
+# ---------------------------------------------------------------------------
+
+
+class TestTrimTrailingZeros:
+    def test_none(self):
+        assert _trim_trailing_zeros(None) == []
+
+    def test_empty(self):
+        assert _trim_trailing_zeros([]) == []
+
+    def test_single_zero(self):
+        assert _trim_trailing_zeros([0]) == []
+
+    def test_all_zero(self):
+        assert _trim_trailing_zeros([0, 0, 0]) == []
+
+    def test_single_nonzero(self):
+        assert _trim_trailing_zeros([1.5]) == [1.5]
+
+    def test_trailing_only(self):
+        assert _trim_trailing_zeros([1, 0, 0]) == [1]
+
+    def test_interior_zero_preserved(self):
+        assert _trim_trailing_zeros([1, 0, 2, 0, 0]) == [1, 0, 2]
+
+    def test_no_trailing(self):
+        assert _trim_trailing_zeros([1, 2, 3]) == [1, 2, 3]
+
+    def test_tuple(self):
+        assert _trim_trailing_zeros((1.0, 0.0, 0.0)) == [1.0]
+
+    def test_numpy_array(self):
+        arr = np.array([1.0, 2.0, 0.0, 0.0])
+        out = _trim_trailing_zeros(arr)
+        assert len(out) == 2
+        assert float(out[0]) == 1.0
+        assert float(out[1]) == 2.0
+
+    def test_numpy_all_zero(self):
+        arr = np.zeros(4)
+        assert _trim_trailing_zeros(arr) == []
+
+
+# ---------------------------------------------------------------------------
+# Clenshaw / basis-change edge cases (Qbfs)
+# ---------------------------------------------------------------------------
+
+
+class TestClenshawQbfsEdgeCases:
+    def test_empty_coefs_scalar(self, set_test_backend):
+        result = clenshaw_qbfs([], be.array(0.25))
+        assert float(be.to_numpy(result)) == 0.0
+
+    def test_empty_coefs_array(self, set_test_backend):
+        usq = be.array([0.1, 0.25, 0.4])
+        result = clenshaw_qbfs([], usq)
+        assert_allclose(result, be.zeros_like(usq))
+
+    def test_all_zero_coefs(self, set_test_backend):
+        usq = be.array([0.1, 0.5, 0.9])
+        result = clenshaw_qbfs([0.0, 0.0, 0.0, 0.0], usq)
+        assert_allclose(result, be.zeros_like(usq))
+
+    def test_one_coef(self, set_test_backend):
+        # Q_0(u) is constant; the Clenshaw sum 2*alpha[0] for one P_n
+        # coefficient equals 2 * (cs[0] / f_qbfs(0)) = cs[0].
+        usq = be.array([0.1, 0.5, 0.9])
+        cs = [0.5]
+        result = clenshaw_qbfs(cs, usq)
+        # Two-coefficient version with explicit trailing zero must match.
+        result_trail = clenshaw_qbfs([0.5, 0.0], usq)
+        assert_allclose(result, result_trail)
+
+    def test_trailing_zeros_match_trimmed(self, set_test_backend):
+        usq = be.array([0.1, 0.3, 0.7])
+        cs_dense = [0.7, -0.2, 0.4, 0.0, 0.0, 0.0]
+        cs_trim = [0.7, -0.2, 0.4]
+        assert_allclose(
+            clenshaw_qbfs(cs_dense, usq),
+            clenshaw_qbfs(cs_trim, usq),
+        )
+
+    def test_change_basis_handles_trailing_zero(self, set_test_backend):
+        bs_dense = change_basis_qbfs_to_pn([1.0, 0.0, 0.0])
+        bs_trim = change_basis_qbfs_to_pn([1.0])
+        assert_allclose(bs_dense, bs_trim)
+
+    def test_change_basis_empty(self, set_test_backend):
+        bs = change_basis_qbfs_to_pn([])
+        assert be.to_numpy(bs).size == 0
+
+    def test_change_basis_all_zero(self, set_test_backend):
+        bs = change_basis_qbfs_to_pn([0.0, 0.0, 0.0])
+        assert be.to_numpy(bs).size == 0
+
+
+class TestClenshawQbfsDerEdgeCases:
+    def test_empty_coefs(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        alphas = clenshaw_qbfs_der([], usq, j=1)
+        # No coefficients => zero alpha table padded to 2 modes.
+        assert be.to_numpy(alphas).shape[-1] == 2
+
+    def test_j_greater_than_degree(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        cs = [0.5]  # degree 0
+        alphas = clenshaw_qbfs_der(cs, usq, j=2)
+        # Higher derivative tables (j=1, j=2) must be zero.
+        np_alphas = be.to_numpy(alphas)
+        assert np.allclose(np_alphas[1], 0.0)
+        assert np.allclose(np_alphas[2], 0.0)
+
+    def test_compute_z_zprime_empty(self, set_test_backend):
+        u = be.array([0.1, 0.5])
+        usq = u * u
+        s, ds_du = compute_z_zprime_qbfs([], u, usq)
+        assert_allclose(s, be.zeros_like(u))
+        assert_allclose(ds_du, be.zeros_like(u))
+
+    def test_compute_z_zprime_all_zero(self, set_test_backend):
+        u = be.array([0.1, 0.5, 0.9])
+        usq = u * u
+        s, ds_du = compute_z_zprime_qbfs([0.0, 0.0, 0.0], u, usq)
+        assert_allclose(s, be.zeros_like(u))
+        assert_allclose(ds_du, be.zeros_like(u))
+
+    def test_compute_z_zprime_trailing_zeros_match_trimmed(self, set_test_backend):
+        u = be.array([0.1, 0.3, 0.7])
+        usq = u * u
+        s_dense, ds_dense = compute_z_zprime_qbfs([0.7, -0.2, 0.4, 0.0, 0.0], u, usq)
+        s_trim, ds_trim = compute_z_zprime_qbfs([0.7, -0.2, 0.4], u, usq)
+        assert_allclose(s_dense, s_trim)
+        assert_allclose(ds_dense, ds_trim)
+
+
+# ---------------------------------------------------------------------------
+# Clenshaw / basis-change edge cases (Q2D)
+# ---------------------------------------------------------------------------
+
+
+class TestClenshawQ2DEdgeCases:
+    def test_empty_coefs(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        alphas = clenshaw_q2d([], m=1, usq=usq)
+        # Padded to at least 2 modes so callers can safely index alpha[1].
+        assert be.to_numpy(alphas).shape[0] == 2
+        assert np.allclose(be.to_numpy(alphas), 0.0)
+
+    def test_one_coef(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        alphas = clenshaw_q2d([0.5], m=1, usq=usq)
+        # The first mode carries ds[0]; the padded second mode must be zero.
+        assert be.to_numpy(alphas).shape[0] >= 1
+
+    def test_trailing_zeros_match_trimmed_m1(self, set_test_backend):
+        # m == 1 with a coefficient vector of length >= 4 triggers the
+        # special alphas[3] correction in q2d_sum_from_alphas.  A dense
+        # vector with a zero in slot 3 must produce the *same* sum as the
+        # trimmed three-element vector that skips the correction — this is
+        # the prysm one-sweep alpha-index fix.
+        usq = be.array(0.4)
+        cs_dense = [0.7, -0.2, 0.4, 0.0]
+        cs_trim = [0.7, -0.2, 0.4]
+        alphas_dense = clenshaw_q2d(cs_dense, m=1, usq=usq)
+        alphas_trim = clenshaw_q2d(cs_trim, m=1, usq=usq)
+        s_dense = q2d_sum_from_alphas(alphas_dense, m=1, num_coeffs=len(cs_dense))
+        s_trim = q2d_sum_from_alphas(alphas_trim, m=1, num_coeffs=len(cs_trim))
+        # After trimming, num_coeffs collapses to 3 internally, so the
+        # m==1 special correction is correctly skipped — sums must agree.
+        assert_allclose(s_dense, s_trim)
+
+    def test_change_basis_q2d_empty(self, set_test_backend):
+        ds = change_basis_q2d_to_pnm([], m=1)
+        assert be.to_numpy(ds).size == 0
+
+    def test_change_basis_q2d_trailing_zero(self, set_test_backend):
+        ds_dense = change_basis_q2d_to_pnm([1.0, 0.5, 0.0, 0.0], m=2)
+        ds_trim = change_basis_q2d_to_pnm([1.0, 0.5], m=2)
+        assert_allclose(ds_dense, ds_trim)
+
+
+class TestClenshawQ2DDerEdgeCases:
+    def test_empty_coefs(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        alphas = clenshaw_q2d_der([], m=1, usq=usq, j=1)
+        np_a = be.to_numpy(alphas)
+        # Padded to at least 2 modes, all zero.
+        assert np_a.shape[0] == 2  # j+1
+        assert np.allclose(np_a, 0.0)
+
+    def test_j_greater_than_degree(self, set_test_backend):
+        usq = be.array([0.1, 0.5])
+        alphas = clenshaw_q2d_der([0.5], m=2, usq=usq, j=2)
+        np_a = be.to_numpy(alphas)
+        # j=1 and j=2 alpha rows are zero because the polynomial is degree 0.
+        assert np.allclose(np_a[1], 0.0)
+        assert np.allclose(np_a[2], 0.0)
+
+    def test_compute_z_zprime_q2d_trailing_zeros_match_trimmed(self, set_test_backend):
+        u = be.array([0.2, 0.5, 0.8])
+        t = be.array([0.1, 0.6, 1.2])
+        ams_dense = [[0.3, -0.1, 0.2, 0.0]]  # m=1, n=0..3, trailing zero
+        bms_dense = [[0.0, 0.0]]
+        ams_trim = [[0.3, -0.1, 0.2]]
+        bms_trim = [[]]
+        v_dense = compute_z_zprime_q2d([], ams_dense, bms_dense, u, t)
+        v_trim = compute_z_zprime_q2d([], ams_trim, bms_trim, u, t)
+        for a, b in zip(v_dense, v_trim, strict=True):
+            assert_allclose(a, b)
+
+
+# ---------------------------------------------------------------------------
+# q2d_nm_coeffs_to_ams_bms — asymmetric a/b families
+# ---------------------------------------------------------------------------
+
+
+class TestQ2dNmCoeffsAsymmetric:
+    def test_cos_only_family_survives(self):
+        # Only ('a', 2, 0) supplied. zip(ams, bms) must still expose m=2.
+        nms = [(0, 2)]
+        coefs = [0.42]
+        cms, ams, bms = q2d_nm_coeffs_to_ams_bms(nms, coefs)
+        assert cms == []
+        assert len(ams) == 2  # padded up through azimuthal order 2
+        assert len(bms) == 2
+        assert ams[1] == [0.42]
+        assert bms[1] == []
+
+    def test_sin_only_family_survives(self):
+        # Only ('b', 3, 0) supplied. zip must still expose m=3.
+        nms = [(0, -3)]
+        coefs = [0.99]
+        cms, ams, bms = q2d_nm_coeffs_to_ams_bms(nms, coefs)
+        assert len(ams) == 3
+        assert len(bms) == 3
+        assert ams[2] == []  # no cos m=3 family
+        assert bms[2] == [0.99]
+
+
+# ---------------------------------------------------------------------------
+# Geometry-level regression: scaling-style sag with trailing zeros
+# ---------------------------------------------------------------------------
+
+
+class TestGeometrySagWithTrailingZeros:
+    def test_qbfs_sag_unchanged_by_trailing_zero_terms(self, set_test_backend):
+        """A ForbesQNormalSlopeGeometry must produce identical sag when the
+        radial-terms dict contains extra zero-valued terms at high order."""
+        from optiland.coordinate_system import CoordinateSystem
+        from optiland.geometries import (
+            ForbesQNormalSlopeGeometry,
+            ForbesSurfaceConfig,
+        )
+
+        cs = CoordinateSystem()
+        cfg_tight = ForbesSurfaceConfig(
+            radius=20.0,
+            conic=-1.0,
+            terms={0: 1e-3, 1: 5e-4},
+            norm_radius=5.0,
+        )
+        cfg_padded = ForbesSurfaceConfig(
+            radius=20.0,
+            conic=-1.0,
+            terms={0: 1e-3, 1: 5e-4, 2: 0.0, 3: 0.0, 4: 0.0},
+            norm_radius=5.0,
+        )
+        g_tight = ForbesQNormalSlopeGeometry(cs, surface_config=cfg_tight)
+        g_padded = ForbesQNormalSlopeGeometry(cs, surface_config=cfg_padded)
+        x = be.array([0.5, 1.0, 2.0, 3.5])
+        y = be.array([0.2, -0.4, 1.0, 2.0])
+        assert_allclose(g_tight.sag(x, y), g_padded.sag(x, y))
+
+
+# Mark Q2D regression tests on numpy backend — torch import not available
+# in some local environments; parametrized backend fixture covers both.
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")


### PR DESCRIPTION
addresses the first part of several performance and bug fixes for the implementation of the qtype polynomials geometry, as suggested in #617 

PR 1/4