### PR TITLE
Fix ray intersection instability and rendering bugs for off-axis parabolic mirrors

### DIFF
--- a/optiland/geometries/standard.py
+++ b/optiland/geometries/standard.py
@@ -136,11 +136,24 @@ class StandardGeometry(BaseGeometry):
         # discriminant
         d = b**2 - 4 * a * c
 
-        # two solutions for distance to conic
+        # Two solutions for distance to conic, computed via the numerically
+        # stable form (Numerical Recipes / "citardauque" formula) rather
+        # than the textbook (-b +/- sqrt(d)) / (2a). For rays close to the
+        # optical axis (small L, M) and conics near a parabola (k = -1),
+        # "a" is a tiny value dominated by floating-point noise rather than
+        # 0 exactly, so the a == 0 guard below never triggers in practice.
+        # The textbook formula then subtracts two nearly-equal numbers
+        # (b and sqrt(d), both ~ -2*N*R) in the numerator while dividing by
+        # a near-zero "a", amplifying that cancellation error by orders of
+        # magnitude. This form avoids the cancellation entirely and reduces
+        # continuously to the a == 0 (linear) solution as a -> 0, so no
+        # separate branch is needed for that case.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            t1 = (-b + be.sqrt(d)) / (2 * a)
-            t2 = (-b - be.sqrt(d)) / (2 * a)
+            sign_b = be.where(b >= 0, 1.0, -1.0)
+            q = -0.5 * (b + sign_b * be.sqrt(d))
+            t1 = q / a
+            t2 = c / q
 
         # find intersection points in z
         z1 = rays.z + t1 * rays.N
@@ -148,10 +161,6 @@ class StandardGeometry(BaseGeometry):
 
         # take intersection closest to z = 0 (i.e., vertex of geometry)
         t = be.where(be.abs(z1) <= be.abs(z2), t1, t2)
-
-        # handle case when a = 0
-        # Assumes b is not zero when a is zero, based on original logic.
-        t = be.where(a == 0, -c / b, t)
 
         return t
 

--- a/optiland/visualization/system/surface.py
+++ b/optiland/visualization/system/surface.py
@@ -42,7 +42,12 @@ class Surface2D:
 
         if self.surf.aperture:
             x_min, x_max, y_min, y_max = self.surf.aperture.extent
-            extent = be.max(be.array([x_min, x_max, y_min, y_max]))
+            # Use the largest absolute bound so that apertures offset from
+            # the surface vertex (e.g. OffsetRadialAperture) are fully
+            # covered by the symmetric [-extent, extent] sampling window
+            # used in _compute_sag; a plain max() would collapse to the
+            # aperture radius and miss the offset region entirely.
+            extent = be.max(be.abs(be.array([x_min, x_max, y_min, y_max])))
             # Fall back to ray extent if aperture extent is infinite
             self.extent = extent if be.isfinite(be.array(extent)) else ray_extent
         else:

--- a/optiland/visualization/system/system.py
+++ b/optiland/visualization/system/system.py
@@ -7,6 +7,7 @@ Kramer Harrison, 2024
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
@@ -249,10 +250,28 @@ class OpticalSystem:
             else:
                 continue
 
-            # Define local coordinates based on projection
-            x_local = be.array([x_min, x_max])
-            y_local = be.array([y_min, y_max])
-            z_local = be.array([0.0, 0.0])
+            # Define local coordinates based on projection. Only the axis
+            # actually shown in this projection is swept between its aperture
+            # bounds; the other is held at 0 (its axis-of-symmetry value)
+            # rather than paired corner-to-corner, which would otherwise mix
+            # in the wrong sag contribution for offset apertures. The sag is
+            # evaluated at each point (instead of assuming z=0) so the
+            # indicator line follows the true, possibly-tilted surface
+            # instead of a flat plane through the vertex.
+            if projection == "XZ":
+                x_local = be.array([x_min, x_max])
+                y_local = be.array([0.0, 0.0])
+            else:  # YZ
+                x_local = be.array([0.0, 0.0])
+                y_local = be.array([y_min, y_max])
+            # Apertures with an unbounded extent (e.g. an annular
+            # obstruction defined with r_max = inf) have no well-defined
+            # sag at their outer edge; fall back to the vertex plane there
+            # rather than evaluating sag() out of its domain.
+            finite = be.isfinite(x_local) & be.isfinite(y_local)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                z_local = be.where(finite, surface.geometry.sag(x_local, y_local), 0.0)
             x_global, y_global, z_global = transform(
                 x_local, y_local, z_local, surface, is_global=False
             )

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -211,6 +211,65 @@ class TestStandardGeometry:
         distance = geometry.distance(rays)
         assert_allclose(distance, 10.201933401020467)
 
