### PR TITLE
Robust Surface Addition & Coordinate Calculation Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov/
 sg_execution_times.rst
 .qlty/
 .claude/
+scratch/

--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -58,7 +58,7 @@ def _trim_trailing_zeros(coefs):
         n -= 1
     if n == 0:
         return []
-    if isinstance(coefs, (list, tuple)):
+    if isinstance(coefs, list | tuple):
         return list(coefs[:n])
     # NumPy array or Torch tensor — keep entries by reference so that any
     # autograd graph attached to surviving entries is preserved.

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -482,10 +482,10 @@ class MaterialFile(BaseMaterial):
 
     def _parse_formula_data(self, sub_data: dict, sub_data_type: str) -> None:
         """Parse formula-based material data."""
-        self.coefficients = be.array(
-            [float(k) for k in sub_data.get("coefficients", "").split()]
-        )
-        self.coefficients = be.reshape(self.coefficients, (-1, 1))
+        coeff_values = [float(k) for k in sub_data.get("coefficients", "").split()]
+        # Build a 2D column array directly from Python values so the result is
+        # always a graph-leaf (avoids a non-leaf view from reshape on a 1-D tensor).
+        self.coefficients = be.array([[c] for c in coeff_values])
         self._set_formula_type(sub_data_type)
 
     def _parse_tabulated_data(self, sub_data: dict, sub_data_type: str) -> None:
@@ -513,10 +513,8 @@ class MaterialFile(BaseMaterial):
         try:
             coeff = data["SPECS"]["thermal_dispersion"][0]
             if coeff.get("type", "").startswith("Schott"):
-                self.thermdispcoef = be.array(
-                    [float(k) for k in coeff.get("coefficients", "").split()]
-                )
-                self.thermdispcoef = be.reshape(self.thermdispcoef, (-1, 1))
+                td_values = [float(k) for k in coeff.get("coefficients", "").split()]
+                self.thermdispcoef = be.array([[c] for c in td_values])
 
             self._t0 = float(data["SPECS"]["temperature"].split(" ")[0])
         except KeyError:

--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -265,9 +265,10 @@ class OpticUpdater:
         ya, ua = self.optic.paraxial.marginal_ray()
         offset = float(ya[-1, 0] / ua[-1, 0])
         surfaces = self.optic.surfaces
-        self.optic.surfaces[-1].geometry.cs.z -= offset
-        surfaces[-2].thickness = (
-            self.optic.surfaces[-1].geometry.cs.z - surfaces[-2].geometry.cs.z
+        old_z = float(surfaces[-1].geometry.cs.z)
+        surfaces[-1].geometry.cs.z = be.array(old_z - offset)
+        surfaces[-2].thickness = float(surfaces[-1].geometry.cs.z) - float(
+            surfaces[-2].geometry.cs.z
         )
 
     def flip(self):

--- a/optiland/surfaces/factories/coordinate_system_factory.py
+++ b/optiland/surfaces/factories/coordinate_system_factory.py
@@ -77,9 +77,15 @@ class CoordinateSystemFactory:
                 z = 0  # first surface, always at zero
             else:
                 prev_surface = surface_group.surfaces[index - 1]
-                z_prev_surface = prev_surface.geometry.cs.z
-                thickness_after_prev_surface = prev_surface.thickness
-                z = z_prev_surface + thickness_after_prev_surface
+                z_prev = prev_surface.geometry.cs.z
+                t_prev = prev_surface.thickness
+                # Extract plain floats so the new coordinate is a leaf scalar,
+                # not a non-leaf tensor created by arithmetic on traced values.
+                if hasattr(z_prev, "item"):
+                    z_prev = z_prev.item()
+                if hasattr(t_prev, "item"):
+                    t_prev = t_prev.item()
+                z = float(z_prev) + float(t_prev)
 
         rx = kwargs.get("rx", 0)
         ry = kwargs.get("ry", 0)

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import copy
 from contextlib import suppress
+from copy import deepcopy
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -81,28 +82,66 @@ class SurfaceGroup:
                 self._surfaces[i + 1]._on_upstream_material_change
             )
 
