### PR TITLE
[codex] Add bounded CMA-ES optimizer

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -39,6 +39,7 @@ We sincerely appreciate the contributions of the following individuals, whose ef
 - **RayPragma** (`GitHub <https://github.com/RayPragma>`_)
 - **Doron Behar** (`GitHub <https://github.com/doronbehar>`_)
 - **Ayachi Padmanabh Mishra** (`GitHub <https://github.com/AyachiMishra>`_)
+- **somnus-J-307** (`GitHub <https://github.com/somnus-J-307>`_)
 
 
 Your contributions, whether in the form of code, documentation, feedback, or discussions, are what make **Optiland** better for everyone.

--- a/optiland/optimization/__init__.py
+++ b/optiland/optimization/__init__.py
@@ -33,6 +33,7 @@ except (ImportError, ModuleNotFoundError, OSError):
 from .optimizer.scipy import glass_expert
 
 from .optimizer.custom import (
+    CMAES,
     ParticleSwarm,
 )
 

--- a/optiland/optimization/optimizer/custom/__init__.py
+++ b/optiland/optimization/optimizer/custom/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from .cma_es import CMAES
 from .particle_swarm import ParticleSwarm
 
 __all__ = [
+    "CMAES",
     "ParticleSwarm",
 ]

--- a/optiland/optimization/optimizer/custom/cma_es.py
+++ b/optiland/optimization/optimizer/custom/cma_es.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy import optimize
+
+import optiland.backend as be
+
+from ..scipy.base import OptimizerGeneric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ...problem import OptimizationProblem
+
+
+class CMAES(OptimizerGeneric):
+    """Bounded covariance matrix adaptation evolution strategy optimizer.
+
+    The optimizer runs in a normalized search space and implements weighted
+    recombination, cumulative step-size adaptation, and rank-one plus rank-mu
+    covariance updates. Fixed variables are excluded from the internal search
+    space.
+
+    Args:
+        problem: The optimization problem to solve.
+    """
+
+    def __init__(self, problem: OptimizationProblem) -> None:
+        super().__init__(problem)
+
+    def optimize(
+        self,
+        maxiter: int = 500,
+        population_size: int | None = None,
+        sigma0: float = 0.3,
+        tolx: float = 1e-8,
+        tolfun: float = 1e-12,
+        max_resampling: int = 100,
+        seed: int | None = None,
+        disp: bool = True,
+        callback: Callable[[int, np.ndarray, float], bool | None] | None = None,
+    ) -> optimize.OptimizeResult:
+        """Run CMA-ES.
+
+        Args:
+            maxiter: Maximum number of generations.
+            population_size: Number of candidates per generation. If ``None``,
+                uses ``4 + floor(3 * log(n))`` for ``n`` movable variables.
+            sigma0: Initial global step size in normalized coordinates.
+            tolx: Stop when the largest coordinate search scale falls below
+                this value.
+            tolfun: Stop when recent best objective values vary by no more than
+                this value.
+            max_resampling: Maximum attempts to draw each bounded candidate.
+            seed: Random seed for reproducibility.
+            disp: Whether to print generation progress.
+            callback: Optional callback called as
+                ``callback(generation, best_position, best_value)``. Returning
+                ``True`` stops the optimization.
+
+        Returns:
+            A SciPy-style optimization result.
+
+        Raises:
+            ValueError: If an algorithm parameter, bound, or current variable
+                value is invalid.
+        """
+        x0_backend = [variable.value for variable in self.problem.variables]
+        x0 = np.asarray(be.to_numpy(x0_backend), dtype=float)
+        lower, upper = self._validate_bounds(x0)
+        movable = upper > lower
+        dimension = int(np.count_nonzero(movable))
+
+        if population_size is None and dimension > 0:
+            population_size = 4 + int(np.floor(3.0 * np.log(dimension)))
+        elif population_size is None:
+            population_size = 0
+
+        self._validate_parameters(
+            maxiter=maxiter,
+            population_size=population_size,
+            sigma0=sigma0,
+            tolx=tolx,
+            tolfun=tolfun,
+            max_resampling=max_resampling,
+            has_movable_variables=dimension > 0,
+        )
+
+        self._x.append(x0_backend)
+        best_position = x0.copy()
+        best_value = float(self._fun(best_position))
+        nfev = 1
+
+        if dimension == 0:
+            self._set_problem_state(best_position)
+            return optimize.OptimizeResult(
+                x=best_position,
+                fun=best_value,
+                nit=0,
+                nfev=nfev,
+                success=True,
+                message="No movable variables to optimize.",
+                population_size=0,
+                sigma=0.0,
+                mean=best_position.copy(),
+                covariance=np.empty((0, 0), dtype=float),
+                condition_number=1.0,
+            )
+
+        movable_lower = lower[movable]
+        movable_span = upper[movable] - movable_lower
+        mean = (x0[movable] - movable_lower) / movable_span
+        sigma = float(sigma0)
+        covariance = np.eye(dimension)
+        eigenvectors = np.eye(dimension)
+        deviations = np.ones(dimension)
+        path_sigma = np.zeros(dimension)
+        path_covariance = np.zeros(dimension)
+        condition_number = 1.0
+
+        mu = population_size // 2
+        weights = np.log(mu + 0.5) - np.log(np.arange(1, mu + 1))
+        weights /= np.sum(weights)
+        mu_eff = 1.0 / np.sum(weights**2)
+
+        c_sigma = (mu_eff + 2.0) / (dimension + mu_eff + 5.0)
+        d_sigma = (
+            1.0
+            + 2.0 * max(0.0, np.sqrt((mu_eff - 1.0) / (dimension + 1.0)) - 1.0)
+            + c_sigma
+        )
+        c_covariance = (4.0 + mu_eff / dimension) / (
+            dimension + 4.0 + 2.0 * mu_eff / dimension
+        )
+        c1 = 2.0 / ((dimension + 1.3) ** 2 + mu_eff)
+        c_mu = min(
+            1.0 - c1,
+            2.0 * (mu_eff - 2.0 + 1.0 / mu_eff) / ((dimension + 2.0) ** 2 + mu_eff),
+        )
+        expected_norm = np.sqrt(dimension) * (
+            1.0 - 1.0 / (4.0 * dimension) + 1.0 / (21.0 * dimension**2)
+        )
+        history_size = max(
+            10,
+            int(np.ceil(30.0 * dimension / population_size)),
+        )
+        best_history: deque[float] = deque(maxlen=history_size)
+        rng = np.random.default_rng(seed)
+
+        success = False
+        message = "Maximum number of generations reached."
+        completed_generations = 0
+
+        if disp:
+            print(
+                f"CMA-ES start: best merit = {best_value:.12g}, "
+                f"population_size = {population_size}, ndim = {dimension}"
+            )
+
+        for generation in range(1, maxiter + 1):
+            sampled = self._sample_population(
+                mean=mean,
+                sigma=sigma,
+                eigenvectors=eigenvectors,
+                deviations=deviations,
+                population_size=population_size,
+                max_resampling=max_resampling,
+                rng=rng,
+            )
+            if sampled is None:
+                message = (
+                    "Unable to sample a candidate within bounds after "
+                    f"{max_resampling} attempts."
+                )
+                break
+
+            candidates, steps = sampled
+            fitness = np.empty(population_size, dtype=float)
+            for index, candidate in enumerate(candidates):
+                full_candidate = self._to_physical(
+                    candidate,
+                    x0,
+                    movable,
+                    movable_lower,
+                    movable_span,
+                )
+                fitness[index] = float(self._fun(full_candidate))
+            nfev += population_size
+
+            order = np.argsort(fitness)
+            candidates = candidates[order]
+            steps = steps[order]
+            fitness = fitness[order]
+
+            if fitness[0] < best_value:
+                best_value = float(fitness[0])
+                best_position = self._to_physical(
+                    candidates[0],
+                    x0,
+                    movable,
+                    movable_lower,
+                    movable_span,
+                )
+
+            old_mean = mean.copy()
+            selected_candidates = candidates[:mu]
+            selected_steps = steps[:mu]
+            mean = np.sum(weights[:, np.newaxis] * selected_candidates, axis=0)
+            weighted_step = np.sum(
+                weights[:, np.newaxis] * selected_steps,
+                axis=0,
+            )
+
+            inverse_sqrt_step = eigenvectors @ (
+                (eigenvectors.T @ weighted_step) / deviations
+            )
+            path_sigma = (1.0 - c_sigma) * path_sigma + np.sqrt(
+                c_sigma * (2.0 - c_sigma) * mu_eff
+            ) * inverse_sqrt_step
+
+            path_sigma_norm = np.linalg.norm(path_sigma)
+            normalized_path = path_sigma_norm / np.sqrt(
+                1.0 - (1.0 - c_sigma) ** (2 * generation)
+            )
+            h_sigma = float(
+                normalized_path / expected_norm < 1.4 + 2.0 / (dimension + 1.0)
+            )
+
+            path_covariance = (
+                1.0 - c_covariance
+            ) * path_covariance + h_sigma * np.sqrt(
+                c_covariance * (2.0 - c_covariance) * mu_eff
+            ) * weighted_step
+
+            rank_mu = np.zeros_like(covariance)
+            for weight, step in zip(weights, selected_steps, strict=True):
+                rank_mu += weight * np.outer(step, step)
+
+            covariance = (
+                (
+                    1.0
+                    - c1
+                    - c_mu
+                    + c1 * (1.0 - h_sigma) * c_covariance * (2.0 - c_covariance)
+                )
+                * covariance
+                + c1 * np.outer(path_covariance, path_covariance)
+                + c_mu * rank_mu
+            )
+            covariance = 0.5 * (covariance + covariance.T)
+
+            sigma *= np.exp(
+                (c_sigma / d_sigma) * (path_sigma_norm / expected_norm - 1.0)
+            )
+
+            eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+            largest_eigenvalue = float(np.max(eigenvalues))
+            negative_tolerance = -1e-12 * max(1.0, largest_eigenvalue)
+            if float(np.min(eigenvalues)) < negative_tolerance:
+                message = "Covariance matrix lost positive semidefiniteness."
+                completed_generations = generation
+                break
+
+            eigenvalues = np.maximum(eigenvalues, np.finfo(float).eps)
+            deviations = np.sqrt(eigenvalues)
+            condition_number = float(np.max(eigenvalues) / np.min(eigenvalues))
+            completed_generations = generation
+            best_history.append(best_value)
+
+            if disp:
+                mean_shift = np.linalg.norm(mean - old_mean)
+                print(
+                    f"Generation {generation:4d} | "
+                    f"best merit = {best_value:.12g} | "
+                    f"sigma = {sigma:.6g} | mean shift = {mean_shift:.6g}"
+                )
+
+            if callback is not None and callback(
+                generation,
+                best_position.copy(),
+                best_value,
+            ):
+                success = True
+                message = "Optimization stopped by callback."
+                break
+
+            coordinate_scale = sigma * float(np.max(np.sqrt(np.diag(covariance))))
+            if coordinate_scale <= tolx:
+                success = True
+                message = (
+                    f"Optimization converged: search scale fell below tolx={tolx}."
+                )
+                break
+
+            if (
+                len(best_history) == history_size
+                and max(max(best_history), float(np.max(fitness)))
+                - min(min(best_history), float(np.min(fitness)))
+                <= tolfun
+            ):
+                success = True
+                message = (
+                    "Optimization converged: recent objective values changed "
+                    f"by at most tolfun={tolfun}."
+                )
+                break
+
+            if condition_number > 1e14:
+                message = "Covariance matrix condition number exceeded 1e14."
+                break
+
+        self._set_problem_state(best_position)
+        physical_mean = self._to_physical(
+            mean,
+            x0,
+            movable,
+            movable_lower,
+            movable_span,
+        )
+        return optimize.OptimizeResult(
+            x=best_position.copy(),
+            fun=best_value,
+            nit=completed_generations,
+            nfev=nfev,
+            success=success,
+            message=message,
+            population_size=population_size,
+            sigma=sigma,
+            mean=physical_mean,
+            covariance=covariance.copy(),
+            condition_number=condition_number,
+        )
+
+    def _validate_bounds(self, x0: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Validate and return finite variable bounds."""
+        bounds = [variable.bounds for variable in self.problem.variables]
+        if any(bound is None or len(bound) != 2 for bound in bounds):
+            raise ValueError("CMAES requires all variables to have finite bounds.")
+
+        lower = np.asarray([bound[0] for bound in bounds], dtype=float)
+        upper = np.asarray([bound[1] for bound in bounds], dtype=float)
+        if np.any(~np.isfinite(lower)) or np.any(~np.isfinite(upper)):
+            raise ValueError("CMAES requires all variables to have finite bounds.")
+        if np.any(upper < lower):
+            raise ValueError("Each variable bound must satisfy lower <= upper.")
+        if np.any(~np.isfinite(x0)) or np.any(x0 < lower) or np.any(x0 > upper):
+            raise ValueError("Current variable values must lie within their bounds.")
+        return lower, upper
+
+    @staticmethod
+    def _validate_parameters(
+        *,
+        maxiter: int,
+        population_size: int,
+        sigma0: float,
+        tolx: float,
+        tolfun: float,
+        max_resampling: int,
+        has_movable_variables: bool,
+    ) -> None:
+        """Validate CMA-ES configuration."""
+        if maxiter < 1:
+            raise ValueError("maxiter must be at least 1.")
+        if population_size != 0 and population_size < 2:
+            raise ValueError("population_size must be at least 2.")
+        if has_movable_variables and population_size == 0:
+            raise ValueError("population_size must be at least 2.")
+        if not np.isfinite(sigma0) or sigma0 <= 0.0:
+            raise ValueError("sigma0 must be positive.")
+        if not np.isfinite(tolx) or tolx < 0.0:
+            raise ValueError("tolx must be non-negative.")
+        if not np.isfinite(tolfun) or tolfun < 0.0:
+            raise ValueError("tolfun must be non-negative.")
+        if max_resampling < 1:
+            raise ValueError("max_resampling must be at least 1.")
+
+    @staticmethod
+    def _sample_population(
+        *,
+        mean: np.ndarray,
+        sigma: float,
+        eigenvectors: np.ndarray,
+        deviations: np.ndarray,
+        population_size: int,
+        max_resampling: int,
+        rng: np.random.Generator,
+    ) -> tuple[np.ndarray, np.ndarray] | None:
+        """Sample a population by rejecting candidates outside the unit box."""
+        dimension = mean.size
+        candidates = np.empty((population_size, dimension), dtype=float)
+        steps = np.empty_like(candidates)
+
+        for candidate_index in range(population_size):
+            for _ in range(max_resampling):
+                normal = rng.standard_normal(dimension)
+                step = eigenvectors @ (deviations * normal)
+                candidate = mean + sigma * step
+                if np.all((candidate >= 0.0) & (candidate <= 1.0)):
+                    candidates[candidate_index] = candidate
+                    steps[candidate_index] = step
+                    break
+            else:
+                return None
+
+        return candidates, steps
+
+    @staticmethod
+    def _to_physical(
+        normalized: np.ndarray,
+        template: np.ndarray,
+        movable: np.ndarray,
+        lower: np.ndarray,
+        span: np.ndarray,
+    ) -> np.ndarray:
+        """Expand normalized movable coordinates into a physical vector."""
+        physical = template.copy()
+        physical[movable] = lower + normalized * span
+        return physical
+
+    def _set_problem_state(self, position: np.ndarray) -> None:
+        """Update the problem to the supplied complete variable vector."""
+        for index, variable in enumerate(self.problem.variables):
+            variable.update(position[index])
+        self.problem.update_optics()

--- a/optiland/optimization/optimizer/custom/cma_es.py
+++ b/optiland/optimization/optimizer/custom/cma_es.py
@@ -38,7 +38,6 @@ class CMAES(OptimizerGeneric):
         sigma0: float = 0.3,
         tolx: float = 1e-8,
         tolfun: float = 1e-12,
-        max_resampling: int = 100,
         seed: int | None = None,
         disp: bool = True,
         callback: Callable[[int, np.ndarray, float], bool | None] | None = None,
@@ -54,7 +53,6 @@ class CMAES(OptimizerGeneric):
                 this value.
             tolfun: Stop when recent best objective values vary by no more than
                 this value.
-            max_resampling: Maximum attempts to draw each bounded candidate.
             seed: Random seed for reproducibility.
             disp: Whether to print generation progress.
             callback: Optional callback called as
@@ -85,7 +83,6 @@ class CMAES(OptimizerGeneric):
             sigma0=sigma0,
             tolx=tolx,
             tolfun=tolfun,
-            max_resampling=max_resampling,
             has_movable_variables=dimension > 0,
         )
 
@@ -167,16 +164,8 @@ class CMAES(OptimizerGeneric):
                 eigenvectors=eigenvectors,
                 deviations=deviations,
                 population_size=population_size,
-                max_resampling=max_resampling,
                 rng=rng,
             )
-            if sampled is None:
-                message = (
-                    "Unable to sample a candidate within bounds after "
-                    f"{max_resampling} attempts."
-                )
-                break
-
             candidates, steps = sampled
             fitness = np.empty(population_size, dtype=float)
             for index, candidate in enumerate(candidates):
@@ -268,7 +257,7 @@ class CMAES(OptimizerGeneric):
             deviations = np.sqrt(eigenvalues)
             condition_number = float(np.max(eigenvalues) / np.min(eigenvalues))
             completed_generations = generation
-            best_history.append(best_value)
+            best_history.append(float(fitness[0]))
 
             if disp:
                 mean_shift = np.linalg.norm(mean - old_mean)
@@ -295,11 +284,10 @@ class CMAES(OptimizerGeneric):
                 )
                 break
 
-            if (
-                len(best_history) == history_size
-                and max(max(best_history), float(np.max(fitness)))
-                - min(min(best_history), float(np.min(fitness)))
-                <= tolfun
+            current_fitness_range = float(np.max(fitness) - np.min(fitness))
+            historic_fitness_range = max(best_history) - min(best_history)
+            if len(best_history) == history_size and (
+                current_fitness_range <= tolfun and historic_fitness_range <= tolfun
             ):
                 success = True
                 message = (
@@ -320,6 +308,7 @@ class CMAES(OptimizerGeneric):
             movable_lower,
             movable_span,
         )
+        physical_covariance = covariance * np.outer(movable_span, movable_span)
         return optimize.OptimizeResult(
             x=best_position.copy(),
             fun=best_value,
@@ -330,7 +319,7 @@ class CMAES(OptimizerGeneric):
             population_size=population_size,
             sigma=sigma,
             mean=physical_mean,
-            covariance=covariance.copy(),
+            covariance=physical_covariance,
             condition_number=condition_number,
         )
 
@@ -358,7 +347,6 @@ class CMAES(OptimizerGeneric):
         sigma0: float,
         tolx: float,
         tolfun: float,
-        max_resampling: int,
         has_movable_variables: bool,
     ) -> None:
         """Validate CMA-ES configuration."""
@@ -374,8 +362,6 @@ class CMAES(OptimizerGeneric):
             raise ValueError("tolx must be non-negative.")
         if not np.isfinite(tolfun) or tolfun < 0.0:
             raise ValueError("tolfun must be non-negative.")
-        if max_resampling < 1:
-            raise ValueError("max_resampling must be at least 1.")
 
     @staticmethod
     def _sample_population(
@@ -385,25 +371,21 @@ class CMAES(OptimizerGeneric):
         eigenvectors: np.ndarray,
         deviations: np.ndarray,
         population_size: int,
-        max_resampling: int,
         rng: np.random.Generator,
-    ) -> tuple[np.ndarray, np.ndarray] | None:
-        """Sample a population by rejecting candidates outside the unit box."""
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Sample a population and reflect candidates into the unit box."""
         dimension = mean.size
         candidates = np.empty((population_size, dimension), dtype=float)
         steps = np.empty_like(candidates)
 
         for candidate_index in range(population_size):
-            for _ in range(max_resampling):
-                normal = rng.standard_normal(dimension)
-                step = eigenvectors @ (deviations * normal)
-                candidate = mean + sigma * step
-                if np.all((candidate >= 0.0) & (candidate <= 1.0)):
-                    candidates[candidate_index] = candidate
-                    steps[candidate_index] = step
-                    break
-            else:
-                return None
+            normal = rng.standard_normal(dimension)
+            step = eigenvectors @ (deviations * normal)
+            candidate = mean + sigma * step
+            candidate = np.mod(candidate, 2.0)
+            candidate = np.where(candidate <= 1.0, candidate, 2.0 - candidate)
+            candidates[candidate_index] = candidate
+            steps[candidate_index] = (candidate - mean) / sigma
 
         return candidates, steps
 

--- a/tests/optimization/test_cma_es.py
+++ b/tests/optimization/test_cma_es.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from scipy import optimize
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import optiland.backend as be
 from optiland import optimization
@@ -95,6 +98,7 @@ class TestCMAES:
         [
             ({"maxiter": 0}, "maxiter must be at least 1."),
             ({"population_size": 1}, "population_size must be at least 2."),
+            ({"population_size": 0}, "population_size must be at least 2."),
             ({"sigma0": 0.0}, "sigma0 must be positive."),
             ({"sigma0": -0.1}, "sigma0 must be positive."),
             ({"sigma0": np.nan}, "sigma0 must be positive."),
@@ -102,7 +106,6 @@ class TestCMAES:
             ({"tolx": np.nan}, "tolx must be non-negative."),
             ({"tolfun": -1.0}, "tolfun must be non-negative."),
             ({"tolfun": np.nan}, "tolfun must be non-negative."),
-            ({"max_resampling": 0}, "max_resampling must be at least 1."),
         ],
     )
     def test_invalid_parameters_fail_before_evaluation(
@@ -308,6 +311,37 @@ class TestCMAES:
         assert abs(result.x[0]) < 0.1
         assert abs(result.x[1]) < 1e-7
 
+    def test_covariance_is_returned_in_physical_units(self, set_test_backend) -> None:
+        """Test covariance scaling from normalized to physical coordinates."""
+
+        def run(spans: np.ndarray) -> optimize.OptimizeResult:
+            problem = MockProblem(
+                [MockVariable(0.5 * span, (0.0, span)) for span in spans],
+                target_fun=lambda values: sum(
+                    (value / span) ** 2
+                    for value, span in zip(values, spans, strict=True)
+                ),
+            )
+            return CMAES(problem).optimize(
+                maxiter=5,
+                population_size=6,
+                sigma0=0.1,
+                tolx=0.0,
+                tolfun=0.0,
+                seed=17,
+                disp=False,
+            )
+
+        unit_spans = np.ones(2)
+        physical_spans = np.array([10.0, 100.0])
+        unit_result = run(unit_spans)
+        physical_result = run(physical_spans)
+
+        np.testing.assert_allclose(
+            physical_result.covariance,
+            unit_result.covariance * np.outer(physical_spans, physical_spans),
+        )
+
     def test_rotated_ellipsoid_convergence(self, set_test_backend) -> None:
         """Test learning of correlation between variables."""
         rotation = np.array(
@@ -389,6 +423,34 @@ class TestCMAES:
 
         assert result.success is True
         assert result.nit == 10
+        assert "objective values changed by at most" in result.message
+
+    def test_tolfun_uses_generation_best_history(self, set_test_backend) -> None:
+        """Test convergence after an obsolete global best leaves history."""
+        evaluations = 0
+
+        def shifted_flat_objective(values: list[float]) -> float:
+            nonlocal evaluations
+            evaluations += 1
+            return 0.0 if evaluations <= 6 else 100.0
+
+        problem = MockProblem(
+            [MockVariable(0.5, (0.0, 1.0))],
+            target_fun=shifted_flat_objective,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=12,
+            population_size=4,
+            sigma0=0.05,
+            tolx=0.0,
+            tolfun=0.0,
+            seed=18,
+            disp=False,
+        )
+
+        assert result.success is True
+        assert result.nit == 11
         assert "objective values changed by at most" in result.message
 
     def test_tolx_stopping(self, set_test_backend) -> None:
@@ -488,28 +550,63 @@ class TestCMAES:
         assert result.condition_number > 1e14
         assert result.message == "Covariance matrix condition number exceeded 1e14."
 
-    def test_resampling_exhaustion(self, set_test_backend) -> None:
-        """Test explicit failure when no bounded sample can be generated."""
+    def test_covariance_psd_safeguard(self, set_test_backend, monkeypatch) -> None:
+        """Test termination when covariance loses positive semidefiniteness."""
         problem = MockProblem(
             [
-                MockVariable(0.0, (0.0, 1.0)),
-                MockVariable(0.0, (0.0, 1.0)),
+                MockVariable(0.5, (0.0, 1.0)),
+                MockVariable(0.5, (0.0, 1.0)),
             ]
+        )
+        monkeypatch.setattr(
+            np.linalg,
+            "eigh",
+            lambda covariance: (
+                np.array([-1.0, 1.0]),
+                np.eye(2),
+            ),
         )
 
         result = CMAES(problem).optimize(
             maxiter=10,
-            population_size=4,
-            sigma0=100.0,
-            max_resampling=1,
-            seed=13,
+            population_size=6,
+            sigma0=0.1,
+            seed=19,
             disp=False,
         )
 
         assert result.success is False
-        assert result.nit == 0
-        assert result.nfev == 1
-        assert "Unable to sample a candidate within bounds" in result.message
+        assert result.nit == 1
+        assert result.message == "Covariance matrix lost positive semidefiniteness."
+
+    def test_large_steps_are_reflected_into_bounds(self, set_test_backend) -> None:
+        """Test feasible sampling for large steps in a bounded search space."""
+        evaluated: list[list[float]] = []
+
+        def objective(values: list[float]) -> float:
+            evaluated.append(values.copy())
+            return sum(value**2 for value in values)
+
+        problem = MockProblem(
+            [MockVariable(0.5, (0.0, 1.0)) for _ in range(8)],
+            target_fun=objective,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=1,
+            population_size=10,
+            sigma0=100.0,
+            tolx=0.0,
+            tolfun=0.0,
+            seed=13,
+            disp=False,
+        )
+
+        assert result.nit == 1
+        assert result.nfev == 11
+        assert all(
+            0.0 <= value <= 1.0 for candidate in evaluated for value in candidate
+        )
 
     def test_result_updates_problem_state(self, set_test_backend) -> None:
         """Test that the final problem state matches the best result."""

--- a/tests/optimization/test_cma_es.py
+++ b/tests/optimization/test_cma_es.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+from scipy import optimize
+
+import optiland.backend as be
+from optiland import optimization
+from optiland.optimization.optimizer.custom import CMAES
+from optiland.optimization.optimizer.custom.cma_es import CMAES as CMAESDirect
+
+
+class MockVariable:
+    """Mock variable for CMA-ES tests."""
+
+    def __init__(self, value: float, bounds: tuple[float, float] | None) -> None:
+        self.value = value
+        self.bounds = bounds
+
+    def update(self, value: float) -> None:
+        """Update the variable value."""
+        self.value = value
+
+
+class MockProblem:
+    """Mock optimization problem with a configurable objective."""
+
+    def __init__(
+        self,
+        variables: list[MockVariable],
+        target_fun: Callable[[list[float]], float] | None = None,
+    ) -> None:
+        self.variables = variables
+        self.initial_value = 0.0
+        self.optics_updated = False
+        self.evaluation_count = 0
+        self.target_fun = target_fun
+
+    def update_optics(self) -> None:
+        """Record that the problem state was refreshed."""
+        self.optics_updated = True
+
+    def sum_squared(self) -> float:
+        """Evaluate the configured objective."""
+        self.evaluation_count += 1
+        values = [be.to_numpy(variable.value).item() for variable in self.variables]
+        if self.target_fun is not None:
+            return self.target_fun(values)
+        return sum(value**2 for value in values)
+
+
+class TestCMAES:
+    """Unit tests for the bounded CMA-ES optimizer."""
+
+    def test_public_exports(self, set_test_backend) -> None:
+        """Test that CMAES is available from public modules."""
+        assert CMAES is CMAESDirect
+        assert optimization.CMAES is CMAESDirect
+
+    def test_init(self, set_test_backend) -> None:
+        """Test CMAES initialization."""
+        problem = MockProblem([MockVariable(1.0, (-5.0, 5.0))])
+
+        optimizer = CMAES(problem)
+
+        assert optimizer.problem is problem
+        assert optimizer._x == []
+
+    def test_default_population_size_uses_movable_dimensions(
+        self, set_test_backend
+    ) -> None:
+        """Test the classic default population size formula."""
+        problem = MockProblem(
+            [
+                MockVariable(1.0, (-5.0, 5.0)),
+                MockVariable(2.0, (-5.0, 5.0)),
+                MockVariable(3.0, (-5.0, 5.0)),
+                MockVariable(4.0, (4.0, 4.0)),
+            ]
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=1,
+            population_size=None,
+            seed=1,
+            disp=False,
+        )
+
+        assert result.population_size == 7
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"maxiter": 0}, "maxiter must be at least 1."),
+            ({"population_size": 1}, "population_size must be at least 2."),
+            ({"sigma0": 0.0}, "sigma0 must be positive."),
+            ({"sigma0": -0.1}, "sigma0 must be positive."),
+            ({"sigma0": np.nan}, "sigma0 must be positive."),
+            ({"tolx": -1.0}, "tolx must be non-negative."),
+            ({"tolx": np.nan}, "tolx must be non-negative."),
+            ({"tolfun": -1.0}, "tolfun must be non-negative."),
+            ({"tolfun": np.nan}, "tolfun must be non-negative."),
+            ({"max_resampling": 0}, "max_resampling must be at least 1."),
+        ],
+    )
+    def test_invalid_parameters_fail_before_evaluation(
+        self,
+        set_test_backend,
+        kwargs: dict[str, float | int],
+        message: str,
+    ) -> None:
+        """Test parameter validation before objective evaluation."""
+        problem = MockProblem([MockVariable(1.0, (-5.0, 5.0))])
+        optimizer = CMAES(problem)
+        evaluations_before = problem.evaluation_count
+
+        with pytest.raises(ValueError, match=message):
+            optimizer.optimize(disp=False, **kwargs)
+
+        assert problem.evaluation_count == evaluations_before
+
+    @pytest.mark.parametrize(
+        ("bounds", "message"),
+        [
+            (None, "CMAES requires all variables to have finite bounds."),
+            ((1.0,), "CMAES requires all variables to have finite bounds."),
+            ((-np.inf, 5.0), "CMAES requires all variables to have finite bounds."),
+            ((-5.0, np.inf), "CMAES requires all variables to have finite bounds."),
+            ((5.0, -5.0), "Each variable bound must satisfy lower <= upper."),
+        ],
+    )
+    def test_invalid_bounds(
+        self,
+        set_test_backend,
+        bounds,
+        message: str,
+    ) -> None:
+        """Test rejection of unsupported bounds."""
+        problem = MockProblem([MockVariable(1.0, bounds)])
+
+        with pytest.raises(ValueError, match=message):
+            CMAES(problem).optimize(disp=False)
+
+    def test_current_value_outside_bounds(self, set_test_backend) -> None:
+        """Test rejection of an infeasible current design."""
+        problem = MockProblem([MockVariable(6.0, (-5.0, 5.0))])
+
+        with pytest.raises(
+            ValueError,
+            match="Current variable values must lie within their bounds.",
+        ):
+            CMAES(problem).optimize(disp=False)
+
+    def test_non_finite_current_value(self, set_test_backend) -> None:
+        """Test rejection of a non-finite current design."""
+        problem = MockProblem([MockVariable(np.nan, (-5.0, 5.0))])
+
+        with pytest.raises(
+            ValueError,
+            match="Current variable values must lie within their bounds.",
+        ):
+            CMAES(problem).optimize(disp=False)
+
+    def test_current_design_is_preserved_as_baseline(self, set_test_backend) -> None:
+        """Test that random sampling cannot lose a superior current design."""
+        variables = [
+            MockVariable(0.0, (-5.0, 5.0)),
+            MockVariable(1.0, (-5.0, 5.0)),
+        ]
+        problem = MockProblem(
+            variables,
+            target_fun=lambda values: values[0] ** 2 + (values[1] - 1.0) ** 2,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=1,
+            population_size=6,
+            sigma0=0.5,
+            seed=2,
+            disp=False,
+        )
+
+        assert result.fun == 0.0
+        assert np.array_equal(result.x, [0.0, 1.0])
+        assert result.nfev == 7
+
+    def test_fixed_variable_is_excluded_from_search(self, set_test_backend) -> None:
+        """Test that fixed dimensions remain unchanged."""
+        variables = [
+            MockVariable(3.0, (-5.0, 5.0)),
+            MockVariable(2.0, (2.0, 2.0)),
+        ]
+        problem = MockProblem(
+            variables,
+            target_fun=lambda values: values[0] ** 2 + (values[1] - 1.0) ** 2,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=150,
+            sigma0=0.25,
+            tolx=1e-7,
+            tolfun=1e-12,
+            seed=3,
+            disp=False,
+        )
+
+        assert np.isclose(result.x[0], 0.0, atol=2e-2)
+        assert result.x[1] == 2.0
+        assert result.covariance.shape == (1, 1)
+
+    def test_all_fixed_variables(self, set_test_backend) -> None:
+        """Test optimization when every variable is fixed."""
+        variables = [
+            MockVariable(1.0, (1.0, 1.0)),
+            MockVariable(2.0, (2.0, 2.0)),
+        ]
+        problem = MockProblem(variables)
+
+        result = CMAES(problem).optimize(seed=4, disp=False)
+
+        assert result.success is True
+        assert result.nit == 0
+        assert result.nfev == 1
+        assert np.array_equal(result.x, [1.0, 2.0])
+        assert result.covariance.shape == (0, 0)
+        assert "No movable variables" in result.message
+        assert problem.optics_updated is True
+
+    def test_invalid_population_size_with_all_fixed_variables(
+        self, set_test_backend
+    ) -> None:
+        """Test explicit population validation even without movable dimensions."""
+        problem = MockProblem([MockVariable(1.0, (1.0, 1.0))])
+
+        with pytest.raises(
+            ValueError,
+            match="population_size must be at least 2.",
+        ):
+            CMAES(problem).optimize(population_size=1, disp=False)
+
+    def test_sphere_convergence(self, set_test_backend) -> None:
+        """Test convergence on a sphere function."""
+        problem = MockProblem(
+            [
+                MockVariable(3.0, (-5.0, 5.0)),
+                MockVariable(-2.0, (-5.0, 5.0)),
+                MockVariable(4.0, (-5.0, 5.0)),
+            ]
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=250,
+            sigma0=0.3,
+            tolx=1e-8,
+            tolfun=1e-14,
+            seed=5,
+            disp=False,
+        )
+
+        assert result.fun < 1e-8
+        assert np.linalg.norm(result.x) < 1e-3
+        assert result.nfev == 1 + result.population_size * result.nit
+
+    def test_axis_scaled_ellipsoid_convergence(self, set_test_backend) -> None:
+        """Test adaptation to unequal coordinate scales."""
+        problem = MockProblem(
+            [
+                MockVariable(4.0, (-5.0, 5.0)),
+                MockVariable(-4.0, (-5.0, 5.0)),
+            ],
+            target_fun=lambda values: values[0] ** 2 + 100.0 * values[1] ** 2,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=300,
+            population_size=10,
+            sigma0=0.3,
+            seed=6,
+            disp=False,
+        )
+
+        assert result.fun < 1e-7
+        assert np.linalg.norm(result.x) < 1e-3
+
+    def test_different_physical_variable_scales(self, set_test_backend) -> None:
+        """Test normalization across variables with different physical scales."""
+        problem = MockProblem(
+            [
+                MockVariable(500.0, (-1000.0, 1000.0)),
+                MockVariable(-0.0005, (-0.001, 0.001)),
+            ],
+            target_fun=lambda values: (
+                (values[0] / 1000.0) ** 2 + (values[1] / 0.001) ** 2
+            ),
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=250,
+            population_size=10,
+            sigma0=0.3,
+            seed=15,
+            disp=False,
+        )
+
+        assert result.fun < 1e-8
+        assert abs(result.x[0]) < 0.1
+        assert abs(result.x[1]) < 1e-7
+
+    def test_rotated_ellipsoid_convergence(self, set_test_backend) -> None:
+        """Test learning of correlation between variables."""
+        rotation = np.array(
+            [
+                [np.cos(np.pi / 4), -np.sin(np.pi / 4)],
+                [np.sin(np.pi / 4), np.cos(np.pi / 4)],
+            ]
+        )
+
+        def objective(values: list[float]) -> float:
+            rotated = rotation @ np.asarray(values)
+            return float(rotated[0] ** 2 + 100.0 * rotated[1] ** 2)
+
+        problem = MockProblem(
+            [
+                MockVariable(4.0, (-5.0, 5.0)),
+                MockVariable(-3.0, (-5.0, 5.0)),
+            ],
+            target_fun=objective,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=350,
+            population_size=12,
+            sigma0=0.3,
+            seed=7,
+            disp=False,
+        )
+
+        assert result.fun < 1e-7
+        assert np.linalg.norm(result.x) < 1e-3
+        correlation = result.covariance[0, 1] / np.sqrt(
+            result.covariance[0, 0] * result.covariance[1, 1]
+        )
+        assert abs(correlation) > 0.5
+
+    def test_reproducible_with_seed(self, set_test_backend) -> None:
+        """Test deterministic results for identical seeds."""
+
+        def run():
+            problem = MockProblem(
+                [
+                    MockVariable(3.0, (-5.0, 5.0)),
+                    MockVariable(-2.0, (-5.0, 5.0)),
+                ]
+            )
+            return CMAES(problem).optimize(
+                maxiter=20,
+                population_size=8,
+                seed=8,
+                disp=False,
+            )
+
+        first = run()
+        second = run()
+
+        assert np.array_equal(first.x, second.x)
+        assert first.fun == second.fun
+        assert first.nit == second.nit
+        assert first.nfev == second.nfev
+        assert np.array_equal(first.covariance, second.covariance)
+
+    def test_tolfun_stopping(self, set_test_backend) -> None:
+        """Test stopping when recent objective values are flat."""
+        problem = MockProblem(
+            [MockVariable(0.5, (0.0, 1.0))],
+            target_fun=lambda values: 42.0,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=100,
+            population_size=4,
+            sigma0=0.1,
+            tolx=0.0,
+            tolfun=0.0,
+            seed=9,
+            disp=False,
+        )
+
+        assert result.success is True
+        assert result.nit == 10
+        assert "objective values changed by at most" in result.message
+
+    def test_tolx_stopping(self, set_test_backend) -> None:
+        """Test stopping when the search distribution is sufficiently small."""
+        problem = MockProblem([MockVariable(0.5, (0.0, 1.0))])
+
+        result = CMAES(problem).optimize(
+            maxiter=100,
+            sigma0=0.01,
+            tolx=1.0,
+            tolfun=0.0,
+            seed=10,
+            disp=False,
+        )
+
+        assert result.success is True
+        assert result.nit == 1
+        assert "search scale fell below" in result.message
+
+    def test_callback_stopping(self, set_test_backend) -> None:
+        """Test callback data and callback-requested stopping."""
+        problem = MockProblem([MockVariable(0.5, (0.0, 1.0))])
+        calls: list[tuple[int, np.ndarray, float]] = []
+
+        def callback(
+            generation: int,
+            best_position: np.ndarray,
+            best_value: float,
+        ) -> bool:
+            calls.append((generation, best_position.copy(), best_value))
+            return True
+
+        result = CMAES(problem).optimize(
+            maxiter=100,
+            seed=11,
+            disp=False,
+            callback=callback,
+        )
+
+        assert result.success is True
+        assert result.nit == 1
+        assert result.message == "Optimization stopped by callback."
+        assert calls[0][0] == 1
+        assert np.array_equal(calls[0][1], result.x)
+        assert calls[0][2] == result.fun
+
+    def test_maximum_generations_result(self, set_test_backend) -> None:
+        """Test result status when the generation limit is reached."""
+        problem = MockProblem(
+            [MockVariable(0.5, (0.0, 1.0))],
+            target_fun=lambda values: values[0] ** 2,
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=1,
+            sigma0=0.1,
+            tolx=0.0,
+            tolfun=0.0,
+            seed=12,
+            disp=False,
+        )
+
+        assert result.success is False
+        assert result.nit == 1
+        assert result.message == "Maximum number of generations reached."
+
+    def test_condition_number_safeguard(self, set_test_backend, monkeypatch) -> None:
+        """Test termination when the covariance matrix becomes ill-conditioned."""
+        problem = MockProblem(
+            [
+                MockVariable(0.5, (0.0, 1.0)),
+                MockVariable(0.5, (0.0, 1.0)),
+            ]
+        )
+
+        monkeypatch.setattr(
+            np.linalg,
+            "eigh",
+            lambda covariance: (
+                np.array([1e-15, 1.0]),
+                np.eye(2),
+            ),
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=10,
+            population_size=6,
+            sigma0=0.1,
+            tolx=0.0,
+            tolfun=0.0,
+            seed=16,
+            disp=False,
+        )
+
+        assert result.success is False
+        assert result.nit == 1
+        assert result.condition_number > 1e14
+        assert result.message == "Covariance matrix condition number exceeded 1e14."
+
+    def test_resampling_exhaustion(self, set_test_backend) -> None:
+        """Test explicit failure when no bounded sample can be generated."""
+        problem = MockProblem(
+            [
+                MockVariable(0.0, (0.0, 1.0)),
+                MockVariable(0.0, (0.0, 1.0)),
+            ]
+        )
+
+        result = CMAES(problem).optimize(
+            maxiter=10,
+            population_size=4,
+            sigma0=100.0,
+            max_resampling=1,
+            seed=13,
+            disp=False,
+        )
+
+        assert result.success is False
+        assert result.nit == 0
+        assert result.nfev == 1
+        assert "Unable to sample a candidate within bounds" in result.message
+
+    def test_result_updates_problem_state(self, set_test_backend) -> None:
+        """Test that the final problem state matches the best result."""
+        variables = [
+            MockVariable(3.0, (-5.0, 5.0)),
+            MockVariable(-2.0, (-5.0, 5.0)),
+        ]
+        problem = MockProblem(variables)
+
+        result = CMAES(problem).optimize(
+            maxiter=100,
+            seed=14,
+            disp=False,
+        )
+
+        final_values = [
+            be.to_numpy(variable.value).item() for variable in problem.variables
+        ]
+        assert np.array_equal(final_values, result.x)
+        assert problem.optics_updated is True
+        assert isinstance(result, optimize.OptimizeResult)


### PR DESCRIPTION
## Summary

- add a native, dependency-free bounded CMA-ES optimizer
- normalize movable continuous variables to the unit interval and exclude fixed variables from the internal search space
- implement weighted recombination, cumulative step-size adaptation, and rank-one plus rank-mu covariance updates
- use rejection sampling for bound handling and return a `scipy.optimize.OptimizeResult`
- expose `CMAES` through the public optimization modules
- add focused tests for convergence, rotated and scaled problems, bounds, fixed variables, reproducibility, stopping criteria, and state updates

## Motivation

This implements the native CMA-ES direction discussed in #457. The PR is opened as a draft so the implementation is concrete and reviewable while the exact first-version scope can still be adjusted.

## Scope

This first version intentionally excludes Active CMA, restart strategies, parallel evaluation, live plotting, and new dependencies.

## Validation

- `python -m pytest -v tests/optimization/test_cma_es.py tests/optimization/test_particle_swarm.py tests/test_optimization.py` - 88 passed
- `python -m ruff check optiland/` - passed
- `python -m ruff format --check optiland/optimization/optimizer/custom/cma_es.py optiland/optimization/optimizer/custom/__init__.py optiland/optimization/__init__.py tests/optimization/test_cma_es.py` - passed

Related to #457.