+    def test_distance_parabola_axial_ray(self, set_test_backend):
+        # Regression test: for a parabolic surface (conic = -1) and an axial
+        # ray (L = M = 0, N = 1), the quadratic's leading coefficient
+        # a = k * N**2 + L**2 + M**2 + N**2 vanishes exactly, since k = -1.
+        # Without a guard for a == 0, this used to produce +/-inf distances.
+        cs = CoordinateSystem()
+        geometry = geometries.StandardGeometry(cs, radius=-100.0, conic=-1.0)
+
+        rays = RealRays(10.0, 0.0, -50.0, 0.0, 0.0, 1.0, 1.0, 0.55)
+        distance = geometry.distance(rays)
+        assert_allclose(distance, 49.5)
+
+        z_intersect = -50.0 + float(be.to_numpy(distance).item())
+        assert_allclose(z_intersect, geometry.sag(10.0, 0.0))
+
+    def test_distance_parabola_near_degenerate_a(self, set_test_backend):
+        # Regression test: for near-axial rays (tiny L, M) on a parabolic
+        # surface (conic = -1), the quadratic's leading coefficient
+        # a = k*N**2 + L**2 + M**2 + N**2 is only *exactly* zero when M and L
+        # are exactly zero. In a real multi-surface system, accumulated
+        # floating-point error leaves M as a tiny nonzero residual (e.g.
+        # ~1e-6), so a becomes a tiny nonzero float rather than exactly 0.
+        # The naive quadratic formula (-b +/- sqrt(d)) / (2a) then suffers
+        # catastrophic cancellation in the numerator amplified by dividing
+        # by a near-zero a, producing non-smooth/incorrect intersection
+        # points even though the a == 0 guard never triggers.
+        cs = CoordinateSystem()
+        geometry = geometries.StandardGeometry(cs, radius=-250.0, conic=-1.0)
+
+        y0, z0 = -33.49, -110.0
+        M_values = [-4e-6, -2e-6, -5e-7, 0.0, 5e-7, 2e-6, 4e-6]
+        N_values = [np.sqrt(1 - m**2) for m in M_values]
+
+        rays = RealRays(
+            [0.0] * len(M_values),
+            [y0] * len(M_values),
+            [z0] * len(M_values),
+            [0.0] * len(M_values),
+            M_values,
+            N_values,
+            [1.0] * len(M_values),
+            [0.55] * len(M_values),
+        )
+        t = geometry.distance(rays)
+
+        M_arr = be.array(M_values)
+        N_arr = be.array(N_values)
+        y_hit = y0 + M_arr * t
+        z_hit = z0 + N_arr * t
+
+        # every intersection must lie exactly on the parabola: y**2 = 2*R*z
+        assert_allclose(y_hit**2, 2 * geometry.radius * z_hit)
+
+        # the sag must vary smoothly (monotonically) as M sweeps through
+        # zero, not jump around due to amplified cancellation error
+        z_np = be.to_numpy(z_hit)
+        diffs = np.diff(z_np)
+        assert np.all(diffs > 0) or np.all(diffs < 0)
+
     def test_surface_normal(self, set_test_backend):
         cs = CoordinateSystem()
         geometry = geometries.StandardGeometry(cs, radius=10.0, conic=0.5)

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -347,7 +347,7 @@ class TestRayOperand:
         }
         assert_allclose(
             operand.RayOperand.OPD_difference(**data),
-             0.001328702368213,
+            0.001329917133127,
         )
 
     def test_opd_diff_new_dist(self, set_test_backend, hubble):

