### PR TITLE
Performance/forbes powers

### DIFF
--- a/optiland/geometries/forbes/geometry.py
+++ b/optiland/geometries/forbes/geometry.py
@@ -35,6 +35,7 @@ from optiland.geometries.newton_raphson import NewtonRaphsonGeometry
 
 from .qpoly import (
     _q2d_cartesian_eval,
+    _trim_trailing_zeros,
     clenshaw_q2d,
     clenshaw_qbfs,
     compute_z_q2d,
@@ -45,6 +46,65 @@ from .qpoly import (
 )
 
 _EPSILON = 1e-12
+
+
+class _CoeffCacheDict(dict):
+    """Coefficient dict that invalidates its owner's prepared-coefficient cache.
+
+    The Forbes geometries cache trimmed/stacked coefficient containers and
+    rebuild them lazily (see ``_ensure_coeffs``). The optimizer and ``scale``
+    invalidate that cache explicitly, but a user may also poke a coefficient in
+    place (``geom.radial_terms[n] = value``). This dict catches such in-place
+    edits and marks the owner dirty, so the next ``sag`` / ``_surface_normal``
+    picks them up -- matching the pre-cache behavior where the coefficients
+    were rebuilt on every call.
+
+    The standard ``dict`` constructor signature is kept intact so that
+    ``dataclasses.asdict`` (used by ``to_dict``) can reconstruct the mapping via
+    ``type(obj)(...)``. The owner is attached afterwards with :meth:`_bind`; an
+    unbound instance simply behaves like a plain ``dict``.
+    """
+
+    _owner = None
+
+    def _bind(self, owner) -> _CoeffCacheDict:
+        self._owner = owner
+        return self
+
+    def _invalidate(self) -> None:
+        if self._owner is not None:
+            self._owner._coeffs_dirty = True
+
+    def __setitem__(self, key, value) -> None:
+        super().__setitem__(key, value)
+        self._invalidate()
+
+    def __delitem__(self, key) -> None:
+        super().__delitem__(key)
+        self._invalidate()
+
+    def update(self, *args, **kwargs) -> None:
+        super().update(*args, **kwargs)
+        self._invalidate()
+
+    def setdefault(self, key, default=None):
+        result = super().setdefault(key, default)
+        self._invalidate()
+        return result
+
+    def pop(self, *args, **kwargs):
+        result = super().pop(*args, **kwargs)
+        self._invalidate()
+        return result
+
+    def popitem(self):
+        result = super().popitem()
+        self._invalidate()
+        return result
+
+    def clear(self) -> None:
+        super().clear()
+        self._invalidate()
 
 
 @dataclass
@@ -115,6 +175,19 @@ class ForbesGeometryBase(NewtonRaphsonGeometry):
         )
         self.surface_config = surface_config
         self.solver_config = solver_config
+        # Coefficient cache: ``_prepare_coeffs`` is expensive (dict -> stacked
+        # tensors + per-family trimming, each ``bool(v == 0)`` forcing a CUDA
+        # sync). It is rebuilt only when invalidated -- on construction, on
+        # ``scale``, and on optimizer coefficient updates -- not on every
+        # ``sag``/``_surface_normal`` call. ``norm_radius`` is applied at
+        # evaluation time and does not enter coefficient preparation, so
+        # ``update_normalization`` does not invalidate this cache.
+        self._coeffs_dirty = True
+
+    def _ensure_coeffs(self) -> None:
+        """Rebuild cached coefficient containers only when invalidated."""
+        if self._coeffs_dirty:
+            self._prepare_coeffs()
 
     def _base_sag(self, r2):
         """Calculates the sag of the base conic surface.
@@ -230,11 +303,17 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
     ):
         super().__init__(coordinate_system, surface_config, solver_config)
         if be.get_backend() == "torch":
-            self.radial_terms = {
-                k: be.array(v) for k, v in (self.surface_config.terms or {}).items()
-            }
+            self.radial_terms = _CoeffCacheDict(
+                {k: be.array(v) for k, v in (self.surface_config.terms or {}).items()}
+            )._bind(self)
         else:
-            self.radial_terms = self.surface_config.terms or {}
+            # Preserve the historical numpy aliasing: ``radial_terms`` and
+            # ``surface_config.terms`` are the same object, so in-place edits
+            # propagate to serialization.
+            self.radial_terms = _CoeffCacheDict(self.surface_config.terms or {})._bind(
+                self
+            )
+            self.surface_config.terms = self.radial_terms
 
         if self.surface_config.norm_radius is not None:
             self.normalization_mode = "manual"
@@ -246,9 +325,19 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
         self.is_symmetric = True
 
     def _prepare_coeffs(self):
-        """Prepares the internal coefficient lists from the radial_terms dictionary."""
+        """Prepares the internal coefficient lists from the radial_terms dictionary.
+
+        Also builds the trimmed ``_prepared_radial_coeffs`` container and the
+        ``_all_coeffs_zero`` flag consumed by the hot ``sag``/``_surface_normal``
+        paths, so that trailing-zero trimming (and its CUDA synchronization)
+        happens here -- once per coefficient change -- rather than on every
+        evaluation. Clears the dirty flag.
+        """
         if not self.radial_terms:
             self.coeffs_n, self.coeffs_c = [], be.array([])
+            self._prepared_radial_coeffs = []
+            self._all_coeffs_zero = True
+            self._coeffs_dirty = False
             return
 
         max_n = max(self.radial_terms.keys())
@@ -262,6 +351,10 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
         else:
             self.coeffs_n, self.coeffs_c = [], be.array([])
 
+        self._prepared_radial_coeffs = _trim_trailing_zeros(self.coeffs_c)
+        self._all_coeffs_zero = len(self._prepared_radial_coeffs) == 0
+        self._coeffs_dirty = False
+
     def sag(self, x=0, y=0):
         """Calculate the sag of the Forbes Q (slope-orthogonal) surface.
 
@@ -272,14 +365,14 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
         Returns:
             The sag of the Forbes Q (slope-orthogonal) surface.
         """
-        self._prepare_coeffs()
+        self._ensure_coeffs()
         x, y = be.array(x), be.array(y)
         r2 = x**2 + y**2
         z_base = self._base_sag(r2)
 
         usq = r2 / (self.norm_radius**2)
 
-        poly_sum_m0 = clenshaw_qbfs(self.coeffs_c, usq)
+        poly_sum_m0 = clenshaw_qbfs(self._prepared_radial_coeffs, usq, _no_trim=True)
         prefactor = usq * (1 - usq)
         conic_correction_factor, _ = self._conic_correction_factor(r2)
         departure = prefactor * conic_correction_factor * poly_sum_m0
@@ -301,7 +394,7 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
             tuple[float or array_like, float or array_like, float or array_like]:
                 Components of the unit normal vector (nx, ny, nz).
         """
-        self._prepare_coeffs()
+        self._ensure_coeffs()
         x_in, y_in = be.array(x), be.array(y)
 
         df_dx, df_dy = self._surface_normal_analytical(x_in, y_in)
@@ -342,12 +435,14 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
 
         ds_base_d_rho = self._base_sag_derivative(rho_safe, r2_safe)
 
-        if len(self.coeffs_c) == 0 or be.all(self.coeffs_c == 0):
+        if self._all_coeffs_zero:
             df_d_rho = ds_base_d_rho
         else:
             u = rho_safe / self.norm_radius
 
-            poly_val, dpoly_d_u = compute_z_zprime_qbfs(self.coeffs_c, u, u**2)
+            poly_val, dpoly_d_u = compute_z_zprime_qbfs(
+                self._prepared_radial_coeffs, u, u**2, _no_trim=True
+            )
             dprefactor_d_rho = (2 * u - 4 * u**3) / self.norm_radius
             dpoly_d_rho = dpoly_d_u / self.norm_radius
             conic_factor, dconic_factor_d_rho = self._conic_correction_factor(r2_safe)
@@ -435,6 +530,10 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
         for key in self.radial_terms:
             self.radial_terms[key] = self.radial_terms[key] * scale_factor
 
+        # Coefficients changed: invalidate the cache so the next sag/normal
+        # rebuilds the prepared (trimmed) containers.
+        self._coeffs_dirty = True
+
     def update_normalization(self, semi_aperture: float) -> None:
         if self.normalization_mode == "auto":
             self.norm_radius = be.array(semi_aperture * 1.25)
@@ -493,11 +592,15 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         super().__init__(coordinate_system, surface_config, solver_config)
         self.c = 1 / self.radius if self.radius != 0 else 0
         if be.get_backend() == "torch":
-            self.freeform_coeffs = {
-                k: be.array(v) for k, v in (self.surface_config.terms or {}).items()
-            }
+            self.freeform_coeffs = _CoeffCacheDict(
+                {k: be.array(v) for k, v in (self.surface_config.terms or {}).items()}
+            )._bind(self)
         else:
-            self.freeform_coeffs = self.surface_config.terms or {}
+            # Preserve the historical numpy aliasing (see ForbesQNormalSlope).
+            self.freeform_coeffs = _CoeffCacheDict(
+                self.surface_config.terms or {}
+            )._bind(self)
+            self.surface_config.terms = self.freeform_coeffs
 
         if self.surface_config.norm_radius is not None:
             self.normalization_mode = "manual"
@@ -513,9 +616,17 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         """
         Translates the user-facing Zemax-style `freeform_coeffs` dictionary
         into the internal coefficient lists required by the `qpoly` backend.
+
+        Also builds the trimmed ``_prepared_*`` containers consumed by the hot
+        ``sag``/``_surface_normal`` paths, so trailing-zero trimming (and its
+        CUDA synchronization) happens here -- once per coefficient change --
+        rather than on every evaluation. Clears the dirty flag.
         """
         if not self.freeform_coeffs:
             self.coeffs_n, self.coeffs_c = [], be.array([])
