### PR TITLE
feat(analysis): introduce pluggable distortion strategies and models

### DIFF
--- a/optiland/analysis/__init__.py
+++ b/optiland/analysis/__init__.py
@@ -7,6 +7,16 @@ from .ray_fan import RayFan, BestFitRayFan
 from .y_ybar import YYbar
 from .distortion import Distortion
 from .grid_distortion import GridDistortion
+from .distortion_strategies import (
+    AffineDistortionModel,
+    CentroidReferencePoint,
+    ChiefRayReferencePoint,
+    DistortionModel,
+    DistortionResult,
+    ReferencePointStrategy,
+    RotationalDistortionModel,
+    create_distortion_model,
+)
 from .field_curvature import FieldCurvature
 from .rms_vs_field import RmsSpotSizeVsField, RmsWavefrontErrorVsField
 from .pupil_aberration import PupilAberration

--- a/optiland/analysis/distortion.py
+++ b/optiland/analysis/distortion.py
@@ -15,6 +15,7 @@ import numpy as np
 import optiland.backend as be
 
 from .base import BaseAnalysis
+from .distortion_strategies import DistortionModel, create_distortion_model
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -32,12 +33,20 @@ class Distortion(BaseAnalysis):
             analysis. Defaults to 128.
         distortion_type (str, optional): The type of distortion analysis.
             Defaults to 'f-tan'.
+        method (str or DistortionModel, optional): The distortion strategy to
+            use. ``"paraxial"`` (default) traces a chief ray against a
+            rotationally symmetric reference. ``"nonparaxial"`` uses the
+            transmitted-energy centroid against a best-fit affine reference,
+            enabling distortion for off-axis, freeform, or obscured systems
+            where no chief ray can be traced. A custom :class:`DistortionModel`
+            instance may also be supplied.
 
     Attributes:
         optic (Optic): The optic object being analyzed.
         wavelengths (list): The wavelengths being analyzed.
         num_points (int): The number of points generated for the analysis.
         distortion_type (str): The type of distortion analysis.
+        method: The distortion strategy used.
         data (list): The generated distortion data.
 
     Methods:
@@ -51,9 +60,11 @@ class Distortion(BaseAnalysis):
         wavelengths: str | list = "all",
         num_points: int = 128,
         distortion_type: str = "f-tan",
+        method: str | DistortionModel = "paraxial",
     ):
         self.num_points = num_points
         self.distortion_type = distortion_type
