### PR TITLE
Fix annular lens polygon rendering

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -40,6 +40,9 @@ We sincerely appreciate the contributions of the following individuals, whose ef
 - **Doron Behar** (`GitHub <https://github.com/doronbehar>`_)
 - **Ayachi Padmanabh Mishra** (`GitHub <https://github.com/AyachiMishra>`_)
 - **somnus-J-307** (`GitHub <https://github.com/somnus-J-307>`_)
+- **Nikita Vladimirov** (`GitHub <https://github.com/nvladimus>`_)
+- **Michele Castriotta** (`GitHub <https://github.com/mikics>`_)
+- **Abu Hossain Foysal** (`GitHub <https://github.com/ahfoysal>`_)
 
 
 Your contributions, whether in the form of code, documentation, feedback, or discussions, are what make **Optiland** better for everyone.

--- a/optiland/visualization/system/lens.py
+++ b/optiland/visualization/system/lens.py
@@ -177,15 +177,39 @@ class Lens2D:
         else:
             vertices = be.to_numpy(be.column_stack((z, y)))
 
-        polygon = Polygon(
-            vertices,
-            closed=True,
-            facecolor=facecolor,
-            edgecolor=edgecolor,
-            label="Lens",
-        )
-        ax.add_patch(polygon)
-        return polygon
+        polygons = []
+        for segment in self._finite_vertex_segments(vertices):
+            polygon = Polygon(
+                segment,
+                closed=True,
+                facecolor=facecolor,
+                edgecolor=edgecolor,
+                label="Lens",
+            )
+            ax.add_patch(polygon)
+            polygons.append(polygon)
+        return polygons
+
+    def _finite_vertex_segments(self, vertices):
+        """Split closed polygon vertices into finite contiguous segments."""
+        finite = np.isfinite(vertices).all(axis=1)
+        if finite.all():
+            return [vertices]
+
+        finite_indices = np.flatnonzero(finite)
+        if finite_indices.size == 0:
+            return []
+
+        breaks = np.where(np.diff(finite_indices) > 1)[0] + 1
+        segments = np.split(finite_indices, breaks)
+
+        # The polygon is closed, so finite runs at the start and end are
+        # contiguous across the closing edge and should form one patch.
+        if finite[0] and finite[-1] and len(segments) > 1:
+            segments[0] = np.concatenate([segments[-1], segments[0]])
+            segments = segments[:-1]
+
+        return [vertices[segment] for segment in segments if len(segment) > 2]
 
     def _plot_lenses(self, ax, sags, theme=None, projection="YZ"):
         """Plot the lenses on the given matplotlib axis.
@@ -211,10 +235,15 @@ class Lens2D:
             y = be.concatenate([y1, be.flip(y2)])
             z = be.concatenate([z1, be.flip(z2)])
 
-            artist = self._plot_single_lens(
+            artists_for_lens = self._plot_single_lens(
                 ax, x, y, z, theme=theme, projection=projection
             )
-            artists[artist] = self
+            if artists_for_lens is None:
+                continue
+            if not isinstance(artists_for_lens, list):
+                artists_for_lens = [artists_for_lens]
+            for artist in artists_for_lens:
+                artists[artist] = self
         return artists
 
 

--- a/tests/visualization/system/test_lens2d_annular_aperture.py
+++ b/tests/visualization/system/test_lens2d_annular_aperture.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+# ruff: noqa: E402, I001
+
+import sys
+from unittest.mock import MagicMock
+
+import matplotlib
+import numpy as np
+from matplotlib.patches import Polygon
+
+matplotlib.use("Agg")
+
+sys.modules.setdefault("vtk", MagicMock())
+
+import matplotlib.pyplot as plt
+from optiland import optic
+from optiland.materials import IdealMaterial
+from optiland.physical_apertures import RadialAperture
+
+
+def _build_annular_lens(*, single_lens_group: bool = False) -> optic.Optic:
+    lens = optic.Optic()
+
+    lens.surfaces.add(index=0, radius=np.inf, thickness=5)
+    lens.surfaces.add(
+        index=1,
+        radius=7.72,
+        thickness=0.55,
+        material=IdealMaterial(n=1.369),
+        aperture=RadialAperture(r_max=5.5),
+        is_stop=True,
+    )
+    lens.surfaces.add(
+        index=2,
+        radius=6.5,
+        thickness=0.25,
+        material=IdealMaterial(n=1.332 if single_lens_group else 1.0),
+        aperture=RadialAperture(r_max=5.5),
+    )
+    lens.surfaces.add(
+        index=3,
+        radius=11.5,
+        thickness=0.01,
+        material=IdealMaterial(n=1.38),
+        aperture=RadialAperture(r_max=11.0, r_min=5.0),
+    )
+    lens.surfaces.add(
+        index=4,
+        radius=11.5,
+        thickness=10,
+        material=IdealMaterial(n=1.332 if single_lens_group else 1.0),
+        aperture=RadialAperture(r_max=11.0, r_min=5.0),
+    )
+    lens.surfaces.add(index=5)
+
+    lens.set_aperture(aperture_type="EPD", value=3.0)
+    lens.fields.set_type("angle")
+    lens.fields.add(y=0)
+    lens.wavelengths.add(value=0.55, is_primary=True)
+    return lens
+
+
+def test_annular_lens_polygons_do_not_include_nan_vertices(set_test_backend):
+    lens = _build_annular_lens()
+
+    fig, ax = lens.draw()
+    lens_patches = [patch for patch in ax.patches if isinstance(patch, Polygon)]
+
+    assert len(lens_patches) >= 3
+    for patch in lens_patches:
+        assert np.isfinite(patch.get_xy()).all()
+    plt.close(fig)
+
+
+def test_annular_gap_is_split_into_separate_lens_patches(set_test_backend):
+    lens = _build_annular_lens(single_lens_group=True)
+
+    fig, ax = lens.draw()
+    lens_patches = [patch for patch in ax.patches if isinstance(patch, Polygon)]
+
+    assert len(lens_patches) > 3
+    for patch in lens_patches:
+        assert np.isfinite(patch.get_xy()).all()
+    plt.close(fig)


### PR DESCRIPTION
Fixes #538.

This splits 2D lens fill polygons around non-finite vertices so annular apertures render as separate clean patches instead of passing NaNs into Matplotlib polygons.

Tests:
- `pytest tests/visualization/system/test_lens2d_annular_aperture.py`
- `pytest tests/visualization/system/test_optic_viewer_projection.py`
- `ruff check optiland/visualization/system/lens.py tests/visualization/system/test_lens2d_annular_aperture.py`
- `ruff format --check optiland/visualization/system/lens.py tests/visualization/system/test_lens2d_annular_aperture.py`
- `uv build`
