### PR TITLE
docs: update pip install syntax for PEP 735 (fixes #675)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ Thank you for your interest in contributing to **Optiland**! Contributions are w
    uv sync --group dev
    ```
 
-   This installs Optiland in editable mode plus `pytest`, `ruff`, `mypy`, and `vulture`. If you
-   don't use `uv`, `pip install -e ".[dev]"` (or installing the packages listed under
+   This installs Optiland in editable mode plus `pytest`, `mypy`, and `vulture`. If you
+   don't use `uv`, `pip install -e "." --group dev` (or installing the packages listed under
    `[dependency-groups].dev` in `pyproject.toml` manually) works too.
 3. Run the test suite scoped to what you're changing — **never run the full suite blindly**:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -61,10 +61,11 @@ Development Extras
 ------------------
 
 To install Optiland's development dependencies-pytest, codecov, and linting tools-use:
+*(Note: This requires cloning the repository from source)*
 
 .. code-block:: console
 
-   pip install optiland[dev]
+   pip install "." --group dev
 
 GPU‑Enabled PyTorch (Manual Install)
 ------------------------------------
@@ -83,7 +84,7 @@ Installing from Source
 
 To clone and install the latest development version:
 
-1. **Clone the repository**  
+1. **Clone the repository**
 
    .. code-block:: console
 
@@ -95,25 +96,25 @@ To clone and install the latest development version:
 
       cd optiland
 
-3. **Install with optional extras**  
+3. **Install with optional extras**
 
-   - Core only:  
+   - Core only:
 
      .. code-block:: console
 
         pip install .
 
-   - With PyTorch support (CPU‑only):  
+   - With PyTorch support (CPU‑only):
 
      .. code-block:: console
 
         pip install .[torch]
 
-   - With development dependencies:  
+   - With development dependencies:
 
      .. code-block:: console
 
-        pip install .[dev]
+        pip install "." --group dev
 
 
 Verify Your Installation


### PR DESCRIPTION
### Description
This PR updates the developer installation instructions in `installation.rst` and `CONTRIBUTING.md` to properly reflect the PEP 735 `[dependency-groups]` migration from #406. 

Standard `pip` requires the `--group dev` flag to correctly read dependency groups. The mention of `ruff` being installed via `uv` has also been removed.

Fixes #675