+            self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs = [], [], []
+            self._refresh_prepared_coeffs()
+            self._coeffs_dirty = False
             return
 
         internal_coeffs = {}
@@ -549,6 +660,20 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
                 q2d_nm_coeffs_to_ams_bms(self.coeffs_n, self.coeffs_c)
             )
 
+        self._refresh_prepared_coeffs()
+        self._coeffs_dirty = False
+
+    def _refresh_prepared_coeffs(self) -> None:
+        """Rebuild the trimmed ``_prepared_*`` coefficient containers.
+
+        Trailing exact-zero trimming is done once here (the ``bool(v == 0)``
+        checks force a CUDA sync) so the per-evaluation Clenshaw passes can
+        run with ``_no_trim=True``.
+        """
+        self._prepared_cm0_coeffs = _trim_trailing_zeros(self.cm0_coeffs)
+        self._prepared_ams_coeffs = [_trim_trailing_zeros(a) for a in self.ams_coeffs]
+        self._prepared_bms_coeffs = [_trim_trailing_zeros(b) for b in self.bms_coeffs]
+
     def sag(self, x, y):
         """Calculate the sag of the Forbes Q2D freeform surface.
 
@@ -559,6 +684,7 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         Returns:
             float or array_like: The sag of the Forbes Q2D freeform surface.
         """
+        self._ensure_coeffs()
         x, y = be.array(x), be.array(y)
         r2 = x**2 + y**2
         z_base = self._base_sag(r2)
@@ -570,7 +696,12 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         theta = be.arctan2(y, safe_x)
 
         poly_sum_m0, poly_sum_m_gt0 = compute_z_q2d(
-            self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs, u, theta
+            self._prepared_cm0_coeffs,
+            self._prepared_ams_coeffs,
+            self._prepared_bms_coeffs,
+            u,
+            theta,
+            _no_trim=True,
         )
         conic_correction_factor, _ = self._conic_correction_factor(r2)
         usq = u**2
@@ -598,6 +729,7 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
             tuple[float or array_like, float or array_like, float or array_like]:
                 Components of the unit normal vector (nx, ny, nz).
         """
+        self._ensure_coeffs()
         x_in, y_in = be.array(x), be.array(y)
 
         df_dx, df_dy = self._surface_normal_analytical(x_in, y_in)
@@ -609,14 +741,14 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
     def _surface_normal_analytical_vertex(self):
         """Computes the stable analytical derivative exactly at the vertex."""
         df_dx_vertex, df_dy_vertex = 0.0, 0.0
-        if self.ams_coeffs and self.ams_coeffs[0]:
-            a_coeffs = self.ams_coeffs[0]
-            alphas_a = clenshaw_q2d(a_coeffs, m=1, usq=0.0)
+        if self._prepared_ams_coeffs and self._prepared_ams_coeffs[0]:
+            a_coeffs = self._prepared_ams_coeffs[0]
+            alphas_a = clenshaw_q2d(a_coeffs, m=1, usq=0.0, _no_trim=True)
             sum_a1 = q2d_sum_from_alphas(alphas_a, m=1, num_coeffs=len(a_coeffs))
             df_dx_vertex = sum_a1 / self.norm_radius
-        if self.bms_coeffs and self.bms_coeffs[0]:
-            b_coeffs = self.bms_coeffs[0]
-            alphas_b = clenshaw_q2d(b_coeffs, m=1, usq=0.0)
+        if self._prepared_bms_coeffs and self._prepared_bms_coeffs[0]:
+            b_coeffs = self._prepared_bms_coeffs[0]
+            alphas_b = clenshaw_q2d(b_coeffs, m=1, usq=0.0, _no_trim=True)
             sum_b1 = q2d_sum_from_alphas(alphas_b, m=1, num_coeffs=len(b_coeffs))
             df_dy_vertex = sum_b1 / self.norm_radius
         return df_dx_vertex, df_dy_vertex
@@ -647,7 +779,12 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         u2 = X * X + Y * Y
 
         P, dP_dX, dP_dY = _q2d_cartesian_eval(
-            X, Y, self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs
+            X,
+            Y,
+            self._prepared_cm0_coeffs,
+            self._prepared_ams_coeffs,
+            self._prepared_bms_coeffs,
+            _no_trim=True,
         )
         # Convert dP/dX, dP/dY (w.r.t. normalized coords) to physical.
         dP_dx = dP_dX / self.norm_radius
@@ -705,7 +842,12 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
         theta = be.arctan2(y_in, x_in)
 
         vals = compute_z_zprime_q2d(
-            self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs, u, theta
+            self._prepared_cm0_coeffs,
+            self._prepared_ams_coeffs,
+            self._prepared_bms_coeffs,
+            u,
+            theta,
+            _no_trim=True,
         )
         poly_sum_m0, d_poly_m0_du, poly_sum_m_gt0, dr_poly_m_gt0_du, dt_poly_m_gt0 = (
             vals

--- a/optiland/geometries/forbes/geometry.py
+++ b/optiland/geometries/forbes/geometry.py
@@ -34,6 +34,7 @@ from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries.newton_raphson import NewtonRaphsonGeometry
 
 from .qpoly import (
+    _q2d_cartesian_eval,
     clenshaw_q2d,
     clenshaw_qbfs,
     compute_z_q2d,
@@ -444,6 +445,17 @@ class ForbesQNormalSlopeGeometry(ForbesGeometryBase):
 
 
 class ForbesQ2dGeometry(ForbesGeometryBase):
+    # Default surface-normal path: direct-Cartesian (harmonic powers).
+    # Regular at the origin with finite autograd gradients — the legacy
+    # polar path's `1/r` artefact produced NaN gradients at the vertex.
+    # The polar path with its `_surface_normal_analytical_vertex`
+    # `where`-blend remains available as a fallback by setting
+    # ``_use_cartesian_normal = False`` per-instance; it is kept for
+    # one release as a safety net per the PR-series guidance, and may
+    # be removed in a follow-up once Cartesian has bedded in. See
+    # issue #617.
+    _use_cartesian_normal: bool = True
+
     r"""Forbes Q2D freeform surface.
 
     The Q2D surface is defined by a departure $\delta(u, \theta)$ from a base conic:
@@ -609,9 +621,64 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
             df_dy_vertex = sum_b1 / self.norm_radius
         return df_dx_vertex, df_dy_vertex
 
+    def _surface_normal_analytical_cartesian(self, x_in, y_in):
+        """Direct-Cartesian surface-derivative path for ``ForbesQ2dGeometry``.
+
+        Uses :func:`_q2d_cartesian_eval` (harmonic powers + per-m radial
+        Clenshaw) to obtain the dimensionless polynomial value and its
+        Cartesian derivatives without ever forming a ``1/r`` factor. The
+        base conic sag and conic-correction factor terms still go through
+        the existing rotationally-symmetric helpers; their chain rule
+        from polar to Cartesian uses a safe ``rho`` because
+        ``dconic/drho`` and ``dbase/drho`` both vanish at least linearly
+        at the axis, so the limit is finite and the safe-division
+        artifact is bounded.
+
+        Returns:
+            tuple: ``(df_dx, df_dy)``.
+        """
+        r2 = x_in**2 + y_in**2
+        # Use the regularized rho everywhere so the gradient through
+        # sqrt(r2) is finite at the origin (autograd-safe path).
+        rho_safe = be.sqrt(r2 + _EPSILON**2)
+        r2_safe = rho_safe**2
+        X = x_in / self.norm_radius
+        Y = y_in / self.norm_radius
+        u2 = X * X + Y * Y
+
+        P, dP_dX, dP_dY = _q2d_cartesian_eval(
+            X, Y, self.cm0_coeffs, self.ams_coeffs, self.bms_coeffs
+        )
+        # Convert dP/dX, dP/dY (w.r.t. normalized coords) to physical.
+        dP_dx = dP_dX / self.norm_radius
+        dP_dy = dP_dY / self.norm_radius
+
+        conic_factor, dconic_d_rho = self._conic_correction_factor(r2_safe)
+        cos_t = x_in / rho_safe
+        sin_t = y_in / rho_safe
+        dconic_dx = dconic_d_rho * cos_t
+        dconic_dy = dconic_d_rho * sin_t
+
+        # Departure derivative inside the unit disk (clipped to zero outside).
+        d_dep_dx = dconic_dx * P + conic_factor * dP_dx
+        d_dep_dy = dconic_dy * P + conic_factor * dP_dy
+        d_dep_dx = be.where(u2 > 1, 0.0, d_dep_dx)
+        d_dep_dy = be.where(u2 > 1, 0.0, d_dep_dy)
+
+        d_base_dr = self._base_sag_derivative(rho_safe, r2_safe)
+        d_base_dx = d_base_dr * cos_t
+        d_base_dy = d_base_dr * sin_t
+
+        return d_base_dx + d_dep_dx, d_base_dy + d_dep_dy
+
     def _surface_normal_analytical(self, x_in, y_in):
         """
         Computes the analytical surface derivatives for the numpy backend.
+
+        Dispatches to the direct-Cartesian harmonic-powers path when
+        ``_use_cartesian_normal`` is set (regular at the origin); the
+        default polar path with explicit vertex ``where``-blend is
+        otherwise used. See class-level docstring on the switch.
 
         This method is fully vectorized and uses a `where` clause to combine
         the stable vertex calculation with the general non-vertex calculation.
@@ -624,6 +691,9 @@ class ForbesQ2dGeometry(ForbesGeometryBase):
             tuple[float or array_like, float or array_like]: The analytical surface
                                                 derivatives for the numpy backend.
         """
