### PR TITLE
Fix weighted merit/residual consistency in optimization

### DIFF
--- a/optiland/optimization/batched_evaluator.py
+++ b/optiland/optimization/batched_evaluator.py
@@ -493,7 +493,7 @@ class BatchedRayEvaluator:
                     f"Operand {i} ({operand.operand_type}) was not evaluated"
                 )
             delta = self._compute_delta(operand, value)
-            terms.append(ew * delta**2)
+            terms.append((ew * delta) ** 2)
         return terms
 
     # ------------------------------------------------------------------
@@ -595,7 +595,10 @@ class BatchedRayEvaluator:
                     [self.problem.operands[i].target for i in matching_op_indices]
                 )
                 weights = be.array(
-                    [self.problem.operands[i].weight for i in matching_op_indices]
+                    [
+                        self.problem.operands[i].effective_weight()
+                        for i in matching_op_indices
+                    ]
                 )
 
                 # Compute all deltas for this group simultaneously
@@ -616,7 +619,11 @@ class BatchedRayEvaluator:
                     operand.operand_type, sg, operand.input_data, local_idx
                 )
                 delta = self._compute_delta(operand, val)
-                computed_residuals[global_op_idx] = operand.weight * delta
+                ew = operand.effective_weight()
+                if ew == 0.0:
+                    computed_residuals[global_op_idx] = be.array(0.0)
+                else:
+                    computed_residuals[global_op_idx] = ew * delta
 
         # --- 2. Process Distribution Jobs ---
         for job_idx, job in enumerate(self._distribution_jobs):
@@ -632,7 +639,11 @@ class BatchedRayEvaluator:
                         val = metric_fn(**operand.input_data)
 
                     delta = self._compute_delta(operand, val)
-                    computed_residuals[i] = operand.weight * delta
+                    ew = operand.effective_weight()
+                    if ew == 0.0:
+                        computed_residuals[i] = be.array(0.0)
+                    else:
+                        computed_residuals[i] = ew * delta
 
         # --- 3. Process Direct Jobs ---
         for i in range(num_operands):
@@ -641,11 +652,15 @@ class BatchedRayEvaluator:
             plan_type, _, _ = self._operand_plan[i]
             if plan_type == "direct":
                 operand = self.problem.operands[i]
+                ew = operand.effective_weight()
+                if ew == 0.0:
+                    computed_residuals[i] = be.array(0.0)
+                    continue
                 metric_fn = operand_registry.get(operand.operand_type)
                 val = metric_fn(**operand.input_data)
 
                 delta = self._compute_delta(operand, val)
-                computed_residuals[i] = operand.weight * delta
+                computed_residuals[i] = ew * delta
 
         # --- Final Graph Assembly ---
         for i, res in enumerate(computed_residuals):

--- a/optiland/optimization/problem.py
+++ b/optiland/optimization/problem.py
@@ -143,7 +143,7 @@ class OptimizationProblem:
 
         Each term is computed as::
 
-            effective_weight(op) * op.delta() ** 2
+            (effective_weight(op) * op.delta()) ** 2
 
         where ``effective_weight = operand.weight * field_weight * wl_weight``.
         Field and wavelength weights are read from the optic stored in each
@@ -166,7 +166,7 @@ class OptimizationProblem:
             ew = op.effective_weight()
             if ew == 0.0:
                 continue
-            terms.append(ew * op.delta() ** 2)
+            terms.append((ew * op.delta()) ** 2)
         if not terms:
             return be.array([0.0])
         return be.stack(terms)