+        self.method = method
         super().__init__(optic, wavelengths)
 
     def view(
@@ -119,27 +130,16 @@ class Distortion(BaseAnalysis):
             list: A list of distortion data points.
 
         """
+        model = create_distortion_model(
+            self.method, distortion_type=self.distortion_type
+        )
+
         Hx = be.zeros(self.num_points)
         Hy = be.linspace(1e-10, 1, self.num_points)
 
         data = []
         for wp in self.wavelengths:
-            wavelength = wp.value
-            self.optic.trace_generic(Hx=Hx, Hy=Hy, Px=0, Py=0, wavelength=wavelength)
-            yr = self.optic.surfaces.y[-1, :]
-
-            const = yr[0] / (be.tan(1e-10 * be.radians(self.optic.fields.max_field)))
-
-            if self.distortion_type == "f-tan":
-                yp = const * be.tan(Hy * be.radians(self.optic.fields.max_field))
-            elif self.distortion_type == "f-theta":
-                yp = const * Hy * be.radians(self.optic.fields.max_field)
-            else:
-                raise ValueError(
-                    '''Distortion type must be "f-tan" or
-                                 "f-theta"'''
-                )
-
-            data.append(100 * (yr - yp) / yp)
+            result = model.compute(self.optic, Hx, Hy, wp.value)
+            data.append(model.percent(result, signed=True))
 
         return data

--- a/optiland/analysis/distortion_strategies/__init__.py
+++ b/optiland/analysis/distortion_strategies/__init__.py
@@ -10,7 +10,7 @@ Two orthogonal abstractions are provided:
 
 * :class:`ReferencePointStrategy` — locates the per-field image reference point
   (the "chief-ray replacement"). :class:`ChiefRayReferencePoint` traces a single
-  chief ray (classical behaviour); :class:`CentroidReferencePoint` traces a pupil
+  chief ray (classical behavior); :class:`CentroidReferencePoint` traces a pupil
   bundle and returns the transmitted-energy centroid, which is obscuration-proof
   and works when no chief ray exists.
 

--- a/optiland/analysis/distortion_strategies/__init__.py
+++ b/optiland/analysis/distortion_strategies/__init__.py
@@ -1,0 +1,54 @@
+"""Pluggable strategies for distortion analysis.
+
+This subpackage decomposes distortion computation into small, single-purpose,
+interchangeable strategies so that distortion can be evaluated for classical
+(paraxial, rotationally symmetric) systems as well as for off-axis, freeform,
+or obscured systems where no chief ray can be traced and no scalar focal length
+exists.
+
+Two orthogonal abstractions are provided:
+
+* :class:`ReferencePointStrategy` — locates the per-field image reference point
+  (the "chief-ray replacement"). :class:`ChiefRayReferencePoint` traces a single
+  chief ray (classical behaviour); :class:`CentroidReferencePoint` traces a pupil
+  bundle and returns the transmitted-energy centroid, which is obscuration-proof
+  and works when no chief ray exists.
+
+* :class:`DistortionModel` — defines the distortion-free reference mapping and the
+  residual. :class:`RotationalDistortionModel` reproduces the classical
+  ``f-tan`` / ``f-theta`` model; :class:`AffineDistortionModel` implements the
+  axis-free best-fit affine (plate-scale) reference described in
+  ``jupyter/draft_dist_method_20260620.md``.
+
+The :func:`create_distortion_model` factory wires these together from a simple
+``method`` string, while still allowing fully custom strategy objects to be
+injected (dependency inversion).
+
+Kramer Harrison, 2026
+"""
+
+from __future__ import annotations
+
+from .model import (
+    AffineDistortionModel,
+    DistortionModel,
+    DistortionResult,
+    RotationalDistortionModel,
+    create_distortion_model,
+)
+from .reference_point import (
+    CentroidReferencePoint,
+    ChiefRayReferencePoint,
+    ReferencePointStrategy,
+)
+
+__all__ = [
+    "AffineDistortionModel",
+    "CentroidReferencePoint",
+    "ChiefRayReferencePoint",
+    "DistortionModel",
+    "DistortionResult",
+    "ReferencePointStrategy",
+    "RotationalDistortionModel",
+    "create_distortion_model",
+]

--- a/optiland/analysis/distortion_strategies/__init__.py
+++ b/optiland/analysis/distortion_strategies/__init__.py
@@ -17,8 +17,7 @@ Two orthogonal abstractions are provided:
 * :class:`DistortionModel` — defines the distortion-free reference mapping and the
   residual. :class:`RotationalDistortionModel` reproduces the classical
   ``f-tan`` / ``f-theta`` model; :class:`AffineDistortionModel` implements the
-  axis-free best-fit affine (plate-scale) reference described in
-  ``jupyter/draft_dist_method_20260620.md``.
+  axis-free best-fit affine (plate-scale).
 
 The :func:`create_distortion_model` factory wires these together from a simple
 ``method`` string, while still allowing fully custom strategy objects to be

--- a/optiland/analysis/distortion_strategies/model.py
+++ b/optiland/analysis/distortion_strategies/model.py
@@ -9,7 +9,7 @@ reference is reported. Two models are provided:
   reference ray and distortion is the radial departure from it.
 
 * :class:`AffineDistortionModel` — the axis-free, best-fit affine (plate-scale)
-  reference of ``jupyter/draft_dist_method_20260620.md``. A full ``2x2`` linear
+  reference. A full ``2x2`` linear
   map from field-angle tangents to image coordinates is fit by least squares
   over a field grid; distortion is the residual about that fit. This requires no
   symmetry, no scalar focal length, and no chief ray, so it is valid for

--- a/optiland/analysis/distortion_strategies/model.py
+++ b/optiland/analysis/distortion_strategies/model.py
@@ -190,7 +190,7 @@ class AffineDistortionModel(DistortionModel):
     A full ``2x2`` linear map ``u = A @ p + b`` from field-angle tangents
     ``p = (tan(alpha_x), tan(alpha_y))`` to image coordinates is fit by least
     squares over a field grid. The affine map absorbs intended first-order
-    behaviour (plate scale, anamorphic magnification, image rotation, shear,
+    behavior (plate scale, anamorphic magnification, image rotation, shear,
     origin offset); distortion is the residual about it. No chief ray or scalar
     focal length is required, so the model is valid for off-axis, freeform, and
     obscured systems.

--- a/optiland/analysis/distortion_strategies/model.py
+++ b/optiland/analysis/distortion_strategies/model.py
@@ -1,0 +1,341 @@
+"""Distortion models: distortion-free reference mappings and residuals.
+
+A :class:`DistortionModel` defines (1) the distortion-free reference image
+mapping and (2) how the residual distortion of real landing points about that
+reference is reported. Two models are provided:
+
+* :class:`RotationalDistortionModel` — the classical rotationally symmetric
+  ``f-tan`` / ``f-theta`` model. The plate scale is fixed by a single near-axis
+  reference ray and distortion is the radial departure from it.
+
+* :class:`AffineDistortionModel` — the axis-free, best-fit affine (plate-scale)
+  reference of ``jupyter/draft_dist_method_20260620.md``. A full ``2x2`` linear
+  map from field-angle tangents to image coordinates is fit by least squares
+  over a field grid; distortion is the residual about that fit. This requires no
+  symmetry, no scalar focal length, and no chief ray, so it is valid for
+  off-axis, freeform, and obscured systems.
+
+Both models consume a :class:`ReferencePointStrategy` to obtain real landing
+points, keeping reference-point location (how a field maps to the image) cleanly
+separated from the reference mapping (what counts as undistorted).
+
+Kramer Harrison, 2026
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import optiland.backend as be
+
+from .reference_point import (
+    CentroidReferencePoint,
+    ChiefRayReferencePoint,
+    ReferencePointStrategy,
+)
+
+if TYPE_CHECKING:
+    from optiland._types import BEArray
+    from optiland.optic import Optic
+
+
+@dataclass
+class DistortionResult:
+    """Container for the outcome of a distortion evaluation.
+
+    All coordinates are expressed relative to the reference origin (the image
+    point of the field center / the affine offset ``b``), so an undistorted
+    field center maps to ``(0, 0)``.
+
+    Attributes:
+        x_real: Real image x coordinates of the reference points.
+        y_real: Real image y coordinates of the reference points.
+        x_ideal: Ideal (distortion-free) image x coordinates.
+        y_ideal: Ideal (distortion-free) image y coordinates.
+        reference_radius: Half-field image radius used to normalize percent
+            distortion. ``None`` when distortion is normalized per-point against
+            the local ideal radius (rotational model).
+    """
+
+    x_real: BEArray
+    y_real: BEArray
+    x_ideal: BEArray
+    y_ideal: BEArray
+    reference_radius: float | None = None
+
+
+class DistortionModel(ABC):
+    """Abstract distortion model: reference mapping plus residual reporting.
+
+    The lifecycle is :meth:`fit` (calibrate the reference mapping for a
+    wavelength) followed by :meth:`evaluate` (compute real and ideal points at
+    query fields). :meth:`compute` is a convenience that performs both.
+    """
+
+    @abstractmethod
+    def fit(self, optic: Optic, wavelength: float) -> None:
+        """Calibrate the distortion-free reference mapping for a wavelength."""
+
+    @abstractmethod
+    def evaluate(
+        self, optic: Optic, Hx: BEArray, Hy: BEArray, wavelength: float
+    ) -> DistortionResult:
+        """Evaluate real and ideal image points at the query field points."""
+
+    @abstractmethod
+    def percent(self, result: DistortionResult, *, signed: bool = False) -> BEArray:
+        """Return per-field distortion as a percentage.
+
+        Args:
+            result: A result previously produced by :meth:`evaluate`.
+            signed: If True, request a signed scalar distortion where the model
+                supports it (the rotationally symmetric radial convention).
+                Models without a meaningful sign return the magnitude.
+        """
+
+    def compute(
+        self, optic: Optic, Hx: BEArray, Hy: BEArray, wavelength: float
+    ) -> DistortionResult:
+        """Fit then evaluate in a single call."""
+        self.fit(optic, wavelength)
+        return self.evaluate(optic, Hx, Hy, wavelength)
+
+
+class RotationalDistortionModel(DistortionModel):
+    """Classical rotationally symmetric ``f-tan`` / ``f-theta`` distortion model.
+
+    The plate scale is determined from a single near-axis reference ray, exactly
+    reproducing Optiland's historical distortion computation.
+
+    Args:
+        reference_point: Strategy used to locate image reference points. Defaults
+            to :class:`ChiefRayReferencePoint`.
+        distortion_type: Either ``"f-tan"`` or ``"f-theta"``.
+
+    Raises:
+        ValueError: If ``distortion_type`` is not ``"f-tan"`` or ``"f-theta"``.
+    """
+
+    _NEAR_AXIS = 1e-10
+
+    def __init__(
+        self,
+        reference_point: ReferencePointStrategy | None = None,
+        distortion_type: str = "f-tan",
+    ):
+        if distortion_type not in ("f-tan", "f-theta"):
+            raise ValueError('distortion_type must be "f-tan" or "f-theta"')
+        self.reference_point = reference_point or ChiefRayReferencePoint()
+        self.distortion_type = distortion_type
+        self._origin: tuple[BEArray, BEArray] | None = None
+        self._scale: BEArray | None = None
+        self._max_field_rad: BEArray | None = None
+
+    def _project(self, H: BEArray) -> BEArray:
+        """Project a normalized field coordinate to its reference variable."""
+        angle = H * self._max_field_rad
+        if self.distortion_type == "f-tan":
+            return be.tan(angle)
+        return angle
+
+    def fit(self, optic: Optic, wavelength: float) -> None:
+        """Fix the origin (field-center intercept) and the scalar plate scale."""
+        self._max_field_rad = be.radians(optic.fields.max_field)
+
+        x_c, y_c = self.reference_point.locate(optic, 0.0, 0.0, wavelength)
+        x_c, y_c = x_c[0], y_c[0]
+
+        _, y_ref = self.reference_point.locate(optic, 0.0, self._NEAR_AXIS, wavelength)
+        if self.distortion_type == "f-tan":
+            denom = be.tan(self._NEAR_AXIS * self._max_field_rad)
+        else:
+            denom = self._NEAR_AXIS * self._max_field_rad
+
+        self._scale = (y_ref[0] - y_c) / denom
+        self._origin = (x_c, y_c)
+
+    def evaluate(
+        self, optic: Optic, Hx: BEArray, Hy: BEArray, wavelength: float
+    ) -> DistortionResult:
+        """Trace real points and compute the rotationally symmetric ideal grid."""
+        if self._origin is None or self._scale is None:
+            raise RuntimeError("fit() must be called before evaluate().")
+
+        x_c, y_c = self._origin
+        x_real, y_real = self.reference_point.locate(optic, Hx, Hy, wavelength)
+        x_real = x_real - x_c
+        y_real = y_real - y_c
+
+        x_ideal = self._scale * self._project(Hx)
+        y_ideal = self._scale * self._project(Hy)
+        return DistortionResult(x_real, y_real, x_ideal, y_ideal, None)
+
+    def percent(self, result: DistortionResult, *, signed: bool = False) -> BEArray:
+        """Radial distortion as a percentage of the local ideal radius."""
+        if signed:
+            return 100 * (result.y_real - result.y_ideal) / result.y_ideal
+        delta = be.sqrt(
+            (result.x_real - result.x_ideal) ** 2
+            + (result.y_real - result.y_ideal) ** 2
+        )
+        ideal_radius = be.sqrt(result.x_ideal**2 + result.y_ideal**2)
+        return 100 * delta / ideal_radius
+
+
+class AffineDistortionModel(DistortionModel):
+    """Axis-free best-fit affine (plate-scale) distortion model.
+
+    A full ``2x2`` linear map ``u = A @ p + b`` from field-angle tangents
+    ``p = (tan(alpha_x), tan(alpha_y))`` to image coordinates is fit by least
+    squares over a field grid. The affine map absorbs intended first-order
+    behaviour (plate scale, anamorphic magnification, image rotation, shear,
+    origin offset); distortion is the residual about it. No chief ray or scalar
+    focal length is required, so the model is valid for off-axis, freeform, and
+    obscured systems.
+
+    Args:
+        reference_point: Strategy used to locate image reference points. Defaults
+            to :class:`CentroidReferencePoint`, which is obscuration-proof.
+        fit_grid_size: Number of field samples per axis used to fit the affine
+            map. The grid spans the normalized field square ``[-1, 1]``.
+        field_projection: ``"f-tan"`` (default, rectilinear reference using
+            tangents) or ``"f-theta"`` (scanning reference using angles).
+
+    Raises:
+        ValueError: If ``field_projection`` is not ``"f-tan"`` or ``"f-theta"``.
+    """
+
+    def __init__(
+        self,
+        reference_point: ReferencePointStrategy | None = None,
+        fit_grid_size: int = 11,
+        field_projection: str = "f-tan",
+    ):
+        if field_projection not in ("f-tan", "f-theta"):
+            raise ValueError('field_projection must be "f-tan" or "f-theta"')
+        self.reference_point = reference_point or CentroidReferencePoint()
+        self.fit_grid_size = fit_grid_size
+        self.field_projection = field_projection
+        self._A: BEArray | None = None
+        self._b: tuple[BEArray, BEArray] | None = None
+        self._reference_radius: BEArray | None = None
+        self._max_field_rad: BEArray | None = None
+
+    def _project(self, H: BEArray) -> BEArray:
+        """Project a normalized field coordinate to its reference variable."""
+        angle = H * self._max_field_rad
+        if self.field_projection == "f-tan":
+            return be.tan(angle)
+        return angle
+
+    def fit(self, optic: Optic, wavelength: float) -> None:
+        """Fit the affine reference map by least squares over a field grid."""
+        self._max_field_rad = be.radians(optic.fields.max_field)
+
+        axis = be.linspace(-1.0, 1.0, self.fit_grid_size)
+        Hx_grid, Hy_grid = be.meshgrid(axis, axis)
+        Hx = Hx_grid.flatten()
+        Hy = Hy_grid.flatten()
+
+        x_bar, y_bar = self.reference_point.locate(optic, Hx, Hy, wavelength)
+        px = self._project(Hx)
+        py = self._project(Hy)
+
+        # Exclude fully obscured / failed fields from the fit.
+        valid = be.isfinite(x_bar) & be.isfinite(y_bar)
+        px_v = px[valid]
+        py_v = py[valid]
+
+        design = be.stack([px_v, py_v, be.ones_like(px_v)], axis=1)
+        coeff_x = be.lstsq(design, x_bar[valid])  # [A11, A12, b_x]
+        coeff_y = be.lstsq(design, y_bar[valid])  # [A21, A22, b_y]
+
+        self._A = be.stack(
+            [
+                be.stack([coeff_x[0], coeff_x[1]]),
+                be.stack([coeff_y[0], coeff_y[1]]),
+            ]
+        )
+        self._b = (coeff_x[2], coeff_y[2])
+
+        # Half-field image radius R_max = max ||A p|| over the (valid) fit grid.
+        x_ideal = coeff_x[0] * px_v + coeff_x[1] * py_v
+        y_ideal = coeff_y[0] * px_v + coeff_y[1] * py_v
+        self._reference_radius = be.max(be.sqrt(x_ideal**2 + y_ideal**2))
+
+    def evaluate(
+        self, optic: Optic, Hx: BEArray, Hy: BEArray, wavelength: float
+    ) -> DistortionResult:
+        """Trace real centroids and evaluate the affine ideal at query fields."""
+        if self._A is None or self._b is None:
+            raise RuntimeError("fit() must be called before evaluate().")
+
+        x_bar, y_bar = self.reference_point.locate(optic, Hx, Hy, wavelength)
+        px = self._project(Hx)
+        py = self._project(Hy)
+
+        b_x, b_y = self._b
+        # Ideal points expressed relative to the origin b (A @ p).
+        x_ideal = self._A[0, 0] * px + self._A[0, 1] * py
+        y_ideal = self._A[1, 0] * px + self._A[1, 1] * py
+        x_real = x_bar - b_x
+        y_real = y_bar - b_y
+        return DistortionResult(
+            x_real, y_real, x_ideal, y_ideal, self._reference_radius
+        )
+
+    def percent(self, result: DistortionResult, *, signed: bool = False) -> BEArray:
+        """Residual distortion as a percentage of the half-field image radius."""
+        delta = be.sqrt(
+            (result.x_real - result.x_ideal) ** 2
+            + (result.y_real - result.y_ideal) ** 2
+        )
+        return 100 * delta / result.reference_radius
+
+
+_PARAXIAL_ALIASES = frozenset(
+    {"paraxial", "chief", "chief_ray", "chief-ray", "rotational"}
+)
+_NONPARAXIAL_ALIASES = frozenset({"nonparaxial", "non-paraxial", "centroid", "affine"})
+
+
+def create_distortion_model(
+    method: str | DistortionModel = "paraxial",
+    *,
+    distortion_type: str = "f-tan",
+    **kwargs,
+) -> DistortionModel:
+    """Build a :class:`DistortionModel` from a method name.
+
+    Args:
+        method: Either an existing :class:`DistortionModel` instance (returned
+            unchanged, enabling fully custom strategies), or one of the strings
+            ``"paraxial"`` (chief ray + rotationally symmetric reference) or
+            ``"nonparaxial"`` (energy centroid + best-fit affine reference).
+            Common aliases are accepted.
+        distortion_type: Reference model, ``"f-tan"`` or ``"f-theta"``. Used as
+            the rotational model type for the paraxial method and as the field
+            projection for the non-paraxial method.
+        **kwargs: Forwarded to the selected model constructor (e.g.
+            ``reference_point``, ``fit_grid_size``).
+
+    Returns:
+        A configured :class:`DistortionModel`.
+
+    Raises:
+        ValueError: If ``method`` is an unrecognized string.
+    """
+    if isinstance(method, DistortionModel):
+        return method
+
+    key = method.lower()
+    if key in _PARAXIAL_ALIASES:
+        return RotationalDistortionModel(distortion_type=distortion_type, **kwargs)
+    if key in _NONPARAXIAL_ALIASES:
+        return AffineDistortionModel(field_projection=distortion_type, **kwargs)
+    raise ValueError(
+        f"Unknown distortion method '{method}'. "
+        "Expected 'paraxial' or 'nonparaxial' (or a DistortionModel instance)."
+    )

--- a/optiland/analysis/distortion_strategies/reference_point.py
+++ b/optiland/analysis/distortion_strategies/reference_point.py
@@ -61,7 +61,7 @@ class ReferencePointStrategy(ABC):
 class ChiefRayReferencePoint(ReferencePointStrategy):
     """Reference point given by the chief ray (pupil center) intercept.
 
-    This reproduces the classical behaviour and is valid for rotationally
+    This reproduces the classical behavior and is valid for rotationally
     symmetric, well-behaved systems where a chief ray can be traced.
     """
 

--- a/optiland/analysis/distortion_strategies/reference_point.py
+++ b/optiland/analysis/distortion_strategies/reference_point.py
@@ -1,0 +1,169 @@
+"""Per-field image reference point strategies.
+
+The image reference point is the single image-plane coordinate associated with a
+field direction. Classically this is the chief-ray intercept, but for off-axis,
+freeform, or obscured systems no chief ray exists. This module abstracts the
+reference point behind :class:`ReferencePointStrategy` so that the chief ray can
+be transparently replaced by the transmitted-energy centroid of a traced pupil
+bundle (the "chief-ray replacement" of ``jupyter/draft_dist_method_20260620.md``).
+
+All strategies expose the same :meth:`ReferencePointStrategy.locate` interface and
+are therefore interchangeable wherever a per-field landing point is required
+(standard distortion, grid distortion, and image-simulation warping).
+
+Kramer Harrison, 2026
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+import optiland.backend as be
+from optiland.distribution import create_distribution
+
+if TYPE_CHECKING:
+    from optiland._types import BEArray, DistributionType
+    from optiland.distribution import BaseDistribution
+    from optiland.optic import Optic
+
+
+class ReferencePointStrategy(ABC):
+    """Abstract strategy for locating per-field image reference points.
+
+    Implementations map one or more normalized field coordinates to the
+    corresponding image-plane ``(x, y)`` landing points for a given wavelength.
+    """
+
+    @abstractmethod
+    def locate(
+        self,
+        optic: Optic,
+        Hx: float | BEArray,
+        Hy: float | BEArray,
+        wavelength: float,
+    ) -> tuple[BEArray, BEArray]:
+        """Locate the image reference point(s) for the given field(s).
+
+        Args:
+            optic: The optical system to trace through.
+            Hx: Normalized x field coordinate(s). Scalar or 1D array.
+            Hy: Normalized y field coordinate(s). Scalar or 1D array.
+            wavelength: Wavelength of the trace, in microns.
+
+        Returns:
+            A tuple ``(x, y)`` of 1D arrays giving the image-plane coordinates
+            of the reference point for each input field. Fields for which no
+            reference point can be determined are returned as ``NaN``.
+        """
+
+
+class ChiefRayReferencePoint(ReferencePointStrategy):
+    """Reference point given by the chief ray (pupil center) intercept.
+
+    This reproduces the classical behaviour and is valid for rotationally
+    symmetric, well-behaved systems where a chief ray can be traced.
+    """
+
+    def locate(
+        self,
+        optic: Optic,
+        Hx: float | BEArray,
+        Hy: float | BEArray,
+        wavelength: float,
+    ) -> tuple[BEArray, BEArray]:
+        """Trace the chief ray (``Px = Py = 0``) for each field point."""
+        optic.trace_generic(Hx=Hx, Hy=Hy, Px=0.0, Py=0.0, wavelength=wavelength)
+        x = optic.surfaces.x[-1, :]
+        y = optic.surfaces.y[-1, :]
+        return x, y
+
+
+class CentroidReferencePoint(ReferencePointStrategy):
+    """Reference point given by the transmitted-energy centroid of a ray bundle.
+
+    For each field, a dense, approximately equal-area pupil distribution is
+    traced. Rays flagged as blocked/vignetted (zero intensity) or that fail to
+    trace (non-finite coordinates) are discarded, and the (optionally
+    flux-weighted) centroid of the survivors is returned. This is obscuration-
+    proof and remains well-defined when no chief ray exists.
+
+    Args:
+        num_rays: Sampling density of the pupil distribution. For the default
+            ``"uniform"`` distribution this is the number of points per axis of
+            the underlying square grid (clipped to the unit disk).
+        distribution: Name of the pupil distribution to sample. An
+            (approximately) equal-area distribution such as ``"uniform"`` or
+            ``"hexapolar"`` is recommended so that an unweighted centroid equals
+            the energy centroid under uniform illumination.
+        flux_weighted: If True (default), weight each surviving ray by its
+            transmitted intensity (handling apodization and partial vignetting).
+            If False, all surviving rays are weighted equally.
+    """
+
+    def __init__(
+        self,
+        num_rays: int = 20,
+        distribution: DistributionType = "uniform",
+        *,
+        flux_weighted: bool = True,
+    ):
+        self.num_rays = num_rays
+        self.distribution = distribution
+        self.flux_weighted = flux_weighted
+
+    def _sample_pupil(self) -> BaseDistribution:
+        """Create and populate the configured pupil distribution."""
+        dist = create_distribution(self.distribution)
+        dist.generate_points(self.num_rays)
+        return dist
+
+    def locate(
+        self,
+        optic: Optic,
+        Hx: float | BEArray,
+        Hy: float | BEArray,
+        wavelength: float,
+    ) -> tuple[BEArray, BEArray]:
+        """Trace a pupil bundle per field and return the energy centroid."""
+        Hx = be.atleast_1d(be.array(Hx))
+        Hy = be.atleast_1d(be.array(Hy))
+        num_fields = Hx.shape[0]
+
+        pupil = self._sample_pupil()
+        Px = pupil.x
+        Py = pupil.y
+        num_pupil = Px.shape[0]
+
+        # One ray per (field, pupil-point); fields vary slowest.
+        Hx_full = be.repeat(Hx, num_pupil)
+        Hy_full = be.repeat(Hy, num_pupil)
+        Px_full = be.tile(Px, num_fields)
+        Py_full = be.tile(Py, num_fields)
+
+        optic.trace_generic(
+            Hx=Hx_full, Hy=Hy_full, Px=Px_full, Py=Py_full, wavelength=wavelength
+        )
+
+        shape = (num_fields, num_pupil)
+        x = be.reshape(optic.surfaces.x[-1, :], shape)
+        y = be.reshape(optic.surfaces.y[-1, :], shape)
+        intensity = be.reshape(optic.surfaces.intensity[-1, :], shape)
+
+        # Survivors: transmitted (positive intensity) and successfully traced.
+        valid = be.isfinite(x) & be.isfinite(y) & (intensity > 0)
+
+        if self.flux_weighted:
+            weights = be.where(valid, intensity, be.zeros_like(intensity))
+        else:
+            weights = be.where(valid, be.ones_like(intensity), be.zeros_like(intensity))
+
+        x_clean = be.where(valid, x, be.zeros_like(x))
+        y_clean = be.where(valid, y, be.zeros_like(y))
+
+        weight_sum = be.sum(weights, axis=1)
+        # Fully obscured fields (weight_sum == 0) yield NaN, flagging them as
+        # undefined for downstream masking.
+        x_bar = be.sum(weights * x_clean, axis=1) / weight_sum
+        y_bar = be.sum(weights * y_clean, axis=1) / weight_sum
+        return x_bar, y_bar

--- a/optiland/analysis/distortion_strategies/reference_point.py
+++ b/optiland/analysis/distortion_strategies/reference_point.py
@@ -5,7 +5,7 @@ field direction. Classically this is the chief-ray intercept, but for off-axis,
 freeform, or obscured systems no chief ray exists. This module abstracts the
 reference point behind :class:`ReferencePointStrategy` so that the chief ray can
 be transparently replaced by the transmitted-energy centroid of a traced pupil
-bundle (the "chief-ray replacement" of ``jupyter/draft_dist_method_20260620.md``).
+bundle.
 
 All strategies expose the same :meth:`ReferencePointStrategy.locate` interface and
 are therefore interchangeable wherever a per-field landing point is required

--- a/optiland/analysis/grid_distortion.py
+++ b/optiland/analysis/grid_distortion.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
-import numpy as np
 from matplotlib.lines import Line2D
 
 import optiland.backend as be
 
 from .base import BaseAnalysis
+from .distortion_strategies import DistortionModel, create_distortion_model
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -34,10 +34,18 @@ class GridDistortion(BaseAnalysis):
         num_points (int, optional): Number of grid points per axis. Defaults to 10.
         distortion_type (str, optional): Distortion model, either 'f-tan' or 'f-theta'.
             Defaults to 'f-tan'.
+        method (str or DistortionModel, optional): The distortion strategy to
+            use. ``"paraxial"`` (default) traces a chief ray against a
+            rotationally symmetric reference. ``"nonparaxial"`` uses the
+            transmitted-energy centroid against a best-fit affine reference,
+            enabling grid distortion for off-axis, freeform, or obscured systems
+            where no chief ray can be traced. A custom :class:`DistortionModel`
+            instance may also be supplied.
 
     Attributes:
         num_points (int): Number of grid points per axis.
         distortion_type (str): Distortion model used.
+        method: The distortion strategy used.
         data (dict): Computed distortion data (after running _generate_data()).
 
     Methods:
@@ -51,6 +59,7 @@ class GridDistortion(BaseAnalysis):
         wavelength="primary",
         num_points=10,
         distortion_type="f-tan",
+        method: str | DistortionModel = "paraxial",
     ):
         if isinstance(wavelength, float | int):
             processed_wavelengths = [wavelength]
@@ -64,6 +73,7 @@ class GridDistortion(BaseAnalysis):
 
         self.num_points = num_points
         self.distortion_type = distortion_type
+        self.method = method
         super().__init__(optic, wavelengths=processed_wavelengths)
 
     def view(
@@ -158,33 +168,24 @@ class GridDistortion(BaseAnalysis):
         Raises:
             ValueError: If the distortion type is not 'f-tan' or 'f-theta'.
         """
-        current_wavelength = self.wavelengths[0].value
-        x_chief, y_chief = self._trace_chief_ray(current_wavelength)
-        y_ref = self._trace_reference_ray(current_wavelength, y_chief)
+        model = create_distortion_model(
+            self.method, distortion_type=self.distortion_type
+        )
+        wavelength = self.wavelengths[0].value
+        model.fit(self.optic, wavelength)
 
         Hx, Hy = self._build_field_grid()
-        xp, yp = self._compute_ideal_positions(Hx, Hy, y_chief, y_ref)
+        result = model.evaluate(self.optic, Hx.flatten(), Hy.flatten(), wavelength)
 
-        self.optic.trace_generic(
-            Hx=Hx.flatten(),
-            Hy=Hy.flatten(),
-            Px=0,
-            Py=0,
-            wavelength=current_wavelength,
-        )
+        shape = (self.num_points, self.num_points)
+        xp = be.reshape(result.x_ideal, shape)
+        yp = be.reshape(result.y_ideal, shape)
+        xr = be.reshape(result.x_real, shape)
+        yr = be.reshape(result.y_real, shape)
 
-        xr = (
-            be.reshape(self.optic.surfaces.x[-1, :], (self.num_points, self.num_points))
-            - x_chief
-        )
-        yr = (
-            be.reshape(self.optic.surfaces.y[-1, :], (self.num_points, self.num_points))
-            - y_chief
-        )
-
-        delta = be.sqrt((xp - xr) ** 2 + (yp - yr) ** 2)
-        rp = be.sqrt(xp**2 + yp**2)
-        max_distortion = be.max(100 * delta / rp)
+        pct = model.percent(result, signed=False)
+        finite = be.isfinite(pct)
+        max_distortion = be.max(pct[finite])
 
         return {
             "xp": xp,
@@ -194,35 +195,8 @@ class GridDistortion(BaseAnalysis):
             "max_distortion": max_distortion,
         }
 
-    def _trace_chief_ray(self, wavelength: float) -> tuple:
-        """Returns the image-plane (x, y) position of the on-axis chief ray."""
-        self.optic.trace_generic(Hx=0, Hy=0, Px=0, Py=0, wavelength=wavelength)
-        return self.optic.surfaces.x[-1, 0], self.optic.surfaces.y[-1, 0]
-
-    def _trace_reference_ray(self, wavelength: float, y_chief) -> float:
-        """Returns the image-plane y position of a near-axis reference ray."""
-        self.optic.trace_generic(Hx=0, Hy=1e-10, Px=0, Py=0, wavelength=wavelength)
-        return self.optic.surfaces.y[-1, 0]
-
     def _build_field_grid(self):
         """Returns (Hx, Hy) meshgrid spanning the normalised field square."""
-        max_field = np.sqrt(2) / 2
+        max_field = 2**0.5 / 2
         extent = be.linspace(-max_field, max_field, self.num_points)
         return be.meshgrid(extent, extent)
-
-    def _compute_ideal_positions(self, Hx, Hy, y_chief, y_ref):
-        """Returns (xp, yp) ideal grid positions for the chosen distortion model."""
-        max_field_rad = be.radians(self.optic.fields.max_field)
-
-        if self.distortion_type == "f-tan":
-            const = (y_ref - y_chief) / be.tan(1e-10 * max_field_rad)
-            xp = const * be.tan(Hx * max_field_rad)
-            yp = const * be.tan(Hy * max_field_rad)
-        elif self.distortion_type == "f-theta":
-            const = (y_ref - y_chief) / (1e-10 * max_field_rad)
-            xp = const * Hx * max_field_rad
-            yp = const * Hy * max_field_rad
-        else:
-            raise ValueError('distortion_type must be "f-tan" or "f-theta"')
-
-        return xp, yp

--- a/optiland/analysis/image_simulation/distortion_warper.py
+++ b/optiland/analysis/image_simulation/distortion_warper.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import optiland.backend as be
+
+from ..distortion_strategies import ChiefRayReferencePoint
+
+if TYPE_CHECKING:
+    from ..distortion_strategies import ReferencePointStrategy
 
 
 class DistortionWarper:
@@ -13,10 +20,21 @@ class DistortionWarper:
         source_fov (tuple): (max_x, max_y) of the source field in system units
                             (degrees for infinite, mm for finite).
                             If None, attempts to infer from optic.fields.max_field.
+        reference_point (ReferencePointStrategy, optional): Strategy used to
+            locate per-field image reference points. Defaults to
+            :class:`ChiefRayReferencePoint` (chief-ray intercept). Supply a
+            :class:`CentroidReferencePoint` to warp off-axis, freeform, or
+            obscured systems where no chief ray can be traced.
     """
 
-    def __init__(self, optic, source_fov=None):
+    def __init__(
+        self,
+        optic,
+        source_fov=None,
+        reference_point: ReferencePointStrategy | None = None,
+    ):
         self.optic = optic
+        self.reference_point = reference_point or ChiefRayReferencePoint()
 
         if source_fov is None:
             # Infer from optic
@@ -60,23 +78,17 @@ class DistortionWarper:
         hx_norm = phys_x / optic_max
         hy_norm = phys_y / optic_max
 
-        # Trace Rays
-        self.optic.trace_generic(
-            Hx=hx_norm, Hy=hy_norm, Px=0, Py=0, wavelength=wavelength
+        # 2. Get Landing Coordinates (Real Image Plane) via the reference-point
+        # strategy, so obscured/off-axis systems can be warped via the bundle
+        # centroid when no chief ray exists.
+        x_real, y_real = self.reference_point.locate(
+            self.optic, hx_norm, hy_norm, wavelength
         )
 
-        # 2. Get Landing Coordinates (Real Image Plane)
-        x_real = self.optic.surfaces.x[-1, :]
-        y_real = self.optic.surfaces.y[-1, :]
-
-        # Center relative to chief ray
-        chief_ray = self.optic.trace_generic(
-            Hx=0, Hy=0, Px=0, Py=0, wavelength=wavelength
-        )
-        cx = chief_ray.x[0]
-        cy = chief_ray.y[0]
-        x_real = x_real - cx
-        y_real = y_real - cy
+        # Center relative to the field-center reference point
+        cx, cy = self.reference_point.locate(self.optic, 0.0, 0.0, wavelength)
+        x_real = x_real - cx[0]
+        y_real = y_real - cy[0]
 
         # 3. Fit Polynomial: (x_real, y_real) -> (gx, gy)
         X_features = self._poly_features(x_real, y_real, degree)

--- a/optiland/analysis/image_simulation/engine.py
+++ b/optiland/analysis/image_simulation/engine.py
@@ -25,6 +25,11 @@ class ImageSimulationEngine:
             - n_components (int): Number of EigenPSFs.
             - oversample (int): Upsampling factor for simulation accuracy.
             - padding (int): Pixel padding (guard band) to avoid edge artifacts.
+            - distortion_reference (ReferencePointStrategy): Strategy used to
+              locate per-field image reference points for the distortion warp.
+              Defaults to None (chief-ray intercept). Supply a
+              CentroidReferencePoint to simulate off-axis, freeform, or obscured
+              systems where no chief ray can be traced.
     """
 
     def __init__(self, optic, config=None):
@@ -40,6 +45,7 @@ class ImageSimulationEngine:
             "n_components": 3,
             "oversample": 1,
             "padding": 64,
+            "distortion_reference": None,
         }
         if config:
             self.config.update(config)