+        if self._use_cartesian_normal:
+            return self._surface_normal_analytical_cartesian(x_in, y_in)
+
         df_dx_vertex, df_dy_vertex = self._surface_normal_analytical_vertex()
 
         r2 = x_in**2 + y_in**2

--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -549,6 +549,145 @@ def _compute_m_gt0_components(ams, bms, u, t, usq):
     return poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
 
 
+def _harmonic_powers(X, Y, m_max):
+    """Compute Re/Im parts of (X + iY)**k for k = 0 .. m_max.
+
+    Iteratively applies the complex-multiplication recurrence
+
+        H_c[k+1] = X * H_c[k] - Y * H_s[k]
+        H_s[k+1] = X * H_s[k] + Y * H_c[k]
+
+    Backend-agnostic and singularity-free at the origin (no division
+    by ``r``); autograd-safe (purely functional list construction).
+
+    Args:
+        X: Normalized x-coordinate (be.array).
+        Y: Normalized y-coordinate (be.array).
+        m_max: Highest azimuthal order needed (inclusive).
+
+    Returns:
+        tuple[list[be.array], list[be.array]]: ``(H_c, H_s)`` each of
+            length ``m_max + 1``.
+    """
+    ones = be.ones_like(X) if hasattr(X, "shape") else be.array(1.0)
+    zeros = be.zeros_like(X) if hasattr(X, "shape") else be.array(0.0)
+    H_c = [ones]
+    H_s = [zeros]
+    for _ in range(m_max):
+        c_prev, s_prev = H_c[-1], H_s[-1]
+        H_c.append(X * c_prev - Y * s_prev)
+        H_s.append(X * s_prev + Y * c_prev)
+    return H_c, H_s
+
+
+def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
+    """Evaluate the Q2D polynomial sum P(X, Y) and its Cartesian derivatives.
+
+    P is the dimensionless polynomial part of the Forbes Q2D departure,
+
+        P(X, Y) = u**2 * (1 - u**2) * S_cm0(u**2)
+                + sum_{m>=1} [ Re((X + iY)**m) * S_a_m(u**2)
+                             + Im((X + iY)**m) * S_b_m(u**2) ],
+
+    with ``u**2 = X**2 + Y**2``. Derivatives are computed in normalized
+    Cartesian coordinates via harmonic powers, so the result is regular
+    at ``X = Y = 0`` (no polar ``1/r`` artifact). The caller is
+    responsible for applying the conic-correction factor, the base-sag
+    derivative, and the chain rule from ``X = x / R_n`` to physical
+    coordinates.
+
+    Args:
+        X: Normalized x-coordinate (be.array).
+        Y: Normalized y-coordinate (be.array).
+        cm0: m=0 (Qbfs-style) coefficient sequence; trimmed internally.
+        ams: Per-m cosine coefficient families (index ``i`` is m == i+1).
+        bms: Per-m sine coefficient families, same layout as ``ams``.
+
+    Returns:
+        tuple: ``(P, dP_dX, dP_dY)`` as be.arrays, broadcast to
+            ``X`` / ``Y`` shape.
+    """
+    usq = X * X + Y * Y
+
+    # m == 0 envelope: P_m0 = u^2 (1 - u^2) * S_cm0(u^2)
+    cm0 = _trim_trailing_zeros(cm0)
+    if cm0:
+        # Reuse derivative Clenshaw to get S and dS/du^2 in one sweep.
+        alphas_m0 = clenshaw_qbfs_der(cm0, usq, j=1)
+        if len(cm0) > 1:
+            s_cm0 = 2 * (alphas_m0[0, 0] + alphas_m0[0, 1])
+            dsdu2_cm0 = 2 * (alphas_m0[1, 0] + alphas_m0[1, 1])
+        else:
+            s_cm0 = 2 * alphas_m0[0, 0]
+            dsdu2_cm0 = 2 * alphas_m0[1, 0]
+        env = usq * (1 - usq)
+        P_m0 = env * s_cm0
+        # d/dX [ u^2(1-u^2) * S ] = 2X * [ (1 - 2u^2) S + u^2(1-u^2) dS/du^2 ]
+        radial_chain = (1 - 2 * usq) * s_cm0 + env * dsdu2_cm0
+        dP_m0_dX = 2 * X * radial_chain
+        dP_m0_dY = 2 * Y * radial_chain
+    else:
+        zeros = be.zeros_like(usq)
+        P_m0 = zeros
+        dP_m0_dX = zeros
+        dP_m0_dY = zeros
+
+    # m >= 1: harmonic powers + per-m radial Clenshaw.
+    m_max = max(len(ams), len(bms))
+    if m_max == 0:
+        return P_m0, dP_m0_dX, dP_m0_dY
+
+    H_c, H_s = _harmonic_powers(X, Y, m_max)
+
+    P_terms, dPx_terms, dPy_terms = [], [], []
+    for m_idx in range(m_max):
+        m = m_idx + 1
+        a_coef = _trim_trailing_zeros(ams[m_idx]) if m_idx < len(ams) else []
+        b_coef = _trim_trailing_zeros(bms[m_idx]) if m_idx < len(bms) else []
+        if not a_coef and not b_coef:
+            continue
+
+        s_a = s_b = dsdu2_a = dsdu2_b = 0.0
+        if a_coef:
+            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1)
+            s_a = q2d_sum_from_alphas(alphas_a[0], m, len(a_coef))
+            dsdu2_a = q2d_sum_from_alphas(alphas_a[1], m, len(a_coef))
+        if b_coef:
+            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1)
+            s_b = q2d_sum_from_alphas(alphas_b[0], m, len(b_coef))
+            dsdu2_b = q2d_sum_from_alphas(alphas_b[1], m, len(b_coef))
+
+        Hc_m = H_c[m]
+        Hs_m = H_s[m]
+        Hc_mm1 = H_c[m - 1]
+        Hs_mm1 = H_s[m - 1]
+
+        P_terms.append(Hc_m * s_a + Hs_m * s_b)
+        # d/dX [ H_c[m] S_a + H_s[m] S_b ]
+        #   = m*H_c[m-1]*S_a + H_c[m]*2X*dS_a + m*H_s[m-1]*S_b + H_s[m]*2X*dS_b
+        dPx_terms.append(
+            m * (Hc_mm1 * s_a + Hs_mm1 * s_b)
+            + 2 * X * (Hc_m * dsdu2_a + Hs_m * dsdu2_b)
+        )
+        # d/dY [ H_c[m] S_a + H_s[m] S_b ]
+        #   = -m*H_s[m-1]*S_a + H_c[m]*2Y*dS_a + m*H_c[m-1]*S_b + H_s[m]*2Y*dS_b
+        dPy_terms.append(
+            m * (-Hs_mm1 * s_a + Hc_mm1 * s_b)
+            + 2 * Y * (Hc_m * dsdu2_a + Hs_m * dsdu2_b)
+        )
+
+    if P_terms:
+        P_mgt0 = be.sum(be.stack(P_terms), axis=0)
+        dPx_mgt0 = be.sum(be.stack(dPx_terms), axis=0)
+        dPy_mgt0 = be.sum(be.stack(dPy_terms), axis=0)
+    else:
+        P_mgt0 = be.zeros_like(usq)
+        dPx_mgt0 = be.zeros_like(usq)
+        dPy_mgt0 = be.zeros_like(usq)
+
+    return P_m0 + P_mgt0, dP_m0_dX + dPx_mgt0, dP_m0_dY + dPy_mgt0
+
+
 def _compute_m_gt0_sag_only(ams, bms, u, t, usq):
     """Sag-only counterpart of :func:`_compute_m_gt0_components`.
 

--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -126,15 +126,22 @@ def f_qbfs(n: int) -> float:
     return (term1 - term2 - term3) ** 0.5
 
 
-def change_basis_qbfs_to_pn(cs: list[float]) -> be.array:
+def change_basis_qbfs_to_pn(cs: list[float], _no_trim: bool = False) -> be.array:
     """
     Changes the basis of Q-BFS coefficients to orthonormal Pn coefficients.
 
     Trailing exact-zero entries are removed before basis conversion;
     they would not contribute to the polynomial sum, and keeping them
     drives the Clenshaw recurrence to needlessly high order.
+
+    Args:
+        cs: Q-BFS coefficient sequence.
+        _no_trim: When True, ``cs`` is assumed already trimmed (trailing
+            zeros removed). This avoids the ``bool(v == 0)`` element checks,
+            which force a device-to-host synchronization on CUDA tensors.
     """
-    cs = _trim_trailing_zeros(cs)
+    if not _no_trim:
+        cs = _trim_trailing_zeros(cs)
     m = len(cs) - 1
     if m < 0:
         return be.array(cs)
@@ -191,13 +198,17 @@ def _clenshaw_qbfs_recurrence(bs, usq, alphas):
     return alphas
 
 
-def clenshaw_qbfs(cs: list[float], usq: be.array, alphas: be.array = None):
+def clenshaw_qbfs(
+    cs: list[float], usq: be.array, alphas: be.array = None, _no_trim: bool = False
+):
     """Computes the sum of Q-BFS polynomials using Clenshaw's algorithm.
 
-    Trailing exact-zero coefficients are trimmed before evaluation.
+    Trailing exact-zero coefficients are trimmed before evaluation unless
+    ``_no_trim`` is set (the caller has already prepared a trimmed sequence).
     """
-    cs = _trim_trailing_zeros(cs)
-    bs = change_basis_qbfs_to_pn(cs)
+    if not _no_trim:
+        cs = _trim_trailing_zeros(cs)
+    bs = change_basis_qbfs_to_pn(cs, _no_trim=True)
     m = len(bs) - 1
     if m < 0:
         return be.zeros_like(usq) if hasattr(usq, "shape") else 0.0
@@ -234,14 +245,15 @@ def _clenshaw_qbfs_functional(bs, usq):
     return s, alpha0, alpha1
 
 
-def clenshaw_qbfs_der(cs, usq, j=1, alphas=None):
+def clenshaw_qbfs_der(cs, usq, j=1, alphas=None, _no_trim: bool = False):
     """Computes derivatives of Q-BFS polynomials using Clenshaw's method.
 
