### PR TITLE
fix: use exact OPD for thin lens phase transformation

### DIFF
--- a/optiland/interactions/thin_lens_interaction_model.py
+++ b/optiland/interactions/thin_lens_interaction_model.py
@@ -66,9 +66,8 @@ class ThinLensInteractionModel(BaseInteractionModel):
             RealRays: The refracted rays.
 
         """
-        # add optical path length - workaround for now
-        # TODO: develop more robust method
-        rays.opd = rays.opd - (rays.x**2 + rays.y**2) / (2 * self.f)
+        h2 = rays.x**2 + rays.y**2
+        rays.opd = rays.opd + self.f - be.copysign(be.sqrt(h2 + self.f**2), self.f)
 
         n1 = self.material_pre.n(rays.w)
         n2 = n1 if self.is_reflective else self.material_post.n(rays.w)

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -207,6 +207,29 @@ class TestThinLensInteractionModel:
             [ray_out.x, ray_out.y, ray_out.z, ray_out.L, ray_out.M, ray_out.N],
         )
 
+    @pytest.mark.parametrize("focal_length", [50.0, 100.0])
+    def test_paraxial_surface_constant_opd(self, focal_length, set_test_backend):
+        """All rays through an ideal thin lens in air must arrive with equal OPD."""
+        lens = Optic()
+        lens.surfaces.add(index=0, thickness=be.inf)
+        lens.surfaces.add(
+            index=1,
+            surface_type="paraxial",
+            thickness=focal_length,
+            f=focal_length,
+            is_stop=True,
+        )
+        lens.surfaces.add(index=2)
+        lens.set_aperture(aperture_type="EPD", value=20)
+        lens.fields.set_type(field_type="angle")
+        lens.fields.add(y=0)
+        lens.wavelengths.add(value=0.55, is_primary=True)
+
+        rays = lens.trace(
+            Hx=0, Hy=0, wavelength=0.55, distribution="uniform", num_rays=32
+        )
+        assert_allclose(rays.opd, rays.opd[0], atol=1e-10)
+
     def test_flip(self, surface):
         f_initial = be.copy(surface.interaction_model.f)
         surface.interaction_model.flip()


### PR DESCRIPTION

[test-huygens-psf-paraxial.ipynb](https://github.com/user-attachments/files/29388776/test-huygens-psf-paraxial.ipynb)
## Summary

- Replace the paraxial OPD approximation `-h²/(2f)` with the exact formula `f - sign(f)·√(h²+f²)` in `ThinLensInteractionModel.interact_real_rays()`
- Add `test_paraxial_surface_constant_opd` test verifying all rays arrive with equal OPD

## Problem

The paraxial OPD formula introduced ~400 waves of spurious wavefront error for an f/5 lens (EPD=10 mm, f=50 mm), making `HuygensPSF` produce wildly incorrect results (Strehl ≈ 0.004) for any system containing paraxial surfaces.

**Root cause:** The OPD correction `-(x²+y²)/(2f)` is only valid for small `h/f`. Combined with the geometric propagation path `√(h²+f²)`, the `h²/(2f)` terms don't cancel, producing hundreds of waves of net wavefront error.

## Fix

The exact formula `f - sign(f)·√(h²+f²)` Taylor-expands to `-h²/(2f)` for small h/f, so it's backward-compatible in the paraxial regime while being exact at any NA. This makes paraxial surfaces produce diffraction-limited PSFs (Strehl ≈ 1.0) as expected for ideal thin lenses.

**Note:** The fix is exact for lenses in air (n₁ = n₂ = 1). For non-unity refractive indices, the image-space medium affects the required phase; a follow-up could generalize the formula to `n₂·(d - √(h²+d²))` where `d = f·n₂`.

## Test plan

- [x] All 23 existing thin-lens tests pass
- [x] New `test_paraxial_surface_constant_opd` passes for f=50 and f=100 mm
- [x] Verified via notebook: `HuygensPSF` on a paraxial f=50mm lens gives Strehl ≈ 1.0 (was 0.004 before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)