--- a/tests/visualization/system/test_surface2d_offset_aperture.py
+++ b/tests/visualization/system/test_surface2d_offset_aperture.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import optiland.backend as be
+from optiland import physical_apertures
+from optiland.optic import Optic
+from optiland.visualization.system.optic_viewer import OpticViewer
+from optiland.visualization.system.system import OpticalSystem
+
+
+def _build_optic_with_offset_aperture() -> Optic:
+    """A single parabolic mirror with an aperture offset far from its vertex.
+
+    Regression setup for the bug where an off-axis parabolic mirror
+    (e.g. an off-axis paraboloid, OAP) with an OffsetRadialAperture was not
+    rendered at all in the 2D system plot, because the plotted sag line was
+    sampled over a symmetric window sized from the *un-signed* aperture
+    extent, which for a large offset collapses to a window that misses the
+    aperture entirely.
+    """
+    offset_y = -33.49
+    r_max = 15.0
+
+    optic = Optic()
+    optic.surfaces.add(index=0, radius=be.inf, z=-be.inf)
+    aperture = physical_apertures.OffsetRadialAperture(
+        r_max=r_max, r_min=0, offset_y=offset_y
+    )
+    optic.surfaces.add(
+        index=1,
+        radius=-250.0,
+        z=0.0,
+        conic=-1.0,
+        rx=-np.pi / 2 + np.deg2rad(15),
+        aperture=aperture,
+        material="mirror",
+        is_stop=True,
+    )
+    optic.surfaces.add(index=2, z=-100.0)
+    optic.set_aperture(aperture_type="EPD", value=20)
+    optic.fields.set_type(field_type="angle")
+    optic.fields.add(y=0)
+    optic.wavelengths.add(value=0.55, is_primary=True)
+    return optic
+
+
+def test_offset_aperture_surface_extent_covers_offset_region(set_test_backend):
+    optic = _build_optic_with_offset_aperture()
+    aperture = optic.surfaces[1].aperture
+
+    from optiland.visualization.system.surface import Surface2D
+
+    surf2d = Surface2D(optic.surfaces[1], ray_extent=1.0)
+
+    # The plotting extent must be large enough to cover the full offset
+    # aperture bounds, not just the aperture radius.
+    x_min, x_max, y_min, y_max = aperture.extent
+    assert surf2d.extent >= max(abs(x_min), abs(x_max), abs(y_min), abs(y_max))
+
+
+def test_offset_aperture_surface_is_plotted(set_test_backend):
+    """The mirror surface line must not be entirely NaN'd out by clipping."""
+    optic = _build_optic_with_offset_aperture()
+
+    viewer = OpticViewer(optic)
+    fig, ax, _ = viewer.view(fields=[(0, 0)], num_rays=3, projection="YZ")
+
+    surface_lines = [
+        line
+        for line in ax.get_lines()
+        if line.get_label().startswith("Surface")
+    ]
+    assert surface_lines, "no surface lines were plotted"
+
+    mirror_line = surface_lines[1]  # index 0 = object surface, index 1 = mirror
+    y_data = mirror_line.get_ydata()
+    assert np.any(~np.isnan(y_data)), (
+        "offset-aperture mirror surface was not rendered anywhere"
+    )
+    plt.close(fig)
+
+
+def test_aperture_indicator_follows_surface_sag(set_test_backend):
+    """The aperture-edge indicator line must track the tilted surface's sag.
+
+    Regression test: OpticalSystem._plot_apertures used to build the
+    indicator line assuming the aperture rim sits at local z = 0 (the
+    surface vertex plane), rather than at the surface's actual sag. For a
+    steeply curved, strongly tilted surface (e.g. an off-axis parabola) that
+    mismatch, rotated by the tilt, produced an indicator line offset from
+    the mirror by several mm instead of tracing its edge.
+    """
+    optic = _build_optic_with_offset_aperture()
+    surface = optic.surfaces[1]
+    aperture = surface.aperture
+
+    class DummyRays:
+        def __init__(self, optic):
+            self.r_extent = [15] * optic.surfaces.num_surfaces
+
+    optical_system = OpticalSystem(optic, DummyRays(optic), projection="2d")
+
+    fig, ax = plt.subplots()
+    optical_system._plot_apertures(ax, projection="YZ")
+
+    # There should be exactly one aperture-edge line (plus the two arrow
+    # annotations, which are not Line2D artists).
+    lines = ax.get_lines()
+    assert len(lines) == 1
+    z_data, y_data = lines[0].get_data()
+
+    _, _, y_min, y_max = aperture.extent
+    expected_sag = [
+        be.to_numpy(surface.geometry.sag(0.0, y_min)).item(),
+        be.to_numpy(surface.geometry.sag(0.0, y_max)).item(),
+    ]
+
+    # Recompute the expected global (z, y) of the two aperture-rim points
+    # using the true sag, and compare against what was actually plotted.
+    from optiland.visualization.system.utils import transform
+
+    x_local = be.array([0.0, 0.0])
+    y_local = be.array([y_min, y_max])
+    z_local = be.array(expected_sag)
+    _, y_expected, z_expected = transform(
+        x_local, y_local, z_local, surface, is_global=False
+    )
+
+    np.testing.assert_allclose(sorted(z_data), sorted(be.to_numpy(z_expected)))
+    np.testing.assert_allclose(sorted(y_data), sorted(be.to_numpy(y_expected)))
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes the "ray reflects before/behind the mirror" issue reported for off-axis parabolic mirrors (conic = -1) - the previous fix for the exact a == 0 degenerate case only worked in synthetic examples; in a real multi-surface system, floating-point noise leaves the quadratic solver's leading coefficient a as a tiny nonzero value, so the guard never triggered and (-b ± √d)/(2a) suffered catastrophic cancellation amplified by dividing by that near-zero a. Replaced it with the numerically stable (Numerical Recipes) quadratic form, which degrades continuously to the correct linear solution as a → 0 without a separate branch.