-    Trailing exact-zero coefficients are trimmed before evaluation. When
-    the derivative order ``j`` exceeds the trimmed polynomial degree the
-    higher-order alpha tables are returned as zero.
+    Trailing exact-zero coefficients are trimmed before evaluation unless
+    ``_no_trim`` is set. When the derivative order ``j`` exceeds the trimmed
+    polynomial degree the higher-order alpha tables are returned as zero.
     """
-    cs = _trim_trailing_zeros(cs)
+    if not _no_trim:
+        cs = _trim_trailing_zeros(cs)
     if be.get_backend() == "torch":
         return _clenshaw_qbfs_der_functional(cs, usq, j)
 
@@ -281,7 +293,7 @@ def _clenshaw_qbfs_der_functional(cs, usq, j=1):
         )
         return be.zeros(shape)
 
-    bs = change_basis_qbfs_to_pn(cs)
+    bs = change_basis_qbfs_to_pn(cs, _no_trim=True)
     prefix = 2 - 4 * usq
 
     # functional implementation of the base case (j=0)
@@ -320,7 +332,9 @@ def _clenshaw_qbfs_der_functional(cs, usq, j=1):
     return be.stack(all_alphas_tensors)
 
 
-def compute_z_qbfs(coefs: list[float], usq: be.array) -> be.array:
+def compute_z_qbfs(
+    coefs: list[float], usq: be.array, _no_trim: bool = False
+) -> be.array:
     """Sag-only Q-BFS polynomial sum (no derivative table built).
 
     Equivalent to the first return value of :func:`compute_z_zprime_qbfs`
@@ -330,26 +344,29 @@ def compute_z_qbfs(coefs: list[float], usq: be.array) -> be.array:
     Args:
         coefs: Q-BFS coefficient sequence (trailing zeros are trimmed).
         usq: Squared normalized radius ``u**2``.
+        _no_trim: When True, ``coefs`` is assumed already trimmed.
 
     Returns:
         be.array: The raw Q-BFS polynomial sum at each ``usq`` sample.
     """
-    coefs = _trim_trailing_zeros(coefs)
+    if not _no_trim:
+        coefs = _trim_trailing_zeros(coefs)
     if len(coefs) == 0:
         return be.zeros_like(usq) if hasattr(usq, "shape") else be.array(0.0)
-    return clenshaw_qbfs(coefs, usq)
+    return clenshaw_qbfs(coefs, usq, _no_trim=True)
 
 
 def compute_z_zprime_qbfs(
-    coefs: list[float], u: be.array, usq: be.array
+    coefs: list[float], u: be.array, usq: be.array, _no_trim: bool = False
 ) -> tuple[be.array, be.array]:
     """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u."""
-    coefs = _trim_trailing_zeros(coefs)
+    if not _no_trim:
+        coefs = _trim_trailing_zeros(coefs)
     if len(coefs) == 0:
         zeros = be.zeros_like(u)
         return zeros, zeros
 
-    alphas = clenshaw_qbfs_der(coefs, usq, j=1)
+    alphas = clenshaw_qbfs_der(coefs, usq, j=1, _no_trim=True)
 
     if len(coefs) > 1:
         s = 2 * (alphas[0, 0] + alphas[0, 1])
@@ -431,11 +448,14 @@ def f_q2d(n: int, m: int) -> float:
     return (_f_q2d_raw(n, m) - g_q2d(n - 1, m) ** 2) ** 0.5
 
 
-def change_basis_q2d_to_pnm(cns: list[float], m: int) -> be.array:
+def change_basis_q2d_to_pnm(
+    cns: list[float], m: int, _no_trim: bool = False
+) -> be.array:
     """
     Changes the basis of Q2D coefficients to orthonormal Pnm coefficients.
     """
-    cns = _trim_trailing_zeros(cns)
+    if not _no_trim:
+        cns = _trim_trailing_zeros(cns)
     m = abs(m)
     n_max = len(cns) - 1
     if n_max < 0:
@@ -503,50 +523,58 @@ def _get_s_and_s_prime(alphas, m, num_coeffs):
     return s, s_prime
 
 
-def _compute_m_gt0_components(ams, bms, u, t, usq):
-    """Computes the sum and derivatives for all m>0 components."""
-    poly_sum_terms = []
-    dr_terms = []
-    dt_terms = []
+def _compute_m_gt0_components(ams, bms, u, t, usq, _no_trim: bool = False):
+    """Computes the sum and derivatives for all m>0 components.
+
+    Per-m terms are accumulated incrementally rather than collected into
+    lists and ``be.stack``-ed, which avoids allocating a ``(n_modes, *shape)``
+    intermediate per accumulator (a measurable kernel-launch/allocation cost
+    on CUDA). The running ``a + b`` adds are out-of-place, so the PyTorch
+    autograd graph is preserved.
+    """
+    poly_sum = dr_sum = dt_sum = None
 
     for m_idx, (a_coef, b_coef) in enumerate(zip(ams, bms, strict=False)):
         m = m_idx + 1
         # Trim trailing zeros independently per family so the m==1 special
         # case in q2d_sum_from_alphas reads a correctly sized alpha table
         # and does not over index when the user supplied vector ends in
-        # zeros.
-        a_coef = _trim_trailing_zeros(a_coef)
-        b_coef = _trim_trailing_zeros(b_coef)
+        # zeros. Skipped when the caller passes already-prepared families.
+        if not _no_trim:
+            a_coef = _trim_trailing_zeros(a_coef)
+            b_coef = _trim_trailing_zeros(b_coef)
 
         s_a, s_b, s_prime_a, s_prime_b = 0, 0, 0, 0
         if a_coef:
-            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1)
+            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1, _no_trim=True)
             s_a, s_prime_a = _get_s_and_s_prime(alphas_a, m, len(a_coef))
         if b_coef:
-            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1)
+            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1, _no_trim=True)
             s_b, s_prime_b = _get_s_and_s_prime(alphas_b, m, len(b_coef))
 
         um = u**m
         cost = be.cos(m * t)
         sint = be.sin(m * t)
 
-        poly_sum_terms.append(um * (cost * s_a + sint * s_b))
+        poly_term = um * (cost * s_a + sint * s_b)
         umm1 = u ** (m - 1) if m > 0 else be.ones_like(u)
         two_usq = 2 * usq
 
         aterm = cost * (two_usq * s_prime_a + m * s_a)
         bterm = sint * (two_usq * s_prime_b + m * s_b)
-        dr_terms.append(umm1 * (aterm + bterm))
-        dt_terms.append(m * um * (-s_a * sint + s_b * cost))
+        dr_term = umm1 * (aterm + bterm)
+        dt_term = m * um * (-s_a * sint + s_b * cost)
+
+        poly_sum = poly_term if poly_sum is None else poly_sum + poly_term
+        dr_sum = dr_term if dr_sum is None else dr_sum + dr_term
+        dt_sum = dt_term if dt_sum is None else dt_sum + dt_term
 
     zeros = be.zeros_like(u)
-    poly_sum_m_gt0 = (
-        be.sum(be.stack(poly_sum_terms), axis=0) if poly_sum_terms else zeros
+    return (
+        poly_sum if poly_sum is not None else zeros,
+        dr_sum if dr_sum is not None else zeros,
+        dt_sum if dt_sum is not None else zeros,
     )
-    dr_m_gt0 = be.sum(be.stack(dr_terms), axis=0) if dr_terms else zeros
-    dt_m_gt0 = be.sum(be.stack(dt_terms), axis=0) if dt_terms else zeros
-
-    return poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
 
 
 def _harmonic_powers(X, Y, m_max):
@@ -580,7 +608,7 @@ def _harmonic_powers(X, Y, m_max):
     return H_c, H_s
 
 
-def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
+def _q2d_cartesian_eval(X, Y, cm0, ams, bms, _no_trim: bool = False):
     """Evaluate the Q2D polynomial sum P(X, Y) and its Cartesian derivatives.
 
     P is the dimensionless polynomial part of the Forbes Q2D departure,
@@ -610,10 +638,11 @@ def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
     usq = X * X + Y * Y
 
     # m == 0 envelope: P_m0 = u^2 (1 - u^2) * S_cm0(u^2)
-    cm0 = _trim_trailing_zeros(cm0)
+    if not _no_trim:
+        cm0 = _trim_trailing_zeros(cm0)
     if cm0:
         # Reuse derivative Clenshaw to get S and dS/du^2 in one sweep.
-        alphas_m0 = clenshaw_qbfs_der(cm0, usq, j=1)
+        alphas_m0 = clenshaw_qbfs_der(cm0, usq, j=1, _no_trim=True)
         if len(cm0) > 1:
             s_cm0 = 2 * (alphas_m0[0, 0] + alphas_m0[0, 1])
             dsdu2_cm0 = 2 * (alphas_m0[1, 0] + alphas_m0[1, 1])
@@ -639,21 +668,28 @@ def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
 
     H_c, H_s = _harmonic_powers(X, Y, m_max)
 
-    P_terms, dPx_terms, dPy_terms = [], [], []
+    # Accumulate the m>0 contributions incrementally to avoid building three
+    # term lists and the corresponding ``be.stack`` / ``be.sum`` intermediates
+    # (heavy allocation on CUDA float32 for dense freeforms). Out-of-place adds
+    # keep the autograd graph intact.
+    P_mgt0 = dPx_mgt0 = dPy_mgt0 = None
     for m_idx in range(m_max):
         m = m_idx + 1
