### PR TITLE
fix(optimizer): guard IPython import in live_plotter for headless envs

### DIFF
--- a/optiland/optimization/optimizer/live_plotter.py
+++ b/optiland/optimization/optimizer/live_plotter.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import matplotlib
 import matplotlib.pyplot as plt
-from IPython.display import display
+
+try:
+    from IPython.display import display
+except ImportError:  # IPython optional; only needed for the Jupyter inline backend
+    display = None
 
 import optiland.backend as be
 

--- a/tests/test_live_optimization_plotter.py
+++ b/tests/test_live_optimization_plotter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.util
+import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -64,6 +66,29 @@ def build_optimizer(
     optic = FakeOptic()
     problem = FakeProblem(optic, merit_values or [1.0])
     return FakeOptimizer(problem), optic
+
+
+def test_module_imports_without_ipython(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The module stays importable when IPython is absent (headless envs).
+
+    Re-executes the module source with ``IPython`` blocked so the
+    ``except ImportError`` guard runs and ``display`` falls back to ``None``,
+    without mutating the already-imported shared module other tests rely on.
+    """
+    # A ``None`` entry in ``sys.modules`` makes ``import IPython`` raise
+    # ImportError, simulating an install without IPython.
+    monkeypatch.setitem(sys.modules, "IPython", None)
+    monkeypatch.setitem(sys.modules, "IPython.display", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "live_plotter_no_ipython", live_plotter_module.__file__
+    )
+    assert spec is not None and spec.loader is not None
+    reloaded = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(reloaded)
+
+    assert reloaded.display is None
+    assert hasattr(reloaded, "LiveOptimizationPlotter")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes #629.

### Problem
`optiland/optimization/optimizer/live_plotter.py` imports `from IPython.display import display` at module top, and `optimizer/scipy/base.py` imports `live_plotter` unconditionally. So **any** `import optiland.optimization` requires IPython — even when no live plotting is used. IPython is not in `pyproject.toml` `[project.dependencies]`, so a clean install of optiland + its declared deps crashes the optimizer in headless / server environments:

```
ModuleNotFoundError: No module named 'IPython'
```

### Fix
`display` is only used in the Jupyter inline-backend branch of `LiveOptimizationPlotter._render`, where IPython is guaranteed present. Guard the import and fall back to `None` elsewhere, so the module stays importable without IPython while the inline path is unchanged.

```python
try:
    from IPython.display import display
except ImportError:  # IPython optional; only needed for the Jupyter inline backend
    display = None
```

One-line, no behavior change for notebook users. Happy to instead declare `IPython` as a hard dependency if you'd prefer that over keeping the optimizer importable headless — let me know.
