### PR TITLE
2D viz: Surface outline plotting

### DIFF
--- a/optiland/visualization/system/surface.py
+++ b/optiland/visualization/system/surface.py
@@ -15,6 +15,10 @@ from optiland.physical_apertures import RadialAperture
 from optiland.rays import RealRays
 from optiland.visualization.system.utils import revolve_contour, transform, transform_3d
 
+# Surfaces tilted more than 60° toward the viewing axis are rendered as a
+# boundary ellipse rather than a cross-section line to avoid artifacts.
+_FACE_ON_THRESHOLD = 0.5  # |cos(60°)|
+
 
 class Surface2D:
     """A class used to represent a 2D surface for visualization.
@@ -44,6 +48,21 @@ class Surface2D:
         else:
             self.extent = ray_extent
 
+    # Maps projection name to the index of the viewing axis in global normal.
+    # e.g. for "YZ" the view is along X (index 0); "XZ" along Y (index 1); etc.
+    _VIEWING_AXIS_IDX: dict[str, int] = {"YZ": 0, "XZ": 1, "XY": 2}
+
+    def _is_face_on(self, projection: str) -> bool:
+        """Return True if the surface normal is >60° toward the viewing axis.
+
+        When True, rendering a cross-section line would create an artifact;
+        drawing the aperture boundary ellipse is cleaner instead.
+        """
+        _, rot_mat = self.surf.geometry.cs.get_effective_transform()
+        rot = be.to_numpy(rot_mat)
+        axis_idx = self._VIEWING_AXIS_IDX[projection]
+        return abs(float(rot[axis_idx, 2])) > _FACE_ON_THRESHOLD
+
     def plot(self, ax, theme=None, projection="YZ"):
         """Plots the surface on the given matplotlib axis.
 
@@ -56,7 +75,11 @@ class Surface2D:
                 'XZ', or 'YZ'. Defaults to 'YZ'.
 
         """
-        x, y, z = self._compute_sag(projection)
+        # For surfaces strongly tilted toward the viewing axis the normal
+        # cross-section line becomes a misleading vertical artifact.  Draw the
+        # aperture boundary circle instead so the projection stays clean.
+        sag_projection = "XY" if self._is_face_on(projection) else projection
+        x, y, z = self._compute_sag(sag_projection)
 
         # convert to global coordinates and return
         x, y, z = transform(x, y, z, self.surf, is_global=False)

--- a/optiland/visualization/system/utils.py
+++ b/optiland/visualization/system/utils.py
@@ -58,17 +58,24 @@ def transform_3d(actor, surface):
         The transformed actor with the applied rotation and translation.
 
     """
-    # Get the effective rotation and translation of the surface
     cs = surface.geometry.cs
-    rx, ry, rz = cs.get_effective_rotation_euler()
-    translation, _ = cs.get_effective_transform()
-    dx, dy, dz = translation
+    translation, rot_mat = cs.get_effective_transform()
+    dx, dy, dz = be.to_numpy(translation)
+    rot = be.to_numpy(rot_mat)
 
-    # Apply the rotation and translation to the actor
-    actor.RotateZ(be.degrees(rz))
-    actor.RotateY(be.degrees(ry))
-    actor.RotateX(be.degrees(rx))
-    actor.SetPosition(dx, dy, dz)
+    # Build 4×4 homogeneous matrix [[R, t], [0, 1]] and apply as UserMatrix.
+    # This avoids the rotation-matrix → Euler round-trip that triggers SciPy's
+    # gimbal-lock warning when ry ≈ ±90°.
+    vtk_matrix = vtk.vtkMatrix4x4()
+    vtk_matrix.Identity()
+    for i in range(3):
+        for j in range(3):
+            vtk_matrix.SetElement(i, j, float(rot[i, j]))
+    vtk_matrix.SetElement(0, 3, float(dx))
+    vtk_matrix.SetElement(1, 3, float(dy))
+    vtk_matrix.SetElement(2, 3, float(dz))
+
+    actor.SetUserMatrix(vtk_matrix)
 
     return actor
 


### PR DESCRIPTION
- add visualization of elliptical surf outline when surfaces tilted out of 2D viz plane

Demo:
```python
import numpy as np
from optiland import analysis, optic, optimization

lens = optic.Optic()

# System settings
lens.set_aperture(aperture_type="EPD", value=10.0)
lens.set_field_type(field_type="angle")
lens.add_field(y=0)
lens.add_wavelength(value=0.633, is_primary=True)

# Lens data
lens.add_surface(   index=0, radius=np.inf, z=-np.inf, rx=0, ry=0, rz=0)
lens.add_surface(   index=1, z=0, rx=0, ry=0, rz=0)
lens.add_surface(   index=2, z=5, radius=100, material="bk7",  is_stop=True, rx=0, ry=0, rz=0, aperture=15)  # material in
lens.add_surface(   index=3, z=10, radius=-100, material="air", rx=0, ry=0, rz=0, aperture=15)  # material out
lens.add_surface(   index=4, z=25, material="mirror", rx=-(np.radians(45)+ np.radians(2)), ry=0, rz=0, aperture= 15)  # first mirror
lens.add_surface(   index=5, z=25, y=-15, material="mirror", rx=-(np.radians(45) + np.radians(2)) , ry= np.pi / 2, rz=0, aperture=15)  # second mirror
lens.add_surface(   index=6, z=25, y=-15, x=50, rx=0, ry= np.radians(90), rz=0)  # Image plane

lens.draw(num_rays=10)
lens.draw3D(num_rays=10)
```

<img width="531" height="371" alt="image" src="https://github.com/user-attachments/assets/d7087fa5-ecf8-4f10-88b2-92ce1ec02cfd" />

Closes #273 