-        a_coef = _trim_trailing_zeros(ams[m_idx]) if m_idx < len(ams) else []
-        b_coef = _trim_trailing_zeros(bms[m_idx]) if m_idx < len(bms) else []
+        a_coef = ams[m_idx] if m_idx < len(ams) else []
+        b_coef = bms[m_idx] if m_idx < len(bms) else []
+        if not _no_trim:
+            a_coef = _trim_trailing_zeros(a_coef)
+            b_coef = _trim_trailing_zeros(b_coef)
         if not a_coef and not b_coef:
             continue
 
         s_a = s_b = dsdu2_a = dsdu2_b = 0.0
         if a_coef:
-            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1)
+            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1, _no_trim=True)
             s_a = q2d_sum_from_alphas(alphas_a[0], m, len(a_coef))
             dsdu2_a = q2d_sum_from_alphas(alphas_a[1], m, len(a_coef))
         if b_coef:
-            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1)
+            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1, _no_trim=True)
             s_b = q2d_sum_from_alphas(alphas_b[0], m, len(b_coef))
             dsdu2_b = q2d_sum_from_alphas(alphas_b[1], m, len(b_coef))
 
@@ -662,25 +698,23 @@ def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
         Hc_mm1 = H_c[m - 1]
         Hs_mm1 = H_s[m - 1]
 
-        P_terms.append(Hc_m * s_a + Hs_m * s_b)
+        P_term = Hc_m * s_a + Hs_m * s_b
         # d/dX [ H_c[m] S_a + H_s[m] S_b ]
         #   = m*H_c[m-1]*S_a + H_c[m]*2X*dS_a + m*H_s[m-1]*S_b + H_s[m]*2X*dS_b
