### PR TITLE
Fix OrthogonalDescent scaled variable bounds

### DIFF
--- a/optiland/optimization/optimizer/scipy/orthogonal_descent.py
+++ b/optiland/optimization/optimizer/scipy/orthogonal_descent.py
@@ -83,14 +83,11 @@ class OrthogonalDescent(BaseOptimizer):
         # Calculate initial cost
         f_start = self.problem.rss().item()
 
-        # Determine bounds
-        # Use explicit bounds if available, otherwise use wide range to prevent overflow
-        min_v = generic_var.min_val
-        max_v = generic_var.max_val
-
         limit = 1e12  # Soft limit for unbounded variables
-        low = min_v if min_v is not None else -limit
-        high = max_v if max_v is not None else limit
+        # ``value`` and ``bounds`` are both expressed in the variable's scaled space.
+        bounds = generic_var.bounds
+        low = bounds[0] if bounds is not None and bounds[0] is not None else -limit
+        high = bounds[1] if bounds is not None and bounds[1] is not None else limit
 
         def objective_func(x):
             # Enforce bounds manually for 'brent' method

--- a/tests/optimization/test_orthogonal_descent.py
+++ b/tests/optimization/test_orthogonal_descent.py
@@ -36,11 +36,13 @@ def test_orthogonal_descent_simple_quadratic():
     var_x.value = np.array(0.0)  # Initial value
     var_x.min_val = -5.0
     var_x.max_val = 5.0
+    var_x.bounds = (-5.0, 5.0)
 
     var_y = MagicMock()
     var_y.value = np.array(0.0)
     var_y.min_val = -5.0
     var_y.max_val = 5.0
+    var_y.bounds = (-5.0, 5.0)
 
     def update_x(val):
         var_x.value = np.array(val)
@@ -69,6 +71,29 @@ def test_orthogonal_descent_simple_quadratic():
 
     assert np.isclose(final_x, 1.0, atol=1e-4)
     assert np.isclose(final_y, -2.0, atol=1e-4)
+
+
+def test_orthogonal_descent_uses_scaled_variable_bounds():
+    """Search in the same scaled coordinate system used by Variable.update."""
+    problem = MagicMock(spec=OptimizationProblem)
+    variable = MagicMock()
+    variable.value = np.array(-0.5)
+    variable.min_val = 1.0
+    variable.max_val = 10.0
+    variable.bounds = (-0.9, 0.0)
+
+    def update(value):
+        variable.value = np.array(value)
+
+    variable.update.side_effect = update
+    problem.rss.side_effect = lambda: MagicMock(
+        item=lambda: (variable.value.item() + 0.7) ** 2
+    )
+
+    optimizer = OrthogonalDescent(problem)
+    optimizer._optimize_variable(variable)
+
+    assert np.isclose(variable.value.item(), -0.7, atol=1e-4)
 
 
 class SideEffect:


### PR DESCRIPTION
## Summary

- Use each variable's transformed `bounds` when OrthogonalDescent performs its one-dimensional search.
- Add regression coverage for a scaled variable whose raw and optimization-space bounds differ.

## Root Cause

`Variable.value` is expressed in the variable's scaled optimization space, and `Variable.update()` expects values in that same space. OrthogonalDescent instead compared candidates against raw `min_val` and `max_val`. For a thickness variable with physical bounds `[1, 10]` mm, this rejected valid scaled candidates from `[-0.9, 0.0]` as out of bounds.

## Impact

The optimizer now evaluates and constrains candidates in a consistent coordinate system. This is independent of the coordinate-wise local minimum observed in the Cooke triplet case study.

## Validation

- `python -m pytest -q tests/optimization/test_orthogonal_descent.py`
- `python -m ruff check optiland/optimization/optimizer/scipy/orthogonal_descent.py tests/optimization/test_orthogonal_descent.py`
- `python -m ruff format --check optiland/optimization/optimizer/scipy/orthogonal_descent.py tests/optimization/test_orthogonal_descent.py`
- `git diff --check`
