### PR TITLE
Fix Zernike surface normal at center

### DIFF
--- a/optiland/geometries/zernike.py
+++ b/optiland/geometries/zernike.py
@@ -281,9 +281,26 @@ class ZernikePolynomialGeometry(NewtonRaphsonGeometry):
             dZdrho, dZdphi = self.zernike.get_derivative(n, m, rho, phi)
             norm_constant = self.zernike._norm_constant(n, m)
 
-            # Partial derivatives w.r.t. x and y
-            dzdx = dzdx + norm_constant * c * (dZdrho * drho_dx + dZdphi * dphi_dx)
-            dzdy = dzdy + norm_constant * c * (dZdrho * drho_dy + dZdphi * dphi_dy)
+            derivative_x = dZdrho * drho_dx + dZdphi * dphi_dx
+            derivative_y = dZdrho * drho_dy + dZdphi * dphi_dy
+
+            if abs(m) == 1:
+                center_slope = (
+                    self.zernike._radial_derivative(
+                        n,
+                        m,
+                        be.zeros_like(rho),
+                    )
+                    / self.norm_radius
+                )
+
+                if m > 0:
+                    derivative_x = be.where(center, center_slope, derivative_x)
+                else:
+                    derivative_y = be.where(center, center_slope, derivative_y)
+
+            dzdx = dzdx + norm_constant * c * derivative_x
+            dzdy = dzdy + norm_constant * c * derivative_y
 
         # Surface normal vector in cartesian coords: (-dzdx, -dzdy, 1)
         # normalized. Check sign conventions!

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -1317,6 +1317,48 @@ class TestZernikeGeometry:
         assert new_geometry.zernike_type == geometry.zernike_type
         assert new_geometry.norm_radius == geometry.norm_radius
 
+    @pytest.mark.parametrize(
+        "coefficients",
+        [
+            [0.0, 0.5, 0.0],
+            [0.0, 0.0, 0.5],
+        ],
+    )
+    def test_surface_normal_at_center(self, set_test_backend, coefficients):
+        geometry = self.create_geometry(
+            coefficients=coefficients,
+            norm_radius=2.0,
+            zernike_type="standard",
+            radius=be.inf,
+        )
+
+        h = 1e-6
+        dzdx = (geometry.sag(h, 0.0) - geometry.sag(-h, 0.0)) / (2 * h)
+        dzdy = (geometry.sag(0.0, h) - geometry.sag(0.0, -h)) / (2 * h)
+
+        norm = be.sqrt(dzdx**2 + dzdy**2 + 1)
+        expected = (dzdx / norm, dzdy / norm, -1 / norm)
+
+        actual = geometry._surface_normal(be.array(0.0), be.array(0.0))
+
+        assert_allclose(actual, expected, atol=1e-8)
+
+    @pytest.mark.parametrize("set_test_backend", ["torch"], indirect=True)
+    def test_surface_normal_at_center_autograd(self, set_test_backend):
+        geometry = self.create_geometry(
+            coefficients=[0.0, 0.0, 0.5],
+            norm_radius=2.0,
+            zernike_type="standard",
+            radius=be.inf,
+        )
+        geometry.coefficients.requires_grad_(True)
+
+        nx, _, _ = geometry._surface_normal(be.array(0.0), be.array(0.0))
+        nx.backward()
+
+        assert geometry.coefficients.grad is not None
+        assert be.all(be.isfinite(geometry.coefficients.grad))
+
 
 # --- Fixtures for Toroidal Tests ---
 @pytest.fixture


### PR DESCRIPTION
Depends on #663.

## Summary

- Handle the finite Cartesian derivative at the center for Zernike terms with `|m| = 1`.
- Preserve the autograd-safe center masking.
- Add finite-difference tests for both tilt directions with NumPy and Torch.
- Add a Torch backward regression test.

## Rationale

At `rho = 0`, polar-coordinate derivatives are singular. The existing masking prevents divisions by zero and NaNs, but also forces all derivatives to zero at the center.

Terms with `|m| = 1` have a finite, nonzero Cartesian derivative at the origin. This change applies that limit explicitly.

The temporary `rho2 = 1` value remains only as a safe placeholder for expressions evaluated inside `where`; the actual center coordinate remains zero.

## Tests

```text
pytest tests/test_geometries.py::TestZernikeGeometry -v