### PR TITLE
Fix SHGO optimizer variable shape bug

### DIFF
--- a/optiland/optimization/variable/variable.py
+++ b/optiland/optimization/variable/variable.py
@@ -184,7 +184,16 @@ class Variable:
             ValueError: If the variable type is invalid.
 
         """
+        import optiland.backend as be
+
+        if isinstance(new_value, list | tuple):
+            new_value = new_value[0]
+
         unscaled_value = self.variable.inverse_scale(new_value)
+
+        if hasattr(unscaled_value, "ndim") and unscaled_value.ndim > 0:
+            unscaled_value = be.ravel(unscaled_value)[0]
+
         self.variable.update_value(unscaled_value)
 
     def reset(self):


### PR DESCRIPTION
## Fix: Optimizer Variable Shape Bug

- `optiland/optimization/variable/variable.py`: Updated the `Variable.update(self, new_value)` method so that whenever a new value is proposed by an optimizer (such as SHGO from scipy), it is reduced to a 0-dimensional element.
    - By using `unscaled_value = optiland.backend.ravel(unscaled_value)[0]`, we ensure the extracted value behaves as an Optiland backend array (NumPy or PyTorch), while keeping its native 0-D nature and retaining PyTorch gradient graphs where necessary.