@@ -106,7 +112,9 @@ class ImageSimulationEngine:
         # 2. Simulation Loop per Channel
         processed_channels = []
         sim = SpatiallyVariableSimulator()
-        warper = DistortionWarper(self.optic)
+        warper = DistortionWarper(
+            self.optic, reference_point=self.config["distortion_reference"]
+        )
 
         for _i, (wave, channel_img) in enumerate(
             zip(wavelengths, input_channels, strict=False)

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -20,8 +20,7 @@ class FieldPoint(NamedTuple):
     Attributes:
         coord: (x, y) field coordinate in the field coordinate system.
         weight: Non-negative relative importance scalar. Defaults to 1.0 for
-            user-supplied raw coordinates. Refer to optiland weight semantics in
-            SPEC_weights.md §2.1.
+            user-supplied raw coordinates.
     """
 
     coord: tuple[float, float]
@@ -34,8 +33,7 @@ class WavelengthPoint(NamedTuple):
     Attributes:
         value: Wavelength in micrometers.
         weight: Non-negative relative importance scalar. Defaults to 1.0 for
-            user-supplied raw values. Refer to optiland weight semantics in
-            SPEC_weights.md §2.1.
+            user-supplied raw values.
     """
 
     value: float

--- a/tests/analysis/test_distortion_strategies.py
+++ b/tests/analysis/test_distortion_strategies.py
@@ -1,0 +1,168 @@
+"""Tests for the pluggable distortion strategies.
+
+These cover the reference-point strategies (chief ray vs. energy centroid), the
+distortion models (rotational vs. affine), the factory, and the integration of
+the non-paraxial path into the standard distortion analysis, grid distortion,
+and image-simulation warper.
+
+Kramer Harrison, 2026
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import optiland.backend as be
+from optiland import analysis
+from optiland.analysis.distortion_strategies import (
+    AffineDistortionModel,
+    CentroidReferencePoint,
+    ChiefRayReferencePoint,
+    DistortionModel,
+    RotationalDistortionModel,
+    create_distortion_model,
+)
+from optiland.analysis.image_simulation import DistortionWarper
+from optiland.samples.objectives import CookeTriplet
+
+
+@pytest.fixture
+def cooke_triplet():
+    return CookeTriplet()
+
+
+class TestReferencePointStrategies:
+    def test_chief_ray_locate_shapes(self, set_test_backend, cooke_triplet):
+        locator = ChiefRayReferencePoint()
+        Hx = be.array([0.0, 0.0, 0.0])
+        Hy = be.array([0.0, 0.5, 1.0])
+        x, y = locator.locate(cooke_triplet, Hx, Hy, 0.55)
+        assert x.shape[0] == 3
+        assert y.shape[0] == 3
+        # On-axis field lands near the origin for this symmetric system.
+        assert_allclose(be.to_numpy(x)[0], 0.0, atol=1e-9)
+        assert_allclose(be.to_numpy(y)[0], 0.0, atol=1e-9)
+
+    def test_centroid_matches_chief_for_symmetric_system(
+        self, set_test_backend, cooke_triplet
+    ):
+        # For a well-behaved rotationally symmetric system, the transmitted
+        # centroid coincides with the chief-ray intercept to high accuracy.
+        chief = ChiefRayReferencePoint()
+        centroid = CentroidReferencePoint(num_rays=32)
+        Hy = be.array([0.0, 0.7])
+        Hx = be.zeros_like(Hy)
+        xc, yc = chief.locate(cooke_triplet, Hx, Hy, 0.55)
+        xb, yb = centroid.locate(cooke_triplet, Hx, Hy, 0.55)
+        assert_allclose(be.to_numpy(xb), be.to_numpy(xc), atol=5e-3)
+        assert_allclose(be.to_numpy(yb), be.to_numpy(yc), atol=5e-3)
+
+    def test_centroid_unweighted_runs(self, set_test_backend, cooke_triplet):
+        centroid = CentroidReferencePoint(num_rays=20, flux_weighted=False)
+        x, y = centroid.locate(cooke_triplet, be.array([0.3]), be.array([0.3]), 0.55)
+        assert np.all(np.isfinite(be.to_numpy(x)))
+        assert np.all(np.isfinite(be.to_numpy(y)))
+
+
+class TestRotationalModel:
+    def test_invalid_distortion_type(self, set_test_backend):
+        with pytest.raises(ValueError):
+            RotationalDistortionModel(distortion_type="invalid")
+
+    def test_evaluate_before_fit_raises(self, set_test_backend, cooke_triplet):
+        model = RotationalDistortionModel()
+        with pytest.raises(RuntimeError):
+            model.evaluate(cooke_triplet, be.array([0.0]), be.array([0.5]), 0.55)
+
+    def test_field_center_is_zero_distortion(self, set_test_backend, cooke_triplet):
+        model = RotationalDistortionModel()
+        result = model.compute(cooke_triplet, be.array([0.0]), be.array([1e-10]), 0.55)
+        pct = model.percent(result, signed=True)
+        assert_allclose(be.to_numpy(pct)[0], 0.0, atol=1e-6)
+
+
+class TestAffineModel:
+    def test_invalid_projection(self, set_test_backend):
+        with pytest.raises(ValueError):
+            AffineDistortionModel(field_projection="invalid")
+
+    def test_evaluate_before_fit_raises(self, set_test_backend, cooke_triplet):
+        model = AffineDistortionModel(fit_grid_size=5)
+        with pytest.raises(RuntimeError):
+            model.evaluate(cooke_triplet, be.array([0.0]), be.array([0.5]), 0.55)
+
+    def test_reference_radius_positive(self, set_test_backend, cooke_triplet):
+        model = AffineDistortionModel(
+            reference_point=CentroidReferencePoint(num_rays=16), fit_grid_size=7
+        )
+        model.fit(cooke_triplet, 0.55)
+        assert float(be.to_numpy(model._reference_radius)) > 0.0
+
+    def test_affine_residual_finite(self, set_test_backend, cooke_triplet):
+        model = AffineDistortionModel(
+            reference_point=CentroidReferencePoint(num_rays=16), fit_grid_size=7
+        )
+        result = model.compute(
+            cooke_triplet, be.array([0.0, 0.5]), be.array([0.0, 0.5]), 0.55
+        )
+        pct = model.percent(result)
+        assert np.all(np.isfinite(be.to_numpy(pct)))
+
+
+class TestFactory:
+    def test_paraxial_alias(self, set_test_backend):
+        model = create_distortion_model("paraxial")
+        assert isinstance(model, RotationalDistortionModel)
+
+    def test_nonparaxial_alias(self, set_test_backend):
+        model = create_distortion_model("centroid")
+        assert isinstance(model, AffineDistortionModel)
+
+    def test_instance_passthrough(self, set_test_backend):
+        custom = AffineDistortionModel()
+        assert create_distortion_model(custom) is custom
+
+    def test_unknown_method_raises(self, set_test_backend):
+        with pytest.raises(ValueError):
+            create_distortion_model("bogus")
+
+    def test_distortion_type_forwarded(self, set_test_backend):
+        model = create_distortion_model("paraxial", distortion_type="f-theta")
+        assert isinstance(model, RotationalDistortionModel)
+        assert model.distortion_type == "f-theta"
+
+    def test_is_distortion_model(self, set_test_backend):
+        assert isinstance(create_distortion_model("paraxial"), DistortionModel)
+
+
+class TestNonParaxialIntegration:
+    def test_radial_distortion_nonparaxial(self, set_test_backend, cooke_triplet):
+        dist = analysis.Distortion(cooke_triplet, method="nonparaxial")
+        assert len(dist.data) == len(cooke_triplet.wavelengths.get_wavelengths())
+        for arr in dist.data:
+            assert np.all(np.isfinite(be.to_numpy(arr)))
+
+    def test_grid_distortion_nonparaxial(self, set_test_backend, cooke_triplet):
+        dist = analysis.GridDistortion(cooke_triplet, method="nonparaxial")
+        assert dist.data["xr"].shape == (10, 10)
+        assert dist.data["yp"].shape == (10, 10)
+        assert float(be.to_numpy(dist.data["max_distortion"])) >= 0.0
+
+    def test_grid_distortion_custom_model(self, set_test_backend, cooke_triplet):
+        model = AffineDistortionModel(
+            reference_point=CentroidReferencePoint(num_rays=16), fit_grid_size=7
+        )
+        dist = analysis.GridDistortion(cooke_triplet, method=model)
+        assert dist.data["xr"].shape == (10, 10)
+
+    def test_warper_with_centroid_reference(self, set_test_backend, cooke_triplet):
+        warper = DistortionWarper(
+            cooke_triplet, reference_point=CentroidReferencePoint(num_rays=16)
+        )
+        grid = warper.generate_distortion_map(
+            0.55, (16, 16), num_grid_points=7, degree=3
+        )
+        assert tuple(grid.shape) == (1, 16, 16, 2)
+        assert np.all(np.isfinite(be.to_numpy(grid)))

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,7 +1,5 @@
 """Tests for field and wavelength weighting system.
 
-Tests all 20 requirements from SPEC_weights.md §10.
-
 Kramer Harrison, 2026
 """
 


### PR DESCRIPTION
Decomposes distortion calculation into small, single-purpose, interchangeable strategies. This enables distortion evaluation for classical (paraxial, rotationally symmetric) systems as well as off-axis, freeform, or obscured systems where no chief ray can be traced.

- Add ReferencePointStrategy, ChiefRayReferencePoint, and CentroidReferencePoint to locate the per-field image reference points.

- Add DistortionModel, RotationalDistortionModel, and AffineDistortionModel to define the distortion-free reference mapping and calculate residual distortion.

- Integrate these strategies into Distortion and GridDistortion analysis modules.

- Update DistortionWarper and ImageSimulationEngine to support CentroidReferencePoint.

- Add comprehensive tests in tests/analysis/test_distortion_strategies.py covering both NumPy and PyTorch backends.