@@ -191,7 +191,13 @@ class OptimizationProblem:
         """
         if self._batched_evaluator is not None:
             return self._batched_evaluator.residual_vector()
-        terms = [op.fun() for op in self.operands]
+        terms = []
+        for op in self.operands:
+            ew = op.effective_weight()
+            if ew == 0.0:
+                terms.append(be.array(0.0))
+            else:
+                terms.append(ew * op.delta())
         if not terms:
             return be.array([])
         return be.stack(terms)
@@ -245,14 +251,14 @@ class OptimizationProblem:
 
         df = pd.DataFrame(data)
 
-        # Contribution uses effective_weight × delta² per operand
+        # Contribution uses (effective_weight × delta)² per operand.
         ew_list = [op.effective_weight() for op in self.operands]
         contrib_values = []
         for op, ew in zip(self.operands, ew_list, strict=False):
             if ew == 0.0:
                 contrib_values.append(be.array(0.0))
             else:
-                contrib_values.append(be.array(ew) * op.delta() ** 2)
+                contrib_values.append((be.array(ew) * op.delta()) ** 2)
 
         total = sum(self._to_item(v) for v in contrib_values)
 
@@ -311,7 +317,7 @@ class OptimizationProblem:
         field weight (looked up from the optic via the operand's ``input_data``),
         and the wavelength weight.  The formula used in the merit function is::
 
-            effective_weight × delta ** 2
+            (effective_weight × delta) ** 2
 
         Each returned dict contains:
 

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -557,7 +557,7 @@ class TestWeightBreakdown:
 
 
 class TestPolychromaticWeightedAverageFormula:
-    """Verifies the weighted average helper can be used for polychromatic aggregation."""
+    """Verifies weighted averages for polychromatic aggregation."""
 
     def test_weighted_psf_average_formula(self):
         # Simulate two PSF "scalars" representing peak values at two wavelengths
@@ -586,7 +586,7 @@ class TestPolychromaticWeightedAverageFormula:
 
 class TestBackwardCompatibility:
     def test_resolve_fields_all_weight_one_for_default_optic(self):
-        """Default optic has all field weights=1.0 — resolve_fields should reflect this."""
+        """Default optic field weights are all 1.0."""
         lens = CookeTriplet()
         fps = resolve_fields(lens, "all")
         assert all(fp.weight == pytest.approx(1.0) for fp in fps)
@@ -609,20 +609,36 @@ class TestBackwardCompatibility:
         ew = op.effective_weight()
         assert ew == pytest.approx(3.7)
 
-    def test_fun_array_unchanged_behavior_with_default_weights(self):
-        """fun_array with all-1.0 weights: ew * delta^2 == weight * delta^2 == fun()^2."""
+    def test_fun_array_matches_squared_residual_with_operand_weight(self):
+        """sum_squared must match the least-squares residual objective."""
         lens = CookeTriplet()
         problem = OptimizationProblem()
+        weight = 3.7
         problem.add_operand(
             operand_type="f2",
             target=100.0,
-            weight=1.0,
+            weight=weight,
             input_data={"optic": lens},
         )
-        # With all weights=1.0, effective_weight=1.0, so:
-        # fun_array()[0] == 1.0 * delta^2 == delta^2
+
         op = problem.operands[0]
         delta = float(be.to_numpy(be.array(op.delta())))
-        values = problem.fun_array()
-        computed = float(be.to_numpy(values[0]))
-        assert computed == pytest.approx(delta**2)
+        contribution = float(be.to_numpy(problem.fun_array()[0]))
+        residual = float(be.to_numpy(problem.residual_vector()[0]))
+
+        assert contribution == pytest.approx((weight * delta) ** 2)
+        assert residual == pytest.approx(weight * delta)
+        assert float(be.to_numpy(problem.sum_squared())) == pytest.approx(
+            float(be.to_numpy(be.sum(problem.residual_vector() ** 2))),
+        )
+
+    def test_fun_array_matches_squared_residual_with_field_wavelength_weights(self):
+        """Field/wavelength weights should affect merit and residuals consistently."""
+        optic = _make_weighted_optic()
+        problem = OptimizationProblem()
+        problem.add_operand(
+            operand_type="f2",
+            target=80.0,
+            weight=1.5,
+            input_data={"optic": optic, "field": 0, "wavelength": 1},
+        )


### PR DESCRIPTION
## Summary
- Align `OptimizationProblem.sum_squared()`/`fun_array()` with `residual_vector()` so weighted merit values use the same objective as least-squares residuals.
- Update the batched evaluator to apply `effective_weight()` consistently for contribution terms and residuals.
- Add regression coverage for operand weights and field/wavelength effective weights so the two merit paths stay equivalent.

## Root cause
Issue #601 exposed that the optimization case study could stop with the final air gaps almost unchanged. While reproducing it, I found that the generic merit path and least-squares residual path used different weight semantics after field/wavelength weighting support was added: `sum_squared()` used `weight * delta**2`, while `residual_vector()` represented `weight * delta`, whose squared objective is `(weight * delta)**2`.

That made `OptimizerGeneric` optimize a different relative objective from `LeastSquares`, especially for operands with `weight=10` such as the RMS spot size operands in the case study.

## Notes
With this change, the final air thickness optimization in the #601 reproducer no longer stays near 5 mm; in my local run it moved the two gaps from 5 mm to about 2.486 mm and 1.0 mm. This does not fully reproduce the older notebook output values, so I am opening this as a draft for feedback on whether this consistency fix is the right scope before continuing with any tutorial-output alignment work.

Fixes #601.

## Validation
- `python -m pytest tests/optimization tests/test_optimization.py tests/test_weights.py -q`
- `python -m ruff check optiland/optimization/problem.py optiland/optimization/batched_evaluator.py tests/test_weights.py`
- `python -m ruff format --check optiland/optimization/problem.py optiland/optimization/batched_evaluator.py tests/test_weights.py`
- `git diff --check`