-    def __add__(self, other):
+    def __add__(self, other: SurfaceGroup) -> SurfaceGroup:
         """Add two SurfaceGroup objects together.
 
-        Note that this ignores the image surface of the current group and the object
-        surface of the other group.
+        Drops the image surface of ``self`` (last element) and the object
+        surface of ``other`` (first element), then stitches the remaining
+        surfaces so that ``other``'s first physical surface is placed at the
+        position immediately after ``self``'s last surface (accounting for
+        its thickness).
+
+        ``other`` is never mutated; a deep copy of its surfaces is taken
+        before any coordinate adjustments are applied.
+
+        Note:
+            ``self``'s last surface is treated as the image-plane marker and
+            is dropped from the combined group.  For correct composition,
+            append a flat (radius = ∞) image surface to ``self`` before
+            calling ``__add__``.  If ``self``'s last surface is a real
+            optical element with finite thickness, its propagation space is
+            still honoured via the junction-z calculation even though the
+            surface itself is not retained.
         """
-        # add the offset of the last surface in self to each surface in other
-        offset = self.surfaces[-1].geometry.cs.z if self.surfaces else 0.0
+        # Deep-copy other's surfaces so the original is never mutated and the
+        # combined group does not share mutable objects with other.
+        other_copies = [deepcopy(s) for s in other._surfaces]
 
-        # add object surface distance if finite
-        object_distance = other.surfaces[0].geometry.cs.z
-        if be.isfinite(object_distance):
-            offset = offset - object_distance
+        # Junction z: the position after self's last surface (= self's image plane).
+        # Using last.z + last.thickness correctly handles the case where the last
+        # surface has a finite propagation space before the focal plane.
+        last = self._surfaces[-1]
+        last_z = float(last.geometry.cs.z)
+        last_thickness = last.thickness
+        if hasattr(last_thickness, "item"):
+            last_thickness = last_thickness.item()
 
-        for surf in other.surfaces[1:]:
-            surf.geometry.cs.z = surf.geometry.cs.z + offset
+        if be.isinf(be.array(last_thickness)):
+            junction_z = last_z
+        else:
+            junction_z = last_z + float(last_thickness)
 
-        # remove stop surface from other
-        for surface in other.surfaces:
-            surface.is_stop = False
+        # Compute the global shift for other's surfaces so that other[0]
+        # (the object plane) coincides with junction_z.
+        object_distance = float(other_copies[0].geometry.cs.z)
+        if be.isfinite(be.array(object_distance)):
+            offset = junction_z - object_distance
+        else:
+            offset = junction_z
 
-        return SurfaceGroup(self._surfaces[:-1] + other._surfaces[1:])
+        # Shift other's physical surfaces (index 1 onwards) into the global frame.
+        for surf in other_copies[1:]:
+            surf.geometry.cs.z = be.array(float(surf.geometry.cs.z) + offset)
+
+        # Remove stop from other if self already has one (preserving self's stop).
+        # Otherwise, we keep other's stop surface as the system stop.
+        self_has_stop = any(surf.is_stop for surf in self._surfaces)
+        if self_has_stop:
+            for surface in other_copies:
+                surface.is_stop = False
+
+        # Drop self's image surface (last) and other's object surface (first).
+        return SurfaceGroup(self._surfaces[:-1] + other_copies[1:])
 
     @cached_property
     def surfaces(self):
@@ -472,9 +511,12 @@ class SurfaceGroup:
                         f"thickness at surface {start_index - 1}"
                     )
 
-                new_z = prev_surface.geometry.cs.z + thickness
+                prev_z = prev_surface.geometry.cs.z
+                if hasattr(prev_z, "item"):
+                    prev_z = prev_z.item()
+                new_z = float(prev_z) + thickness
 
-            current_surface.geometry.cs.z = be.array(new_z)
+            current_surface.geometry.cs.z = be.array(float(new_z))
 
     def flip(
         self,

--- a/tests/test_surface_group.py
+++ b/tests/test_surface_group.py
@@ -583,3 +583,213 @@ class TestSurfaceGroupUpdatesRealObjects:
             match=("Surface index cannot be zero after first surface is created."),
         ):
             lens1.surfaces.add(index=0, thickness=be.inf, material="Air")
