### PR TITLE
Fix curvature solve on plane surfaces

### DIFF
--- a/optiland/solves/curvature.py
+++ b/optiland/solves/curvature.py
@@ -43,6 +43,11 @@ class CurvatureSolve(BaseSolve, ABC):
         """Applies the curvature solve to the optic."""
         pass  # pragma: no cover
 
+    def _set_curvature(self, c):
+        """Set surface curvature through the optic updater."""
+        radius = 1.0 / c if c != 0 else float("inf")
+        self.optic.updater.set_radius(radius, self.surface_idx)
+
     def to_dict(self):
         """Returns a dictionary representation of the solve."""
         solve_dict = super().to_dict()
@@ -134,14 +139,7 @@ class MarginalRayAngleCurvatureSolve(CurvatureSolve):
         den = y_surf * delta_n
         c = (num / den).item()
 
-        # Update curvature
-        if hasattr(self.optic.surfaces[self.surface_idx].geometry, "c"):
-            self.optic.surfaces[self.surface_idx].geometry.c = c
-        elif hasattr(self.optic.surfaces[self.surface_idx].geometry, "radius"):
-            if c != 0:
-                self.optic.surfaces[self.surface_idx].geometry.radius = 1.0 / c
-            else:
-                self.optic.surfaces[self.surface_idx].geometry.radius = float("inf")
+        self._set_curvature(c)
 
     def to_dict(self):
         """Returns a dictionary representation of the solve."""
@@ -244,12 +242,7 @@ class ChiefRayAngleCurvatureSolve(CurvatureSolve):
             damping = 0.5
             c = (1 - damping) * c_current + damping * c_target
 
-            # Update curvature
-            if hasattr(self.optic.surfaces[self.surface_idx].geometry, "radius"):
-                if c != 0:
-                    self.optic.surfaces[self.surface_idx].geometry.radius = 1.0 / c
-                else:
-                    self.optic.surfaces[self.surface_idx].geometry.radius = float("inf")
+            self._set_curvature(c)
 
     def to_dict(self):
         """Returns a dictionary representation of the solve."""

--- a/tests/test_solves.py
+++ b/tests/test_solves.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import optiland.backend as be
+from optiland.optic import Optic
 from optiland.samples.objectives import CookeTriplet
 from optiland.solves import (
     BaseSolve,
@@ -169,6 +170,28 @@ class TestMarginalRayAngleCurvatureSolve:
 
         if surface_idx < len(u_new):
             assert_allclose(u_new[surface_idx], target_angle, atol=1e-4)
+
+    def test_apply_converts_plane_surface(self, set_test_backend):
+        lens = Optic()
+        lens.surfaces.add(index=0, thickness=np.inf)
+        lens.surfaces.add(
+            index=1, thickness=7, radius=20.0, is_stop=True, material="N-SF11"
+        )
+        lens.surfaces.add(index=2, thickness=23.0, radius=np.inf)
+        lens.surfaces.add(index=3)
+        lens.set_aperture(aperture_type="EPD", value=20)
+        lens.fields.set_type(field_type="angle")
+        lens.fields.add(y=0)
+        lens.wavelengths.add(value=0.55, is_primary=True)
+
+        lens.solves.add("marginal_ray_angle", surface_idx=2, angle=-0.1)
+
+        surface = lens.surfaces[2]
+        assert surface.geometry.__class__.__name__ == "StandardGeometry"
+        assert be.isfinite(be.array(surface.geometry.radius))
+
+        _, u = lens.paraxial.marginal_ray()
+        assert_allclose(u[2], -0.1, atol=1e-4)
 
 
 class TestChiefRayAngleCurvatureSolve:


### PR DESCRIPTION
Fixes #659.

Curvature solves now set radius through the optic updater, so planar surfaces become standard surfaces when a finite curvature is solved.

Tested:
- python -m py_compile optiland/solves/curvature.py tests/test_solves.py