-        dPx_terms.append(
-            m * (Hc_mm1 * s_a + Hs_mm1 * s_b)
-            + 2 * X * (Hc_m * dsdu2_a + Hs_m * dsdu2_b)
+        dPx_term = m * (Hc_mm1 * s_a + Hs_mm1 * s_b) + 2 * X * (
+            Hc_m * dsdu2_a + Hs_m * dsdu2_b
         )
         # d/dY [ H_c[m] S_a + H_s[m] S_b ]
         #   = -m*H_s[m-1]*S_a + H_c[m]*2Y*dS_a + m*H_c[m-1]*S_b + H_s[m]*2Y*dS_b
-        dPy_terms.append(
-            m * (-Hs_mm1 * s_a + Hc_mm1 * s_b)
-            + 2 * Y * (Hc_m * dsdu2_a + Hs_m * dsdu2_b)
+        dPy_term = m * (-Hs_mm1 * s_a + Hc_mm1 * s_b) + 2 * Y * (
+            Hc_m * dsdu2_a + Hs_m * dsdu2_b
         )
 
-    if P_terms:
-        P_mgt0 = be.sum(be.stack(P_terms), axis=0)
-        dPx_mgt0 = be.sum(be.stack(dPx_terms), axis=0)
-        dPy_mgt0 = be.sum(be.stack(dPy_terms), axis=0)
-    else:
+        P_mgt0 = P_term if P_mgt0 is None else P_mgt0 + P_term
+        dPx_mgt0 = dPx_term if dPx_mgt0 is None else dPx_mgt0 + dPx_term
+        dPy_mgt0 = dPy_term if dPy_mgt0 is None else dPy_mgt0 + dPy_term
+
+    if P_mgt0 is None:
         P_mgt0 = be.zeros_like(usq)
         dPx_mgt0 = be.zeros_like(usq)
         dPy_mgt0 = be.zeros_like(usq)
@@ -688,37 +722,39 @@ def _q2d_cartesian_eval(X, Y, cm0, ams, bms):
     return P_m0 + P_mgt0, dP_m0_dX + dPx_mgt0, dP_m0_dY + dPy_mgt0
 
 
-def _compute_m_gt0_sag_only(ams, bms, u, t, usq):
+def _compute_m_gt0_sag_only(ams, bms, u, t, usq, _no_trim: bool = False):
     """Sag-only counterpart of :func:`_compute_m_gt0_components`.
 
     Skips the derivative Clenshaw pass and the radial / azimuthal
     derivative accumulators; only the m>0 polynomial sum is returned.
+    Terms are accumulated incrementally (see
+    :func:`_compute_m_gt0_components`).
     """
-    poly_sum_terms = []
+    poly_sum = None
     for m_idx, (a_coef, b_coef) in enumerate(zip(ams, bms, strict=False)):
         m = m_idx + 1
-        a_coef = _trim_trailing_zeros(a_coef)
-        b_coef = _trim_trailing_zeros(b_coef)
+        if not _no_trim:
+            a_coef = _trim_trailing_zeros(a_coef)
+            b_coef = _trim_trailing_zeros(b_coef)
 
         s_a, s_b = 0, 0
         if a_coef:
-            alphas_a = clenshaw_q2d(a_coef, m, usq)
+            alphas_a = clenshaw_q2d(a_coef, m, usq, _no_trim=True)
             s_a = q2d_sum_from_alphas(alphas_a, m, len(a_coef))
         if b_coef:
-            alphas_b = clenshaw_q2d(b_coef, m, usq)
+            alphas_b = clenshaw_q2d(b_coef, m, usq, _no_trim=True)
             s_b = q2d_sum_from_alphas(alphas_b, m, len(b_coef))
 
         um = u**m
         cost = be.cos(m * t)
         sint = be.sin(m * t)
-        poly_sum_terms.append(um * (cost * s_a + sint * s_b))
+        poly_term = um * (cost * s_a + sint * s_b)
+        poly_sum = poly_term if poly_sum is None else poly_sum + poly_term
 
-    if poly_sum_terms:
-        return be.sum(be.stack(poly_sum_terms), axis=0)
-    return be.zeros_like(u)
+    return poly_sum if poly_sum is not None else be.zeros_like(u)
 
 
-def compute_z_q2d(cm0, ams, bms, u, t):
+def compute_z_q2d(cm0, ams, bms, u, t, _no_trim: bool = False):
     """Sag-only Q2D polynomial sum (no derivative table built).
 
     Returns the pair ``(poly_sum_m0, poly_sum_m_gt0)`` — the same first
@@ -739,23 +775,29 @@ def compute_z_q2d(cm0, ams, bms, u, t):
     usq = u * u
     zeros = be.zeros_like(u)
 
-    cm0 = _trim_trailing_zeros(cm0)
-    poly_sum_m0 = zeros if not cm0 else compute_z_qbfs(cm0, usq)
-    poly_sum_m_gt0 = _compute_m_gt0_sag_only(ams, bms, u, t, usq)
+    if not _no_trim:
+        cm0 = _trim_trailing_zeros(cm0)
+    poly_sum_m0 = zeros if not cm0 else compute_z_qbfs(cm0, usq, _no_trim=True)
+    poly_sum_m_gt0 = _compute_m_gt0_sag_only(ams, bms, u, t, usq, _no_trim=_no_trim)
     return poly_sum_m0, poly_sum_m_gt0
 
 
-def compute_z_zprime_q2d(cm0, ams, bms, u, t):
+def compute_z_zprime_q2d(cm0, ams, bms, u, t, _no_trim: bool = False):
     """Computes the polynomial sum components for a Q2D surface."""
     usq = u * u
     zeros = be.zeros_like(u)
 
-    cm0 = _trim_trailing_zeros(cm0)
+    if not _no_trim:
+        cm0 = _trim_trailing_zeros(cm0)
     poly_sum_m0, d_poly_sum_m0_du = zeros, zeros
     if cm0:
-        poly_sum_m0, d_poly_sum_m0_du = compute_z_zprime_qbfs(cm0, u, usq)
+        poly_sum_m0, d_poly_sum_m0_du = compute_z_zprime_qbfs(
+            cm0, u, usq, _no_trim=True
+        )
 
-    poly_sum_m_gt0, dr_m_gt0, dt_m_gt0 = _compute_m_gt0_components(ams, bms, u, t, usq)
+    poly_sum_m_gt0, dr_m_gt0, dt_m_gt0 = _compute_m_gt0_components(
+        ams, bms, u, t, usq, _no_trim=_no_trim
+    )
 
     return poly_sum_m0, d_poly_sum_m0_du, poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
 
@@ -791,11 +833,12 @@ def q2d_nm_coeffs_to_ams_bms(nms: list[tuple[int, int]], coefs: list[float]):
     return cms, ams_ret, bms_ret
 
 
-def clenshaw_q2d(cns, m, usq, alphas=None):
+def clenshaw_q2d(cns, m, usq, alphas=None, _no_trim: bool = False):
     """Evaluates the Q2D Clenshaw alpha table for azimuthal order ``m``."""
-    cns = _trim_trailing_zeros(cns)
+    if not _no_trim:
+        cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
-        ds = change_basis_q2d_to_pnm(cns, m)
+        ds = change_basis_q2d_to_pnm(cns, m, _no_trim=True)
         all_alphas_list = _clenshaw_q2d_functional(ds, m, usq)
 
         if not all_alphas_list:
@@ -807,7 +850,7 @@ def clenshaw_q2d(cns, m, usq, alphas=None):
             return alphas
         return result_tensor
 
-    ds = change_basis_q2d_to_pnm(cns, m)
+    ds = change_basis_q2d_to_pnm(cns, m, _no_trim=True)
     alphas = _initialize_alphas_q(ds, usq, alphas)
     n_max = len(ds) - 1
     if n_max < 0:
@@ -846,9 +889,10 @@ def _clenshaw_q2d_functional(ds, m, usq):
     return all_alphas
 
 
-def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None):
+def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None, _no_trim: bool = False):
     """Computes derivatives of Q-2D polynomials using Clenshaw's method."""
-    cns = _trim_trailing_zeros(cns)
+    if not _no_trim:
+        cns = _trim_trailing_zeros(cns)
     if be.get_backend() == "torch":
         return _clenshaw_q2d_der_functional(cns, m, usq, j)
 
@@ -885,7 +929,7 @@ def _clenshaw_q2d_der_functional(cns, m, usq, j=1):
         )
         return be.zeros(shape)
 
-    ds = change_basis_q2d_to_pnm(cns, m)
+    ds = change_basis_q2d_to_pnm(cns, m, _no_trim=True)
     alphas_j0_list = _clenshaw_q2d_functional(ds, m, usq)
     all_alphas_tensors = [be.stack(alphas_j0_list)]
     prev_alphas_j_list = alphas_j0_list

--- a/tests/test_forbes_coeff_cache.py
+++ b/tests/test_forbes_coeff_cache.py
@@ -1,0 +1,316 @@
+"""Regression tests for Forbes coefficient caching / cache invalidation.
+
+The Forbes Q / Q2D geometries cache prepared (trimmed) coefficient
+containers and rebuild them only when invalidated -- on construction, on
+``scale``, and on optimizer coefficient updates -- rather than on every
+``sag`` / ``_surface_normal`` call (issue #617 performance work). These
+tests pin the *correctness* of that cache: a coefficient change must be
+reflected in the very next evaluation, and the cached path must match a
+freshly constructed surface. Autograd through both coefficient tensors and
+``(x, y)`` must also survive the cached, ``_no_trim`` hot path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.geometries import (
+    ForbesQ2dGeometry,
+    ForbesQNormalSlopeGeometry,
+    ForbesSurfaceConfig,
+)
+from optiland.optimization.scaling.identity import IdentityScaler
+from optiland.optimization.variable import (
+    ForbesQ2dCoeffVariable,
+    ForbesQNormalSlopeCoeffVariable,
+)
+from optiland.samples.simple import AsphericSinglet
+
+from .utils import assert_allclose
+
+
+def _abs_diff(a, b):
+    """Backend- and autograd-safe ``|a - b|`` as a Python float."""
+    return float(be.to_numpy(be.abs(a - b)))
+
+
+def _single_surface_optic(geometry):
+    """Optic exposing ``geometry`` on surface index 1.
+
+    The coefficient variables resolve the geometry through
+    ``optic.surfaces[surface_number].geometry``; replacing the geometry on a
+    ready-made singlet satisfies that lookup without rebuilding an optic.
+    """
+    optic = AsphericSinglet()
+    optic.surfaces[1].geometry = geometry
+    return optic
+
+
+def _qbfs_geom():
+    cfg = ForbesSurfaceConfig(
+        radius=25.0,
+        conic=-0.5,
+        norm_radius=8.0,
+        terms={0: 1.0e-3, 1: -5.0e-4, 2: 2.0e-4, 3: -8.0e-5},
+    )
+    return ForbesQNormalSlopeGeometry(CoordinateSystem(), cfg)
+
+
+def _q2d_geom():
+    cfg = ForbesSurfaceConfig(
+        radius=25.0,
+        conic=-0.5,
+        norm_radius=8.0,
+        terms={
+            ("a", 0, 0): 5.0e-4,
+            ("a", 0, 1): -2.0e-4,
+            ("a", 1, 0): 1.0e-4,
+            ("b", 1, 0): 8.0e-5,
+        },
+    )
+    return ForbesQ2dGeometry(CoordinateSystem(), cfg)
+
+
+# ---------------------------------------------------------------------------
+# Direct in-place dict edits must invalidate the cache (no variable system).
+# ---------------------------------------------------------------------------
+
+
+class TestDirectDictEditInvalidation:
+    """A raw ``geom.radial_terms[k] = v`` poke (bypassing the variable system
+    and ``scale``) must still be reflected by the next evaluation, matching the
+    pre-cache behavior. Guarded by the ``_CoeffCacheDict`` wrapper."""
+
+    def test_qbfs_direct_radial_terms_edit(self, set_test_backend):
+        geom = _qbfs_geom()
+        x, y = be.array(3.0), be.array(2.0)
+        before = be.copy(geom.sag(x, y))  # primes the cache (dirty -> clean)
+
+        geom.radial_terms[1] = be.array(0.05)  # raw in-place edit
+        after = geom.sag(x, y)
+
+        assert _abs_diff(after, before) > 1e-9
+        fresh_cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.5,
+            norm_radius=8.0,
+            terms={0: 1.0e-3, 1: 0.05, 2: 2.0e-4, 3: -8.0e-5},
+        )
+        fresh = ForbesQNormalSlopeGeometry(CoordinateSystem(), fresh_cfg)
+        assert_allclose(after, fresh.sag(x, y))
+
+    def test_q2d_direct_freeform_coeffs_edit(self, set_test_backend):
+        geom = _q2d_geom()
+        x, y = be.array(3.0), be.array(2.0)
+        before = be.copy(geom.sag(x, y))
+
+        geom.freeform_coeffs[("a", 1, 0)] = be.array(0.03)  # raw in-place edit
+        after = geom.sag(x, y)
+
+        assert _abs_diff(after, before) > 1e-9
+        new_terms = {
+            ("a", 0, 0): 5.0e-4,
+            ("a", 0, 1): -2.0e-4,
+            ("a", 1, 0): 0.03,
+            ("b", 1, 0): 8.0e-5,
+        }
+        fresh = ForbesQ2dGeometry(
+            CoordinateSystem(),
+            ForbesSurfaceConfig(
+                radius=25.0, conic=-0.5, norm_radius=8.0, terms=new_terms
+            ),
+        )
+        assert_allclose(after, fresh.sag(x, y))
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation: a coefficient change must be reflected immediately.
+# ---------------------------------------------------------------------------
+
+
+class TestQbfsCacheInvalidation:
+    def test_repeated_sag_is_stable(self, set_test_backend):
+        """Two evaluations without a change must agree (cache not corrupted)."""
+        geom = _qbfs_geom()
+        x, y = be.array(3.0), be.array(2.0)
+        first = geom.sag(x, y)
+        second = geom.sag(x, y)
+        assert_allclose(first, second)
+
+    def test_update_value_changes_sag_and_matches_fresh(self, set_test_backend):
+        geom = _qbfs_geom()
+        optic = _single_surface_optic(geom)
+        x, y = be.array(3.0), be.array(2.0)
+
+        before = be.copy(geom.sag(x, y))
+
+        var = ForbesQNormalSlopeCoeffVariable(optic, 1, 1, scaler=IdentityScaler())
+        var.update_value(0.05)
+        after = geom.sag(x, y)
+
+        # The cached prepared coefficients must have been invalidated.
+        assert _abs_diff(after, before) > 1e-9
+
+        # ... and the result must match a fresh surface built with the new
+        # coefficient (proves the rebuild is correct, not just different).
+        fresh_cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.5,
+            norm_radius=8.0,
+            terms={0: 1.0e-3, 1: 0.05, 2: 2.0e-4, 3: -8.0e-5},
+        )
+        fresh = ForbesQNormalSlopeGeometry(CoordinateSystem(), fresh_cfg)
+        assert_allclose(after, fresh.sag(x, y))
+
+    def test_update_value_changes_surface_normal(self, set_test_backend):
+        geom = _qbfs_geom()
+        optic = _single_surface_optic(geom)
+        x, y = be.array(3.0), be.array(2.0)
+
+        nx0, ny0, nz0 = (be.copy(c) for c in geom._surface_normal(x, y))
+
+        var = ForbesQNormalSlopeCoeffVariable(optic, 1, 2, scaler=IdentityScaler())
+        var.update_value(0.02)
+        nx1, ny1, nz1 = geom._surface_normal(x, y)
+
+        assert _abs_diff(nx1, nx0) > 1e-9
+
+        fresh_cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.5,
+            norm_radius=8.0,
+            terms={0: 1.0e-3, 1: -5.0e-4, 2: 0.02, 3: -8.0e-5},
+        )
+        fresh = ForbesQNormalSlopeGeometry(CoordinateSystem(), fresh_cfg)
+        fnx, fny, fnz = fresh._surface_normal(x, y)
+        assert_allclose(nx1, fnx)
+        assert_allclose(ny1, fny)
+        assert_allclose(nz1, fnz)
+
+
+class TestQ2dCacheInvalidation:
+    @pytest.mark.parametrize("key", [("a", 1, 0), ("b", 1, 0)])
+    def test_update_value_changes_sag_and_matches_fresh(self, set_test_backend, key):
+        geom = _q2d_geom()
+        optic = _single_surface_optic(geom)
+        x, y = be.array(3.0), be.array(2.0)
+
+        before = be.copy(geom.sag(x, y))
+
+        var = ForbesQ2dCoeffVariable(optic, 1, key, scaler=IdentityScaler())
+        var.update_value(0.03)
+        after = geom.sag(x, y)
+
+        assert _abs_diff(after, before) > 1e-9
+
+        new_terms = {
+            ("a", 0, 0): 5.0e-4,
+            ("a", 0, 1): -2.0e-4,
+            ("a", 1, 0): 1.0e-4,
+            ("b", 1, 0): 8.0e-5,
+        }
+        new_terms[key] = 0.03
+        fresh_cfg = ForbesSurfaceConfig(
+            radius=25.0, conic=-0.5, norm_radius=8.0, terms=new_terms
+        )
+        fresh = ForbesQ2dGeometry(CoordinateSystem(), fresh_cfg)
+        assert_allclose(after, fresh.sag(x, y))
+
+    def test_update_value_changes_surface_normal(self, set_test_backend):
+        geom = _q2d_geom()
+        optic = _single_surface_optic(geom)
+        x, y = be.array(3.0), be.array(2.0)
+
+        nx0 = be.copy(geom._surface_normal(x, y)[0])
+
+        var = ForbesQ2dCoeffVariable(optic, 1, ("a", 1, 0), scaler=IdentityScaler())
+        var.update_value(0.03)
+        nx1 = geom._surface_normal(x, y)[0]
+        assert _abs_diff(nx1, nx0) > 1e-9
+
+
+# ---------------------------------------------------------------------------
+# scale() must invalidate and produce the correctly scaled behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestScaleInvalidation:
+    def test_qbfs_scale_changes_sag(self, set_test_backend):
+        geom = _qbfs_geom()
+        x, y = be.array(3.0), be.array(2.0)
+        before = be.copy(geom.sag(x, y))  # primes the cache
+
+        geom.scale(2.0)
+        after = geom.sag(be.array(6.0), be.array(4.0))
+
+        # A geometry scaled by k satisfies z_scaled(k*r) = k * z(r).
+        assert_allclose(after, 2.0 * before, rtol=1e-6, atol=1e-9)
+
+    def test_q2d_scale_changes_sag(self, set_test_backend):
+        geom = _q2d_geom()
+        x, y = be.array(3.0), be.array(2.0)
+        before = be.copy(geom.sag(x, y))
+
+        geom.scale(2.0)
+        after = geom.sag(be.array(6.0), be.array(4.0))
+        assert_allclose(after, 2.0 * before, rtol=1e-6, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Autograd must survive the cached, _no_trim hot path.
+# ---------------------------------------------------------------------------
+
+
+class TestAutogradThroughCache:
+    def test_qbfs_grad_through_coeffs_and_xy(self, set_test_backend):
+        if be.get_backend() != "torch":
+            pytest.skip("autograd path is torch-only")
+        import torch
+
+        c1 = torch.tensor(-5.0e-4, dtype=torch.float64, requires_grad=True)
+        cfg = ForbesSurfaceConfig(
+            radius=25.0, conic=-0.5, norm_radius=8.0, terms={0: 1.0e-3, 2: 2.0e-4}
+        )
+        geom = ForbesQNormalSlopeGeometry(CoordinateSystem(), cfg)
+        # Inject a grad-requiring coefficient and invalidate the cache so the
+        # next evaluation rebuilds the prepared containers from it.
+        geom.radial_terms[1] = c1
+        geom._coeffs_dirty = True
+
+        x = torch.tensor(3.0, dtype=torch.float64, requires_grad=True)
+        y = torch.tensor(2.0, dtype=torch.float64, requires_grad=True)
+        z = geom.sag(x, y)
+        z.backward()
+
+        for g in (c1.grad, x.grad, y.grad):
+            assert g is not None
+            assert torch.isfinite(g).all()
+
+    def test_q2d_grad_through_coeffs_and_xy(self, set_test_backend):
+        if be.get_backend() != "torch":
+            pytest.skip("autograd path is torch-only")
+        import torch
+
+        a10 = torch.tensor(1.0e-4, dtype=torch.float64, requires_grad=True)
+        cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.5,
+            norm_radius=8.0,
+            terms={("a", 0, 0): 5.0e-4, ("a", 1, 0): 2.0e-4, ("b", 1, 0): 8.0e-5},
+        )
+        geom = ForbesQ2dGeometry(CoordinateSystem(), cfg)
+        geom.freeform_coeffs[("a", 1, 0)] = a10
+        geom._coeffs_dirty = True
+
+        x = torch.tensor(3.0, dtype=torch.float64, requires_grad=True)
+        y = torch.tensor(2.0, dtype=torch.float64, requires_grad=True)
+        # Sum sag and the Cartesian normal so both hot paths are exercised.
+        z = geom.sag(x, y)
+        dfdx, dfdy = geom._surface_normal_analytical_cartesian(x, y)
+        (z + dfdx + dfdy).backward()
+
+        for g in (a10.grad, x.grad, y.grad):
+            assert g is not None
+            assert torch.isfinite(g).all()

--- a/tests/test_forbes_qpoly.py
+++ b/tests/test_forbes_qpoly.py
@@ -13,6 +13,8 @@ import pytest
 
 import optiland.backend as be
 from optiland.geometries.forbes.qpoly import (
+    _harmonic_powers,
+    _q2d_cartesian_eval,
     _trim_trailing_zeros,
     change_basis_q2d_to_pnm,
     change_basis_qbfs_to_pn,
@@ -395,4 +397,275 @@ class TestForbesQ2dSagRoutingBitParity:
         sag_expected = geom._base_sag(r2) + be.where(u > 1, 0.0, dep)
         assert_allclose(sag_new, sag_expected)
 
+
+# ---------------------------------------------------------------------------
+# PR 3 — harmonic powers + Cartesian Q2D derivatives
+# ---------------------------------------------------------------------------
+
+
+class TestHarmonicPowers:
+    """Sanity-check the (X + iY)**m recurrence used to build the
+    rotationally-equivariant Cartesian derivative path."""
+
+    def test_recurrence_matches_complex_power(self, set_test_backend):
+        rng = np.random.default_rng(0)
+        X_np = rng.uniform(-0.7, 0.7, size=11)
+        Y_np = rng.uniform(-0.7, 0.7, size=11)
+        X = be.array(X_np)
+        Y = be.array(Y_np)
+        Hc, Hs = _harmonic_powers(X, Y, 5)
+        for m in range(6):
+            ref = (X_np + 1j * Y_np) ** m
+            assert_allclose(Hc[m], be.array(ref.real))
+            assert_allclose(Hs[m], be.array(ref.imag))
+
+    def test_origin_is_regular(self, set_test_backend):
+        # At X = Y = 0 we expect (1, 0) for m = 0 and (0, 0) for m >= 1.
+        X = be.array(0.0)
+        Y = be.array(0.0)
+        Hc, Hs = _harmonic_powers(X, Y, 4)
+        assert float(be.to_numpy(Hc[0])) == 1.0
+        for m in range(1, 5):
+            assert float(be.to_numpy(Hc[m])) == 0.0
+            assert float(be.to_numpy(Hs[m])) == 0.0
+
+
+def _fd_partials(fn, x, y, h=1e-6):
+    """Centered finite differences of a scalar-valued ``fn(x, y)``."""
+    return (fn(x + h, y) - fn(x - h, y)) / (2 * h), (fn(x, y + h) - fn(x, y - h)) / (
+        2 * h
+    )
+
+
+class TestQ2dCartesianEvalFD:
+    """`_q2d_cartesian_eval` derivatives must match centered finite
+    differences of the underlying polynomial value."""
+
+    def _coeffs(self):
+        cm0 = [1.0e-3, -5.0e-4, 2.0e-4]
+        ams = [
+            [3.0e-4, -1.0e-4],  # m=1
+            [],  # m=2: empty cosine family
+            [4.0e-5],  # m=3
+        ]
+        bms = [
+            [],  # m=1: empty sine family
+            [2.0e-4, -1.0e-4],  # m=2
+            [],  # m=3
+        ]
+        return cm0, ams, bms
+
+    def test_fd_parity_away_from_origin(self, set_test_backend):
+        cm0, ams, bms = self._coeffs()
+
+        def P_only(x, y):
+            X = be.array(x)
+            Y = be.array(y)
+            P, _, _ = _q2d_cartesian_eval(X, Y, cm0, ams, bms)
+            return float(be.to_numpy(P))
+
+        for x0, y0 in [(0.4, 0.2), (-0.3, 0.6), (0.7, -0.5), (0.1, 0.05)]:
+            X = be.array(x0)
+            Y = be.array(y0)
+            _, dPdX, dPdY = _q2d_cartesian_eval(X, Y, cm0, ams, bms)
+            fd_x, fd_y = _fd_partials(P_only, x0, y0, h=1e-6)
+            assert_allclose(dPdX, be.array(fd_x), rtol=1e-5, atol=1e-9)
+            assert_allclose(dPdY, be.array(fd_y), rtol=1e-5, atol=1e-9)
+
+    def test_fd_parity_near_and_at_origin(self, set_test_backend):
+        cm0, ams, bms = self._coeffs()
+
+        def P_only(x, y):
+            X = be.array(x)
+            Y = be.array(y)
+            P, _, _ = _q2d_cartesian_eval(X, Y, cm0, ams, bms)
+            return float(be.to_numpy(P))
+
+        for x0, y0 in [(0.0, 0.0), (1e-8, 0.0), (0.0, 1e-8), (1e-4, 1e-4)]:
+            X = be.array(x0)
+            Y = be.array(y0)
+            _, dPdX, dPdY = _q2d_cartesian_eval(X, Y, cm0, ams, bms)
+            # Use a step that is large compared to x0/y0 so the FD itself
+            # is well-conditioned (h >> |x0| keeps the centered difference
+            # in the smooth region around the origin).
+            h = max(1e-5, abs(x0) * 10, abs(y0) * 10)
+            fd_x, fd_y = _fd_partials(P_only, x0, y0, h=h)
+            assert_allclose(dPdX, be.array(fd_x), rtol=1e-4, atol=1e-9)
+            assert_allclose(dPdY, be.array(fd_y), rtol=1e-4, atol=1e-9)
+
+
+class TestForbesQ2dCartesianNormal:
+    """The Cartesian-normal path on ``ForbesQ2dGeometry`` must agree
+    with the polar path away from the origin and remain finite at the
+    origin (where the polar path applies a separate ``where``-blend)."""
+
+    def _build(self):
+        from optiland.coordinate_system import CoordinateSystem
+        from optiland.geometries import ForbesQ2dGeometry, ForbesSurfaceConfig
+
+        cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.5,
+            terms={
+                ("a", 0, 0): 1.2e-3,
+                ("a", 0, 1): -4.0e-4,
+                ("a", 1, 0): 2.0e-4,
+                ("a", 1, 1): -8.0e-5,
+                ("b", 1, 0): 1.0e-4,
+                ("a", 2, 0): 3.0e-5,
+                ("b", 2, 1): -1.0e-5,
+                ("a", 3, 0): 5.0e-6,
+            },
+            norm_radius=8.0,
+        )
+        return ForbesQ2dGeometry(CoordinateSystem(), cfg)
+
+    def test_cartesian_matches_polar_away_from_origin(self, set_test_backend):
+        geom = self._build()
+        x = be.array([0.5, 1.0, 2.5, -3.0, 4.5])
+        y = be.array([0.3, -0.7, 1.4, 2.0, -0.5])
+        polar = geom._surface_normal_analytical(x, y)
+        cart = geom._surface_normal_analytical_cartesian(x, y)
+        # Tolerances loose enough to cover the polar (1/r) path's own
+        # round-off but tight enough to catch a real disagreement.
+        assert_allclose(cart[0], polar[0], rtol=1e-8, atol=1e-10)
+        assert_allclose(cart[1], polar[1], rtol=1e-8, atol=1e-10)
+
+    def test_cartesian_finite_at_exact_origin(self, set_test_backend):
+        geom = self._build()
+        x = be.array(0.0)
+        y = be.array(0.0)
+        dfdx, dfdy = geom._surface_normal_analytical_cartesian(x, y)
+        v_x = float(be.to_numpy(dfdx))
+        v_y = float(be.to_numpy(dfdy))
+        assert np.isfinite(v_x)
+        assert np.isfinite(v_y)
+        # At origin only the m=1 family contributes to the slope. With
+        # ('a', 1, 0) > 0 the X-slope must be > 0 and ('b', 1, 0) > 0
+        # gives a positive Y-slope.
+        assert v_x > 0.0
+        assert v_y > 0.0
+
+    def test_cartesian_fd_parity_at_and_near_origin(self, set_test_backend):
+        geom = self._build()
+
+        def sag(x_, y_):
+            return float(be.to_numpy(geom.sag(be.array(x_), be.array(y_))))
+
+        # FD step h must be large enough to avoid catastrophic cancellation
+        # in float64 sag evaluations (the sag itself is ~ 1e-6 mm near the
+        # axis), but small enough that the O(h^2) truncation error stays
+        # below the asserted tolerance.  h = 1e-3 mm is a safe sweet spot
+        # for this geometry: sag changes are well above eps_f64 * |sag|.
+        h = 1.0e-3
+        for x0, y0 in [(0.0, 0.0), (1e-6, 0.0), (0.0, 1e-6), (1e-4, 1e-4)]:
+            dfdx, dfdy = geom._surface_normal_analytical_cartesian(
+                be.array(x0), be.array(y0)
+            )
+            fd_x = (sag(x0 + h, y0) - sag(x0 - h, y0)) / (2 * h)
+            fd_y = (sag(x0, y0 + h) - sag(x0, y0 - h)) / (2 * h)
+            assert_allclose(dfdx, be.array(fd_x), rtol=1e-5, atol=1e-9)
+            assert_allclose(dfdy, be.array(fd_y), rtol=1e-5, atol=1e-9)
+
+    def test_default_is_cartesian(self, set_test_backend):
+        geom = self._build()
+        assert geom._use_cartesian_normal is True
+
+    def test_cartesian_switch_dispatches(self, set_test_backend):
+        geom = self._build()
+        x = be.array([0.5, 1.2, -0.4])
+        y = be.array([0.3, -0.8, 1.0])
+        # Default is Cartesian — dispatch must match the explicit call.
+        default = geom._surface_normal_analytical(x, y)
+        cart = geom._surface_normal_analytical_cartesian(x, y)
+        assert_allclose(default[0], cart[0])
+        assert_allclose(default[1], cart[1])
+
+        # Toggling off must route through the legacy polar path, which
+        # away from origin agrees with Cartesian.
+        geom._use_cartesian_normal = False
+        try:
+            polar = geom._surface_normal_analytical(x, y)
+        finally:
+            geom._use_cartesian_normal = True
+        assert_allclose(cart[0], polar[0], rtol=1e-8, atol=1e-10)
+        assert_allclose(cart[1], polar[1], rtol=1e-8, atol=1e-10)
+
+    def test_cartesian_handles_asymmetric_families(self, set_test_backend):
+        from optiland.coordinate_system import CoordinateSystem
+        from optiland.geometries import ForbesQ2dGeometry, ForbesSurfaceConfig
+
+        # Only cosine-m=2 and only sine-m=3 families — exercises the
+        # asymmetric a-only / b-only family path inside the Cartesian
+        # evaluator.
+        cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=0.0,
+            terms={
+                ("a", 2, 0): 2.0e-4,
+                ("a", 2, 1): -1.0e-4,
+                ("b", 3, 0): 1.0e-4,
+            },
+            norm_radius=8.0,
+        )
+        geom = ForbesQ2dGeometry(CoordinateSystem(), cfg)
+
+        # The Cartesian helper must run without IndexError on the
+        # asymmetric per-m families.
+        x = be.array([0.3, 1.5, -2.0, 0.0])
+        y = be.array([0.4, -0.5, 1.2, 0.0])
+        dfdx, dfdy = geom._surface_normal_analytical_cartesian(x, y)
+        assert np.all(np.isfinite(be.to_numpy(dfdx)))
+        assert np.all(np.isfinite(be.to_numpy(dfdy)))
+
+        # Away from origin, Cartesian must match polar.
+        x_off = be.array([0.3, 1.5, -2.0])
+        y_off = be.array([0.4, -0.5, 1.2])
+        polar = geom._surface_normal_analytical(x_off, y_off)
+        cart = geom._surface_normal_analytical_cartesian(x_off, y_off)
+        assert_allclose(cart[0], polar[0], rtol=1e-8, atol=1e-10)
+        assert_allclose(cart[1], polar[1], rtol=1e-8, atol=1e-10)
+
+
+class TestForbesQ2dCartesianTorchAutograd:
+    """The Cartesian normal must remain autograd-differentiable through
+    both Q coefficients and (x, y), even at the exact origin where the
+    polar path produces NaN gradients."""
+
+    def test_autograd_origin_finite_gradients(self, set_test_backend):
+        if be.get_backend() != "torch":
+            pytest.skip("autograd path is torch-only")
+
+        import torch
+
+        from optiland.coordinate_system import CoordinateSystem
+        from optiland.geometries import ForbesQ2dGeometry, ForbesSurfaceConfig
+
+        cfg = ForbesSurfaceConfig(
+            radius=25.0,
+            conic=-0.3,
+            terms={
+                ("a", 0, 0): 1.0e-3,
+                ("a", 1, 0): 2.0e-4,
+                ("b", 1, 0): 1.5e-4,
+                ("a", 2, 0): 3.0e-5,
+            },
+            norm_radius=8.0,
+        )
+        geom = ForbesQ2dGeometry(CoordinateSystem(), cfg)
+
+        x = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+        y = torch.tensor(0.0, dtype=torch.float64, requires_grad=True)
+        dfdx, dfdy = geom._surface_normal_analytical_cartesian(x, y)
+        # The Cartesian derivatives at origin should themselves be finite.
+        assert torch.isfinite(dfdx).all()
+        assert torch.isfinite(dfdy).all()
+        # And backpropagating through them should not produce NaN.
+        (dfdx + dfdy).backward()
+        assert torch.isfinite(x.grad).all()
+        assert torch.isfinite(y.grad).all()
+
+
+# Mark Q2D regression tests on numpy backend — torch import not available
+# in some local environments; parametrized backend fixture covers both.
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")


### PR DESCRIPTION
1. Direct-Cartesian Q2D surface normals (harmonic powers):

  - `_harmonic_powers(X, Y, m_max)` computes `Re/Im` of `(X + iY)**m` via the complex-multiplication recurrence — no `1/r`, regular at the origin.
  - `_q2d_cartesian_eval` evaluates the dimensionless polynomial `P(X, Y)` and its Cartesian derivatives `dP/dX, dP/dY` directly, so the Q2D normal is finite and autograd differentiable at the vertex.
  - `ForbesQ2dGeometry._use_cartesian_normal = True` makes this the default; the legacy polar path with its explicit vertex `where`-blend is retained for one release behind `_use_cartesian_normal = False` as a safety backup.

2. PErformance improvement
- **Trimming out of the hot path.** `_trim_trailing_zeros` checked each trailing coefficient with `bool(v == 0)`, forcing a CUDA sync on every evaluation (the `cudaStreamSynchronize` count matched the trim scalar reads almost exactly). Trimming now happens once at coefficien preparation, producing trimmed `prepared_*` containers; the low-level Clenshaw functions gained an internal `_no_trim=True` fast path (public defaults still trim).
- **Coefficient caching.** `_prepare_coeffs()` (which rebuilt and `be.stack`-ed coefficients — for Qbfs, *twice* per `sag+normal`) is now gated by a `_coeffs_dirty` flag and called via `_ensure_coeffs()`. Invalidated on construction, `scale()`, and optimizer coefficient updates; `update_normalization` does not invalidate (norm_radius is applied at evaluation time, not in preparation).
- **Less allocation.** The Q2D m>0 term sums use incremental out of place accumulation instead of `be.sum(be.stack(...))`
  (autograd safe).


PR 3/4 

#617 