### PR TITLE
Fix OddAsphere coefficients when flipping

### DIFF
--- a/optiland/geometries/odd_asphere.py
+++ b/optiland/geometries/odd_asphere.py
@@ -70,6 +70,11 @@ class OddAsphere(EvenAsphere):
     def __str__(self):
         return "Odd Asphere"
 
+    def flip(self):
+        """Flip the geometry and negate the odd asphere coefficients."""
+        super().flip()
+        self.coefficients = [-coefficient for coefficient in self.coefficients]
+
     def scale(self, scale_factor: float):
         """Scale the geometry parameters.
 

--- a/tests/test_flip_geometries.py
+++ b/tests/test_flip_geometries.py
@@ -120,7 +120,7 @@ def test_flip_even_asphere_geometry():
     assert geom.coefficients == initial_coeffs
 
 
-def test_flip_odd_asphere_geometry():
+def test_flip_odd_asphere_geometry(set_test_backend):
     initial_radius = 75.0
     initial_conic = -1.0
     # Coefficients for OddAsphere are C_i * r^(i+1)
@@ -138,7 +138,7 @@ def test_flip_odd_asphere_geometry():
 
     assert geom.radius == -initial_radius
     assert geom.k == initial_conic
-    assert geom.coefficients == initial_coeffs
+    assert geom.coefficients == [-coefficient for coefficient in initial_coeffs]
 
 
 def test_flip_polynomial_geometry():


### PR DESCRIPTION
## Summary

- Negate `OddAsphere` coefficients when flipping the geometry.
- Add backend-aware regression coverage for the flipped coefficient values.

## Root Cause

`OddAsphere` inherited `NewtonRaphsonGeometry.flip()`, which reverses only the base radius. Its additional sag terms, `C_i * r^i`, therefore remained on the original side of the vertex after a system flip.

## Validation

- `python -m pytest -q tests/test_flip_geometries.py`
- `python -m ruff check optiland/geometries/odd_asphere.py`

Addresses #668.
