### PR TITLE
Expose FFTPSF options in image simulation

### DIFF
--- a/optiland/analysis/image_simulation/engine.py
+++ b/optiland/analysis/image_simulation/engine.py
@@ -27,6 +27,8 @@ class ImageSimulationEngine:
             - n_components (int): Number of EigenPSFs.
             - oversample (int): Upsampling factor for simulation accuracy.
             - padding (int): Pixel padding (guard band) to avoid edge artifacts.
+            - psf_strategy (str): Wavefront reference strategy.
+            - psf_remove_tilt (bool): Whether to remove wavefront tilt.
             - distortion_reference (ReferencePointStrategy): Strategy used to
               locate per-field image reference points for the distortion warp.
               Defaults to None (chief-ray intercept). Supply a
@@ -47,6 +49,8 @@ class ImageSimulationEngine:
             "n_components": 3,
             "oversample": 1,
             "padding": 64,
+            "psf_strategy": "chief_ray",
+            "psf_remove_tilt": False,
             "distortion_reference": None,
         }
         if config:
@@ -128,6 +132,8 @@ class ImageSimulationEngine:
                 grid_shape=self.config["psf_grid_shape"],
                 num_rays=self.config["num_rays"],
                 psf_grid_size=self.config["psf_size"],
+                strategy=self.config["psf_strategy"],
+                remove_tilt=self.config["psf_remove_tilt"],
             )
             eigen_psfs, coeffs, mean_psf = gen.generate_basis(
                 n_components=self.config["n_components"]

--- a/optiland/analysis/image_simulation/psf_basis_generator.py
+++ b/optiland/analysis/image_simulation/psf_basis_generator.py
@@ -24,16 +24,29 @@ class PSFBasisGenerator:
         psf_grid_size (int, optional): PSF grid size (e.g., 256 for 256x256).
 
             If None, calculated from num_rays.
+        strategy (str, optional): Wavefront reference strategy.
+            Default: "chief_ray".
+        remove_tilt (bool, optional): Whether to remove wavefront tilt.
+            Default: False.
     """
 
     def __init__(
-        self, optic, wavelength, grid_shape=(5, 5), num_rays=128, psf_grid_size=None
+        self,
+        optic,
+        wavelength,
+        grid_shape=(5, 5),
+        num_rays=128,
+        psf_grid_size=None,
+        strategy="chief_ray",
+        remove_tilt=False,
     ):
         self.optic = optic
         self.wavelength = wavelength
         self.grid_shape = grid_shape
         self.num_rays = num_rays
         self.psf_grid_size = psf_grid_size
+        self.strategy = strategy
+        self.remove_tilt = remove_tilt
 
     def generate_basis(self, n_components=3):
         """
@@ -118,6 +131,8 @@ class PSFBasisGenerator:
                     wavelength=self.wavelength,
                     num_rays=self.num_rays,
                     grid_size=self.psf_grid_size,
+                    strategy=self.strategy,
+                    remove_tilt=self.remove_tilt,
                 )
 
                 # Normalize sum to 1 to treat as probability distribution


### PR DESCRIPTION
### Summary

This PR exposes the existing FFTPSF `strategy` and `remove_tilt` options through `PSFBasisGenerator` and `ImageSimulationEngine`.

### Changes

- Add `strategy` and `remove_tilt` parameters to `PSFBasisGenerator`.
- Forward both parameters to `FFTPSF`.
- Add `psf_strategy` and `psf_remove_tilt` to `ImageSimulationEngine` configuration.
- Preserve the current defaults:
  - `psf_strategy: "chief_ray"`
  - `psf_remove_tilt: False`

### Motivation

These options are useful for optical systems where the default chief-ray reference is poorly conditioned, such as systems with remote stops or strongly shifted pupils.

The change is backward compatible and does not alter the existing default behavior.

Closes #671