### PR TITLE
fix: read and write text files as UTF-8 explicitly (Windows GBK UnicodeDecodeError)

### DIFF
--- a/optiland/fileio/optiland_handler.py
+++ b/optiland/fileio/optiland_handler.py
@@ -37,7 +37,7 @@ def load_obj_from_json(cls, filepath):
     """
     if not os.path.exists(filepath):
         raise FileNotFoundError(f"File '{filepath}' does not exist.")
-    with open(filepath) as f:
+    with open(filepath, encoding="utf-8") as f:
         data = json.load(f)
     return cls.from_dict(data)
 
@@ -66,7 +66,7 @@ def save_obj_to_json(obj, filepath):
         filepath: The path to the JSON file.
 
     """
-    with open(filepath, "w") as f:
+    with open(filepath, "w", encoding="utf-8") as f:
         json.dump(obj.to_dict(), f, indent=4, cls=OptilandEncoder)
 
 

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -449,7 +449,11 @@ class MaterialFile(BaseMaterial):
         Returns:
             dict: Parsed YAML data.
         """
-        with open(self.filename) as stream:
+        # The RefractiveIndex.INFO YAML files contain non-ASCII characters
+        # (e.g. the degree sign, em dashes). Decode explicitly as UTF-8 so the
+        # read does not depend on the platform's default text encoding -- on
+        # Windows that is cp1252/cp936 (GBK), which raises UnicodeDecodeError.
+        with open(self.filename, encoding="utf-8") as stream:
             return yaml.safe_load(stream)
 
     def _set_formula_type(self, formula_type):

--- a/optiland_gui/analysis_panel.py
+++ b/optiland_gui/analysis_panel.py
@@ -1089,7 +1089,7 @@ class AnalysisPanel(QWidget):
             return
 
         try:
-            with open(filepath) as f:
+            with open(filepath, encoding="utf-8") as f:
                 loaded_settings = json.load(f)
             self._apply_loaded_settings_to_ui(loaded_settings)
             self.logArea.append(
@@ -1598,7 +1598,7 @@ class AnalysisPanel(QWidget):
 
         if filepath:
             try:
-                with open(filepath, "w") as f:
+                with open(filepath, "w", encoding="utf-8") as f:
                     json.dump(settings_to_save, f, indent=4)
                 self.logArea.append(
                     f"Settings for {current_analysis_name} saved to {filepath}"
@@ -1623,7 +1623,7 @@ class AnalysisPanel(QWidget):
 
         if filepath:
             try:
-                with open(filepath) as f:
+                with open(filepath, encoding="utf-8") as f:
                     loaded_settings = json.load(f)
 
                 analysis_name = loaded_settings.get("analysis_name")

--- a/optiland_gui/main_window.py
+++ b/optiland_gui/main_window.py
@@ -441,15 +441,19 @@ class MainWindow(FramelessWindow):
     def load_stylesheets(self) -> None:
         """Load and apply the current theme and sidebar stylesheets."""
         style_str = ""
+        # The .qss files contain non-ASCII glyphs (e.g. the dropdown arrow);
+        # decode as UTF-8 so the read does not fall back to the platform
+        # default (cp1252/cp936 on Windows), which would raise and leave the
+        # app unstyled.
         try:
-            with open(self.current_theme_path) as f_theme:
+            with open(self.current_theme_path, encoding="utf-8") as f_theme:
                 style_str += f_theme.read()
         except Exception as e:
             print(f"Error loading main theme {self.current_theme_path}: {e}")
 
         if os.path.exists(SIDEBAR_QSS_PATH):
             try:
-                with open(SIDEBAR_QSS_PATH) as f_sidebar:
+                with open(SIDEBAR_QSS_PATH, encoding="utf-8") as f_sidebar:
                     style_str += "\n" + f_sidebar.read()
 
             except Exception as e:

--- a/optiland_gui/services/file_service.py
+++ b/optiland_gui/services/file_service.py
@@ -160,7 +160,7 @@ class FileService:
                 self._connector._optic = load_zemax_file(filepath)
                 self._current_filepath = None
             else:
-                with open(filepath) as f:
+                with open(filepath, encoding="utf-8") as f:
                     data = json.load(f, object_hook=json_inf_nan_hook)
                 self._connector._undo_redo_manager.clear_stacks()
                 self._connector._optic = Optic.from_dict(data)
@@ -186,7 +186,7 @@ class FileService:
         """
         try:
             data = self._connector._capture_optic_state()
-            with open(filepath, "w") as f:
+            with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=4, cls=SpecialFloatEncoder)
             self._current_filepath = filepath
             self._connector.set_modified(False)

--- a/optiland_gui/widgets/python_terminal.py
+++ b/optiland_gui/widgets/python_terminal.py
@@ -601,7 +601,7 @@ class PythonTerminalWidget(QWidget):
                 return False
 
         try:
-            with open(file_path, "w") as f:
+            with open(file_path, "w", encoding="utf-8") as f:
                 f.write(editor.toPlainText())
 
             editor.setProperty("is_modified", False)
@@ -621,7 +621,7 @@ class PythonTerminalWidget(QWidget):
         if not filepath:
             return
 
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8") as f:
             content = f.read()
 
         editor = self._get_current_editor()


### PR DESCRIPTION
Reads and writes of text files relied on the platform's default encoding, which
crashes on Windows (cp1252 / cp936 / GBK) when the content contains non-ASCII
characters. This passes `encoding="utf-8"` at every text read/write so behaviour
no longer depends on the locale. Linux/macOS default to UTF-8 and are unaffected.

## Core library
- **`optiland/materials/material_file.py`** — `MaterialFile._read_file` reads the
  RefractiveIndex.INFO YAML files (degree sign, em dashes, …). On a cp936 (GBK)
  Windows machine this previously raised for **any** catalog material:
  ```
  materials.Material("SF6")
  ... UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 ...
  ```
  Validated on that machine: `tests/test_materials.py::TestMaterialFile` went
  from a `UnicodeDecodeError` in `test_formula_4` to **14 passed**.
- **`optiland/fileio/optiland_handler.py`** — load/save Optiland `.json` files.
  `tests/test_fileio/test_optiland_handler.py`: **9 passed**.

## GUI
- **`optiland_gui/main_window.py`** — `load_stylesheets` reads `*.qss` (non-ASCII
  glyphs such as the dropdown arrow); the failed read was swallowed and the app
  launched unstyled.
- **`optiland_gui/services/file_service.py`** — open/save system JSON.
- **`optiland_gui/analysis_panel.py`** — load/save analysis-settings JSON.
- **`optiland_gui/widgets/python_terminal.py`** — load/save `.py` scripts.

All changed files pass `ruff check` and `py_compile`.
