### PR TITLE
fix(materials): content-address the large-array refractive-index cache key (#630)

### DIFF
--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -10,14 +10,33 @@ Kramer Harrison, 2024
 
 from __future__ import annotations
 
+import hashlib
+import weakref
 from abc import ABC, abstractmethod
-from contextlib import suppress
 
 import numpy as np
 
 import optiland.backend as be
 from optiland.propagation.base import BasePropagationModel
 from optiland.propagation.homogeneous import HomogeneousPropagation
+
+# Maps id(array) -> (weakref, content_digest, version_token) so the O(N) content
+# hash in BaseMaterial._array_metadata_key runs once per array object and is
+# reused on later lookups. The weakref callback evicts the entry when the array
+# is collected, so a later array reusing the same id() never reads a stale
+# digest.
+_ARRAY_DIGEST_CACHE: dict[int, tuple] = {}
+
+
+def _array_content_key(value, digest: bytes) -> tuple:
+    """Assemble a cache-key tuple from a content digest plus coarse metadata."""
+    return (
+        "array-content",
+        digest,
+        tuple(getattr(value, "shape", ())),
+        str(getattr(value, "dtype", type(value).__name__)),
+        str(getattr(value, "device", None)),
+    )
 
 
 class BaseMaterial(ABC):
@@ -86,66 +105,50 @@ class BaseMaterial(ABC):
 
     @staticmethod
     def _array_metadata_key(value) -> tuple:
-        """Build an O(1) hash key for large arrays without
-        materializing all elements."""
-        # Torch tensors expose stable storage metadata and a version counter
-        # that changes on in-place writes.
-        if hasattr(value, "data_ptr"):
-            try:
-                sample = ()
-                num_el = value.numel()
-                if num_el > 0:
-                    flat_val = value.flatten()
-                    sample = (
-                        flat_val[0].item(),
-                        flat_val[num_el // 2].item(),
-                        flat_val[-1].item(),
-                    )
-                return (
-                    "tensor-meta",
-                    int(value.data_ptr()),
-                    tuple(value.shape),
-                    tuple(value.stride()) if hasattr(value, "stride") else None,
-                    int(value.storage_offset())
-                    if hasattr(value, "storage_offset")
-                    else 0,
-                    str(value.dtype),
-                    str(value.device) if hasattr(value, "device") else None,
-                    int(getattr(value, "_version", 0)),
-                    sample,
-                )
-            except Exception:
-                pass
+        """Build a content-addressed cache key for large arrays.
 
-        if isinstance(value, np.ndarray):
-            sample = ()
-            if value.size > 0:
-                sample = (
-                    value.flat[0],
-                    value.flat[value.size // 2],
-                    value.flat[-1],
-                )
-            return (
-                "ndarray-meta",
-                int(value.__array_interface__["data"][0]),
-                tuple(value.shape),
-                tuple(value.strides),
-                str(value.dtype),
-                sample,
+        The key identifies an array by its *contents*, never by its memory
+        location. Raw buffer pointers (``ndarray.__array_interface__["data"]``,
+        ``Tensor.data_ptr()``) and ``id()`` are reused by the allocator once an
+        array is garbage-collected, so two distinct wavelength arrays of the
+        same shape/dtype that reuse a freed slot would collide and ``n()`` would
+        return the previous array's refractive index -- a silent
+        cross-wavelength leak (issue #630).
+
+        Hashing the bytes is O(N), so the digest is memoized per array object in
+        ``_ARRAY_DIGEST_CACHE``; repeated lookups of the same array (e.g. one
+        wavelength bundle traced through every surface) are amortized O(1). A
+        weakref callback drops the entry when the array dies, so id() reuse can
+        never surface a stale digest.
+
+        NumPy exposes no in-place-write counter, so an array is treated as
+        immutable for its lifetime (optiland never mutates wavelength buffers in
+        place). Torch tensors carry ``_version``, folded into the memoization
+        token so in-place edits invalidate the cached digest.
+        """
+        oid = id(value)
+        token = int(getattr(value, "_version", 0))
+        cached = _ARRAY_DIGEST_CACHE.get(oid)
+        if cached is not None:
+            ref, digest, cached_token = cached
+            if ref() is value and cached_token == token:
+                return _array_content_key(value, digest)
+
+        if hasattr(value, "detach"):  # torch tensor
+            array = value.detach().cpu().contiguous().numpy()
+        else:  # numpy ndarray, list, or tuple
+            array = np.ascontiguousarray(np.asarray(value))
+        digest = hashlib.blake2b(array.tobytes(), digest_size=16).digest()
+
+        try:
+            ref = weakref.ref(
+                value, lambda _ref, _oid=oid: _ARRAY_DIGEST_CACHE.pop(_oid, None)
             )
-
-        sample = ()
-        shape = getattr(value, "shape", ())
-        if hasattr(value, "__getitem__") and len(shape) > 0:
-            with suppress(Exception):
-                sample = (value[0], value[len(value) // 2], value[-1])
-        return (
-            "array-meta",
-            id(value),
-            tuple(shape),
-            str(getattr(value, "dtype", type(value))),
-            sample,
-        )
+        except TypeError:
+            ref = None  # e.g. list/tuple cannot be weak-referenced; skip memo
+        if ref is not None:
+            _ARRAY_DIGEST_CACHE[oid] = (ref, digest, token)
+        return _array_content_key(value, digest)
 
     def _create_cache_key(self, wavelength: float | be.ndarray, **kwargs) -> tuple:
         """Creates a hashable cache key from wavelength and kwargs."""

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -196,6 +196,32 @@ class TestBaseMaterial:
         gc.collect()
         assert len(_ARRAY_DIGEST_CACHE) <= baseline + 2
 
+    def test_large_array_key_handles_non_weakref_sequence(self, set_test_backend):
+        """list/tuple wavelengths are content-addressed too, but cannot be
+        weak-referenced, so the digest memo is skipped (no error) while the keys
+        stay correct.
+        """
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return 1.0
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return 0.0
+
+        material = DummyMaterial()
+
+        # A list has no .shape, so it takes the metadata-key path; it also can't
+        # be weak-referenced, exercising the memo-skip branch.
+        a = [0.5] * 2_000
+        other = list(a)
+        other[7] = 0.6  # differ at one interior index
+
+        assert material._create_cache_key(a) == material._create_cache_key(list(a))
+        assert material._create_cache_key(a) != material._create_cache_key(other)
+        # tuples take the same (non-weak-referenceable) path without error
+        material._create_cache_key(tuple(a))
+
     def test_detach_if_tensor_numpy(self, set_test_backend):
         """_detach_if_tensor returns numpy arrays unchanged."""
         arr = np.array([1.5, 1.6])

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import time
 import warnings
 from importlib import resources
@@ -112,6 +113,89 @@ class TestBaseMaterial:
         key2 = material._create_cache_key(large, temperature=25)
         assert key1 == key2
 
+    def test_large_array_key_is_content_addressed(self, set_test_backend):
+        """#630: the cache key must depend on array *contents*, not on the
+        array's memory location.
+
+        The old key embedded the buffer address, so two equal-content arrays
+        got different keys and -- worse -- a freed array's address could be
+        reused by a different array and collide, leaking the previous
+        wavelength's refractive index. Keying on a content digest makes equal
+        content yield an equal key regardless of identity or address.
+        """
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return 1.0
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return 0.0
+
+        material = DummyMaterial()
+
+        n = 2_000  # > _MAX_VALUE_KEY_ARRAY_SIZE -> metadata-key path
+        a = np.linspace(0.45, 0.65, n, dtype=np.float64)
+        b = a.copy()  # identical content, different object and buffer address
+        assert a.__array_interface__["data"][0] != b.__array_interface__["data"][0]
+
+        # Equal content -> equal key. (The location-based key failed this.)
+        assert material._create_cache_key(a) == material._create_cache_key(b)
+
+    def test_large_array_key_distinguishes_unsampled_difference(self, set_test_backend):
+        """The content digest must distinguish arrays that differ only at an
+        index the old 3-point (first/middle/last) sample never inspected --
+        otherwise n() leaks one wavelength's index to another once their
+        buffers alias (issue #630).
+        """
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return 1.0
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return 0.0
+
+        material = DummyMaterial()
+
+        n = 2_000
+        a = np.zeros(n, dtype=np.float64)
+        b = np.zeros(n, dtype=np.float64)
+        a[1] = 1.0  # differ only at an interior, unsampled index
+        b[2] = 1.0
+        # endpoints and midpoint coincide -> defeats the old 3-point sample key
+        assert (a[0], a[n // 2], a[-1]) == (b[0], b[n // 2], b[-1])
+
+        assert material._create_cache_key(a) != material._create_cache_key(b)
+
+    def test_large_array_digest_cache_evicts_dead_arrays(self, set_test_backend):
+        """#630: the per-array digest memo is weak -- entries are dropped when
+        the array is collected, so id() reuse cannot surface a stale digest and
+        the memo cannot grow without bound.
+        """
+        from optiland.materials.base import _ARRAY_DIGEST_CACHE
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return float(np.asarray(wavelength)[1])
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return 0.0
+
+        material = DummyMaterial()
+        n = 2_000
+
+        gc.collect()
+        baseline = len(_ARRAY_DIGEST_CACHE)
+        for i in range(50):
+            arr = np.zeros(n, dtype=np.float64)
+            arr[1] = float(i)  # content (and so the expected n) differs each round
+            assert material.n(arr) == float(i)  # never a stale cross-array value
+            del arr
+            gc.collect()  # free the buffer so the next array may reuse its address
+
+        gc.collect()
+        assert len(_ARRAY_DIGEST_CACHE) <= baseline + 2
+
     def test_detach_if_tensor_numpy(self, set_test_backend):
         """_detach_if_tensor returns numpy arrays unchanged."""
         arr = np.array([1.5, 1.6])
@@ -164,6 +248,34 @@ class TestBaseMaterialTorchCaching:
 
         no_grad = torch.tensor(1.5)
         assert BaseMaterial._requires_grad(no_grad) is False
+
+    def test_large_array_key_is_content_addressed(self):
+        """#630 (torch): the large-array key is content-addressed, so two
+        tensors with equal content but different storage share a key, and an
+        in-place edit (which bumps tensor._version) invalidates it.
+        """
+        import torch
+
+        class DummyMaterial(BaseMaterial):
+            def _calculate_n(self, wavelength, **kwargs):
+                return 1.0
+
+            def _calculate_k(self, wavelength, **kwargs):
+                return 0.0
+
+        material = DummyMaterial()
+        n = 2_000  # > _MAX_VALUE_KEY_ARRAY_SIZE -> metadata-key path
+
+        t = torch.linspace(0.45, 0.65, n, dtype=torch.float64)
+        t2 = t.clone()  # equal content, different storage / data_ptr
+        assert t.data_ptr() != t2.data_ptr()
+        assert material._create_cache_key(t) == material._create_cache_key(t2)
+
+        # An in-place edit bumps tensor._version, invalidating the cached digest.
+        c = torch.zeros(n, dtype=torch.float64)
+        key_before = material._create_cache_key(c)
+        c[5] += 1.0
+        assert material._create_cache_key(c) != key_before
 
     def test_cached_value_is_detached_when_no_grad(self):
         """Cached n/k values must be detached when they don't require grad.


### PR DESCRIPTION
Closes #630 — opting for PR B as suggested in the issue thread.

## Problem
`BaseMaterial._array_metadata_key` keyed the `n()`/`k()` cache for arrays larger
than `_MAX_VALUE_KEY_ARRAY_SIZE` on the array's **buffer pointer**
(`ndarray.__array_interface__["data"][0]` / `Tensor.data_ptr()` / `id()`) plus a
first/middle/last value sample (#607). The allocator reuses those addresses
after an array is garbage-collected, so two distinct wavelength arrays of the
same shape/dtype that land in a freed slot — and coincide at the three sampled
indices — collide on the cache key, and `n()` returns the previous array's
refractive index. In multi-ray traces this is a silent ~5–15% per-trace flicker
that corrupts optimizer gradients.

## Fix
Key the cache on a **128-bit blake2b digest of the array contents**, memoized
per array object in a module-level table keyed by `id()` with a **weakref
callback** that evicts the entry when the array is collected:

- **Content-addressed** — equal content → equal key, independent of memory
  location, so GC address reuse can no longer collide distinct arrays.
- **Amortized O(1)** — the O(N) content hash runs once per array object;
  repeated lookups of the same wavelength bundle across surfaces reuse the
  memoized digest, preserving the #557 large-array fast path. (The existing
  `test_large_array_cache_key_runtime_is_sublinear` guard still passes.)
- **No stale digests** — the weakref callback drops the entry before `id()` can
  be reused by a new array.

### Notes / tradeoffs
- **First touch is O(N)**: the first lookup of a given large array hashes its
  bytes once (vs the old O(1) sample). For a bundle traced through many surfaces
  this is amortized away; for a one-shot trace of a very large array it adds a
  single `tobytes()` + digest. The old fast path was O(1) but unsound.
- **Soundness**: a 128-bit digest collides with probability ~2⁻¹²⁸
  (content-addressing, like git), replacing the prior probabilistic 3-point
  sample.
- **Mutation**: NumPy exposes no in-place-write counter, so an array is treated
  as immutable for its lifetime (optiland never mutates wavelength buffers in
  place). Torch `_version` is folded into the memo token, so in-place edits
  invalidate the cached digest.
- **Threading**: the memo is a module-level dict — correct under the GIL (the
  read-miss-then-store race is idempotent). A free-threaded build would want a
  lock; happy to add if preferred.

## Tests (`tests/test_materials.py`)
- `test_large_array_key_is_content_addressed` — equal content (different object
  and buffer address) → equal key. **Fails on `master`** (the location-based key
  differs); passes here.
- `test_large_array_key_distinguishes_unsampled_difference` — content differing
  only at an index the 3-point sample never inspected → different key.
- `test_large_array_digest_cache_evicts_dead_arrays` — the memo is weak and
  bounded; collected arrays are evicted.
- `TestBaseMaterialTorchCaching::test_large_array_key_is_content_addressed` —
  torch tensors are content-addressed and `_version` bumps invalidate the key.

Torch backend validated locally with torch 2.6.0 (content-addressing, `_version`
invalidation, weakref eviction, non-contiguous tensors); the numpy suite passes.