+
+
+class TestSurfaceGroupAdd:
+    """Tests for SurfaceGroup.__add__ (concatenation operator). - Issue #477"""
+
+    def _make_relay(self):
+        """Two-element relay with an explicit image-plane marker."""
+        o = optic.Optic()
+        o.set_aperture(aperture_type="EPD", value=10.0)
+        o.fields.set_type(field_type="angle")
+        o.fields.add(y=0)
+        o.fields.add(y=10)
+        o.wavelengths.add(value=0.55, is_primary=True)
+        o.surfaces.add(index=0, thickness=be.inf)
+        o.surfaces.add(index=1, radius=100, thickness=5, material="N-BK7", is_stop=True)
+        o.surfaces.add(index=2, radius=-100, thickness=40)
+        o.surfaces.add(index=3, radius=be.inf, thickness=0)  # image plane
+        return o
+
+    def _make_eye(self):
+        """Simple eye model with object plane and retina image surface."""
+        o = optic.Optic()
+        o.surfaces.add(index=0, thickness=0)  # object at image plane
+        o.surfaces.add(index=1, radius=7.8, thickness=3.6, material="N-BK7")
+        o.surfaces.add(index=2, radius=-6.0, thickness=16.6)
+        o.surfaces.add(index=3, radius=be.inf)  # retina
+        return o
+
+    def _make_monolithic(self):
+        """Monolithic equivalent of relay + eye."""
+        o = optic.Optic()
+        o.set_aperture(aperture_type="EPD", value=10.0)
+        o.fields.set_type(field_type="angle")
+        o.fields.add(y=0)
+        o.fields.add(y=10)
+        o.wavelengths.add(value=0.55, is_primary=True)
+        o.surfaces.add(index=0, thickness=be.inf)
+        o.surfaces.add(index=1, radius=100, thickness=5, material="N-BK7", is_stop=True)
+        o.surfaces.add(index=2, radius=-100, thickness=40)
+        o.surfaces.add(index=3, radius=7.8, thickness=3.6, material="N-BK7")
+        o.surfaces.add(index=4, radius=-6.0, thickness=16.6)
+        o.surfaces.add(index=5, radius=be.inf)
+        return o
+
+    def test_add_surface_count(self, set_test_backend):
+        """Combined system has the correct number of surfaces."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay.surfaces + eye.surfaces
+        # relay has 4 surfaces (drop last=1), eye has 4 surfaces (drop first=1)
+        assert len(combined) == 6
+
+    def test_add_surface_positions_match_monolithic(self, set_test_backend):
+        """z-positions of the combined group match the monolithic system."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        mono = self._make_monolithic()
+        combined = relay.surfaces + eye.surfaces
+
+        for i, (cs, ms) in enumerate(zip(combined.surfaces, mono.surfaces.surfaces)):
+            assert_allclose(
+                cs.geometry.cs.z,
+                ms.geometry.cs.z,
+            ), f"z mismatch at surface {i}"
+
+    def test_add_surface_radii_match_monolithic(self, set_test_backend):
+        """Radii of the combined group match the monolithic system."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        mono = self._make_monolithic()
+        combined = relay.surfaces + eye.surfaces
+
+        assert_allclose(combined.radii, mono.surfaces.radii)
+
+    def test_add_stop_preserved_from_self(self, set_test_backend):
+        """Stop surface comes from self (relay), not from other (eye)."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        # Give the eye a stop on one of its surfaces before composition.
+        eye.surfaces[1].is_stop = True
+        combined = relay.surfaces + eye.surfaces
+        assert combined.stop_index == 1  # relay's stop at index 1
+
+    def test_add_does_not_mutate_other_z_positions(self, set_test_backend):
+        """other's surface z-positions are unchanged after __add__."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        z_before = [float(s.geometry.cs.z) for s in eye.surfaces]
+        _ = relay.surfaces + eye.surfaces
+        z_after = [float(s.geometry.cs.z) for s in eye.surfaces]
+        assert z_before == z_after, "eye surfaces were mutated by __add__"
+
+    def test_add_does_not_mutate_other_stop_flags(self, set_test_backend):
+        """other's is_stop flags are unchanged after __add__."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        eye.surfaces[1].is_stop = True
+        stops_before = [s.is_stop for s in eye.surfaces]
+        _ = relay.surfaces + eye.surfaces
+        stops_after = [s.is_stop for s in eye.surfaces]
+        assert stops_before == stops_after, "eye stop flags were mutated by __add__"
+
+    def test_add_combined_surfaces_independent_of_other(self, set_test_backend):
+        """Modifying other after __add__ does not affect the combined group."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay.surfaces + eye.surfaces
+
+        # Change a z-position in eye post-composition
+        original_z = float(combined.surfaces[3].geometry.cs.z)
+        eye.surfaces[1].geometry.cs.z = be.array(999.0)
+
+        assert_allclose(
+            combined.surfaces[3].geometry.cs.z,
+            be.array(original_z),
+        ), "combined group shares surface objects with other"
+
+    def test_add_junction_uses_last_surface_thickness(self, set_test_backend):
+        """Junction z = last_relay_z + last_relay_thickness, not just last_relay_z."""
+        relay = optic.Optic()
+        relay.set_aperture(aperture_type="EPD", value=10.0)
+        relay.fields.set_type(field_type="angle")
+        relay.fields.add(y=0)
+        relay.wavelengths.add(value=0.55, is_primary=True)
+        relay.surfaces.add(index=0, thickness=be.inf)
+        relay.surfaces.add(index=1, radius=100, thickness=5, material="N-BK7", is_stop=True)
+        # Last surface has thickness=40 and NO explicit image plane.
+        relay.surfaces.add(index=2, radius=-100, thickness=40)
+
+        eye = optic.Optic()
+        eye.surfaces.add(index=0, thickness=0)  # object at junction
+        eye.surfaces.add(index=1, radius=7.8, thickness=3.6, material="N-BK7")
+        eye.surfaces.add(index=2, radius=be.inf)
+
+        combined = relay.surfaces + eye.surfaces
+
+        # relay[2] (dropped, z=5, thickness=40) -> junction_z = 5+40 = 45
+        # eye[1] should land at z=45
+        expected_cornea_z = 5.0 + 40.0
+        assert_allclose(
+            combined.surfaces[2].geometry.cs.z,
+            be.array(expected_cornea_z),
+        )
+
+    def test_optic_add_spot_matches_monolithic(self, set_test_backend):
+        """Optic.__add__ produces the same on-axis spot RMS as the monolithic system."""
+        from optiland.analysis import SpotDiagram
+
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay + eye
+        mono = self._make_monolithic()
+
+        sc = SpotDiagram(combined, num_rings=3)
+        sm = SpotDiagram(mono, num_rings=3)
+
+        rms_c = sc.rms_spot_radius()
+        rms_m = sm.rms_spot_radius()
+
+        # On-axis field (index 0) must match
+        assert_allclose(rms_c[0][0], rms_m[0][0], rtol=1e-6)
+
+    def test_optic_add_fields_preserved(self, set_test_backend):
+        """Optic.__add__ preserves field angles from the left-hand operand."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay + eye
+
+        relay_coords = relay.fields.get_field_coords()
+        combined_coords = combined.fields.get_field_coords()
+        assert combined_coords == relay_coords
+
+    def test_optic_add_aperture_preserved(self, set_test_backend):
+        """Optic.__add__ preserves the aperture from the left-hand operand."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay + eye
+        assert_allclose(
+            be.array(combined.paraxial.EPD()),
+            be.array(relay.paraxial.EPD()),
+        )
+
+    def test_optic_add_does_not_mutate_other(self, set_test_backend):
+        """Optic.__add__ leaves the right-hand Optic completely unchanged."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        eye.surfaces[1].is_stop = True
+        z_before = [float(s.geometry.cs.z) for s in eye.surfaces]
+        stops_before = [s.is_stop for s in eye.surfaces]
+
+        _ = relay + eye
+
+        z_after = [float(s.geometry.cs.z) for s in eye.surfaces]
+        stops_after = [s.is_stop for s in eye.surfaces]
+        assert z_before == z_after
+        assert stops_before == stops_after
+
+    def test_optic_add_combined_surfaces_independent_of_other(self, set_test_backend):
+        """Mutating other after Optic.__add__ does not affect the combined system."""
+        relay = self._make_relay()
+        eye = self._make_eye()
+        combined = relay + eye
+
+        original_z = float(combined.surfaces[3].geometry.cs.z)
+        eye.surfaces[1].geometry.cs.z = be.array(9999.0)
+
+        assert_allclose(
+            combined.surfaces[3].geometry.cs.z,
+            be.array(original_z),
+        )


