### PR TITLE
Fix panning logic by removing self._pan_start_x and self._pan_start_y update

### DIFF
--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -516,10 +516,6 @@ class MatplotlibViewer(QWidget):
             ax.set_xlim(xlim[0] + dx, xlim[1] + dx)
             ax.set_ylim(ylim[0] + dy, ylim[1] + dy)
 
-            # Update the starting position for the next move
-            self._pan_start_x = event.xdata
-            self._pan_start_y = event.ydata
-
             # Redraw the canvas
             self.canvas.draw_idle()
             return  # Skip the coordinate display when panning


### PR DESCRIPTION
## Summary
Fix issue https://github.com/optiland/optiland/issues/639. As `event.xdata` and `event.ydata` already gives the cursor's position in data coordinates, `self._pan_start_x` and `self._pan_start_y` value updates should be removed.

Recording of the 2D Layout section before the fix:

https://github.com/user-attachments/assets/2587a465-8666-4f48-8f9e-47579a572bc7

And after the fix:

https://github.com/user-attachments/assets/a6709de7-d380-4851-a3de-c75338f9ee96