**Before fix:** (no mirror plotted, aperture-edge plotted incorrectly):
<img width="1356" height="646" alt="image" src="https://github.com/user-attachments/assets/f3d3241e-9228-45da-93d4-60f5d91dca80" />


**After fix:** (rays intersect mirror correctly, aperture-edge in correct location):
<img width="1576" height="786" alt="image" src="https://github.com/user-attachments/assets/ac29c937-5dbe-4974-96ee-5fdb2a0c275b" />

While chasing this with the reporter's full system, two related 2D-plot bugs also turned up and are fixed here:
- Surface2D's sag-curve sampling window used the raw (non-absolute) aperture bounds, so surfaces using an offset aperture (e.g. OffsetRadialAperture) had a sampling window that missed the offset region entirely - the mirror simply didn't render.
- The aperture-edge indicator line assumed the rim sits in the flat vertex plane (z_local = 0) instead of the true sag, causing multi-mm misalignment between the indicator and the mirror on steeply curved, heavily tilted surfaces.

Test plan
- [x] Added test_distance_parabola_axial_ray and test_distance_parabola_near_degenerate_a in tests/test_geometries.py, pinning the axial and near-degenerate-a cases (verified both fail against the pre-fix code)
- [x] Added tests/visualization/system/test_surface2d_offset_aperture.py covering the sampling-window and aperture-indicator-alignment fixes (verified both fail against the pre-fix code)
- [x] Full tests/test_geometries.py, tests/test_standard_surface.py, tests/visualization/ suites pass on both numpy and torch backends
- [x] Visually re-plotted the reporter's full system (50-ray fan) and confirmed the mirror at surface 14 no longer shows rays reflecting before/behind the surface, and aperture indicators at surfaces 12/14 now align with the mirrors

Fixes #559 