### PR DESCRIPTION
# Robust Surface Addition & Coordinate Calculation Refactor

## Summary of Changes
This PR addresses robustness, differentiability, and correctness in coordinate calculations and `SurfaceGroup` addition:
* **Robust Coordinate Stiffering & Differentiability**: Replaces in-place operations and traced-tensor arithmetic in `SurfaceGroup` coordinate updates, `CoordinateSystemFactory`, `OpticUpdater`, and material formulas with explicit leaf conversions (`float(...)` and `be.array(...)`). This prevents the creation of non-leaf PyTorch tensors, securing compatibility with optimization loops.
* **Safer `__add__` Composition**: 
  * Deep copies the second operand's surfaces before mutating or shifting coordinates to prevent shared mutable state.
  * Properly computes the global junction coordinate using `last.geometry.cs.z + last.thickness` to account for propagation spacing before the focal plane.
  * Preserves the first operand's stop surface and clears `is_stop` on subsequent surfaces to avoid multiple stops in a merged system.
* **Testing**: Added unit tests for surface group merging and regression tests.

---

## Verification Test Script
The following script splits a Cooke Triplet into two `Optic` instances, merges them using the `+` operator, and verifies that the resulting RMS spot radii match the original Cooke Triplet exactly (to numerical precision).

```python
import numpy as np
import optiland.backend as be
from optiland import optic
from optiland.samples import CookeTriplet
from optiland.analysis import SpotDiagram


# 1. Instantiate the original Cooke triplet
cooke = CookeTriplet()

# 2. Build the first lens Optic instance
optic1 = optic.Optic()
optic1.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
optic1.surfaces.add(index=1, radius=22.01359, thickness=3.25896, material="SK16")
optic1.surfaces.add(index=2, radius=-435.76044, thickness=6.00755)
optic1.surfaces.add(index=3, radius=be.inf)  # Image plane

# Set up system parameters on the left hand operand
optic1.set_aperture(aperture_type="EPD", value=10)
optic1.fields.set_type("angle")
optic1.fields.add(y=0)
optic1.fields.add(y=14)
optic1.fields.add(y=20)
optic1.wavelengths.add(value=0.48)
optic1.wavelengths.add(value=0.55, is_primary=True)
optic1.wavelengths.add(value=0.65)

# 3. Build the second two lenses Optic instance
optic2 = optic.Optic()
optic2.surfaces.add(index=0, radius=be.inf, thickness=0.0)
optic2.surfaces.add(
    index=1, radius=-22.21328, thickness=0.99997, material=("F2", "schott")
)
optic2.surfaces.add(index=2, radius=20.29192, thickness=4.75041, is_stop=True)
optic2.surfaces.add(index=3, radius=79.68360, thickness=2.95208, material="SK16")
optic2.surfaces.add(index=4, radius=-18.39533, thickness=42.20778)
optic2.surfaces.add(index=5, radius=be.inf)  # Image plane

# 4. Merge them using Optic.__add__
combined = optic1 + optic2

# 5. Compute spot diagrams
sd_original = SpotDiagram(cooke)
sd_combined = SpotDiagram(combined)

# 6. Get RMS spot radii
rms_original = sd_original.rms_spot_radius()
rms_combined = sd_combined.rms_spot_radius()

# 7. Compare and print results
print("=== Original Cooke Triplet RMS Spot Radii ===")
for f_idx, field_rms in enumerate(rms_original):
    print(f"Field {f_idx} (y={cooke.fields.fields[f_idx].y}):")
    for wl_idx, rms in enumerate(field_rms):
        wl_val = cooke.wavelengths.wavelengths[wl_idx].value
        print(f"  Wavelength {wl_val} µm: {rms:.8f} mm")

print("\n=== Combined Optic RMS Spot Radii ===")
for f_idx, field_rms in enumerate(rms_combined):
    print(f"Field {f_idx} (y={combined.fields.fields[f_idx].y}):")
    for wl_idx, rms in enumerate(field_rms):
        wl_val = combined.wavelengths.wavelengths[wl_idx].value
        print(f"  Wavelength {wl_val} µm: {rms:.8f} mm")

# Perform assert check to verify matching to numerical precision
np.testing.assert_allclose(rms_original, rms_combined, rtol=1e-12, atol=1e-12)
```

---

## Results Comparison

| Field ($y$) | Wavelength ($\mu\text{m}$) | Original RMS Spot Radius (mm) | Combined RMS Spot Radius (mm) | Absolute Difference (mm) |
| :--- | :--- | :--- | :--- | :--- |
| **0** ($y=0^\circ$) | 0.48 | 0.00379134 | 0.00379134 | 0.0 |
| | 0.55 (Primary) | 0.00429369 | 0.00429369 | 0.0 |
| | 0.65 | 0.00619562 | 0.00619562 | 0.0 |
| **1** ($y=14^\circ$) | 0.48 | 0.01582480 | 0.01582480 | 0.0 |
| | 0.55 (Primary) | 0.01691841 | 0.01691841 | 0.0 |
| | 0.65 | 0.01922117 | 0.01922117 | 0.0 |
| **2** ($y=20^\circ$) | 0.48 | 0.01323623 | 0.01323623 | 0.0 |
| | 0.55 (Primary) | 0.01211669 | 0.01211669 | 0.0 |
| | 0.65 | 0.01364868 | 0.01364868 | 0.0 |

All values match to numerical precision ($\text{atol} = 10^{-12}$, $\text{rtol} = 10^{-12}$).