### PR TITLE
Fix ray aiming on tilted and back-surface stops (#654)

### DIFF
--- a/optiland/rays/ray_aiming/iterative.py
+++ b/optiland/rays/ray_aiming/iterative.py
@@ -19,6 +19,10 @@ from optiland.rays.ray_aiming.registry import register_aimer
 if TYPE_CHECKING:
     from optiland.optic import Optic
 
+# Maximum number of step halvings in the per-ray backtracking line search
+# used by the Newton/Broyden core (see ``_solve_core``).
+_MAX_BACKTRACK = 8
+
 
 @register_aimer("iterative")
 class IterativeRayAimer(BaseRayAimer):
@@ -196,21 +200,6 @@ class IterativeRayAimer(BaseRayAimer):
         num_rays = len(x)
         full_indices = be.arange_indices(num_rays)
 
-        # Precompute Paraxial Jacobian Factor
-        wl_mean = (
-            be.mean(wavelengths) if hasattr(wavelengths, "__len__") else wavelengths
-        )
-        J_factor = self._get_paraxial_jacobian(float(wl_mean), stop_idx, is_inf)
-        if abs(J_factor) < 1e-12:
-            J_factor = 1e-12
-
-        # Initialize Jacobian Estimate (J)
-        # J = [[j11, j12], [j21, j22]]
-        J11 = be.full(num_rays, J_factor)
-        J12 = be.zeros(num_rays)
-        J21 = be.zeros(num_rays)
-        J22 = be.full(num_rays, J_factor)
-
         # Ensure we are not modifying leaf variables in-place
         x = be.copy(x)
         y = be.copy(y)
@@ -218,6 +207,17 @@ class IterativeRayAimer(BaseRayAimer):
         L = be.copy(L)
         M = be.copy(M)
         N = be.copy(N)
+
+        # Initialize the per-ray 2x2 Jacobian by finite differences. A paraxial
+        # estimate is only a scalar magnitude (equal on both axes, off-diagonal
+        # zero) and cannot represent the sign flip or x-y cross-coupling a
+        # tilted/decentered stop induces -- e.g. a 90 deg fold makes
+        # d(ey)/d(p2) negative, so an assumed-positive diagonal Jacobian steps
+        # the wrong way and Broyden then diverges to NaN (issue #654). Two
+        # extra traces capture the true local response.
+        J11, J12, J21, J22 = self._finite_difference_jacobian(
+            x, y, z, L, M, N, wavelengths, stop_idx, is_inf, lx, ly
+        )
 
         converged = ex**2 + ey**2 < tol_sq
         self.last_iterations = 0
@@ -262,35 +262,76 @@ class IterativeRayAimer(BaseRayAimer):
             dp1 = -(J11_inv * ex_curr + J12_inv * ey_curr) / det
             dp2 = -(J21_inv * ex_curr + J22_inv * ey_curr) / det
 
-            # Update parameters
+            # --- Damped update with per-ray backtracking line search ---
+            # A full Newton/Broyden step can overshoot into a region where a
+            # ray misses a surface (NaN error) or the error simply grows.
+            # Halving the step per ray until the error strictly decreases keeps
+            # a single bad step from poisoning a ray into permanent NaN -- the
+            # divergence/NaN failure mode in issue #654. A ray that cannot
+            # improve holds its last finite state (accepted step 0) and is
+            # reported as non-converged rather than as NaN.
             if is_inf:
-                x[idx] += dp1
-                y[idx] += dp2
+                p1_base = be.copy(x[idx])
+                p2_base = be.copy(y[idx])
             else:
-                L[idx] += dp1
-                M[idx] += dp2
+                p1_base = be.copy(L[idx])
+                p2_base = be.copy(M[idx])
 
-            # Recalculate errors with new parameters
-            rays = self._trace_subset(x, y, z, L, M, N, wavelengths, stop_idx, is_inf)
-            lx, ly = self._get_local_stop_coords(rays, stop_idx)
-            ex_new = lx - tx
-            ey_new = ly - ty
+            old_err_sq = ex_curr**2 + ey_curr**2
+            alpha = be.ones_like(ex_curr)
+            acc_dp1 = be.zeros_like(ex_curr)
+            acc_dp2 = be.zeros_like(ey_curr)
+            acc_ex = be.copy(ex_curr)
+            acc_ey = be.copy(ey_curr)
+            searching = be.ones_like(ex_curr) > 0.0
 
-            # Extract new errors for active set
-            ex_next = ex_new[idx]
-            ey_next = ey_new[idx]
+            for _bt in range(_MAX_BACKTRACK):
+                if is_inf:
+                    x[idx] = p1_base + alpha * dp1
+                    y[idx] = p2_base + alpha * dp2
+                else:
+                    L[idx] = p1_base + alpha * dp1
+                    M[idx] = p2_base + alpha * dp2
 
-            # --- Broyden Update ---
-            # y_k = ex_next - ex_curr
-            # s_k = dp1, dp2
-            dEx = ex_next - ex_curr
-            dEy = ey_next - ey_curr
+                rays = self._trace_subset(
+                    x, y, z, L, M, N, wavelengths, stop_idx, is_inf
+                )
+                lx, ly = self._get_local_stop_coords(rays, stop_idx)
+                ex_try = lx[idx] - tx[idx]
+                ey_try = ly[idx] - ty[idx]
+                new_err_sq = ex_try**2 + ey_try**2
 
-            dx = dp1
-            dy = dp2
+                improved = be.logical_and(
+                    searching,
+                    be.logical_and(
+                        be.logical_not(be.isnan(new_err_sq)),
+                        new_err_sq < old_err_sq,
+                    ),
+                )
+                acc_dp1 = be.where(improved, alpha * dp1, acc_dp1)
+                acc_dp2 = be.where(improved, alpha * dp2, acc_dp2)
+                acc_ex = be.where(improved, ex_try, acc_ex)
+                acc_ey = be.where(improved, ey_try, acc_ey)
+                searching = be.logical_and(searching, be.logical_not(improved))
+                if not be.any(searching):
+                    break
+                alpha = alpha * 0.5
 
-            # Update J
+            # Commit the accepted (possibly zero) step for each active ray.
+            if is_inf:
+                x[idx] = p1_base + acc_dp1
+                y[idx] = p2_base + acc_dp2
+            else:
+                L[idx] = p1_base + acc_dp1
+                M[idx] = p2_base + acc_dp2
+
+            # --- Broyden Update (using the accepted step) ---
             # J += (y - J*s) * s^T / (s^T * s)
+            dEx = acc_ex - ex_curr
+            dEy = acc_ey - ey_curr
+
+            dx = acc_dp1
+            dy = acc_dp2
 
             # Calculate J*s (using OLD J)
             Js_x = J11[idx] * dx + J12[idx] * dy
@@ -314,12 +355,101 @@ class IterativeRayAimer(BaseRayAimer):
             J21[idx] += Ry * dx / norm_sq
             J22[idx] += Ry * dy / norm_sq
 
-            # Update 'ex' and 'ey' arrays for next iter
-            ex = ex_new
-            ey = ey_new
+            # Write the accepted errors back for the next iteration.
+            ex = be.copy(ex)
+            ey = be.copy(ey)
+            ex[idx] = acc_ex
+            ey[idx] = acc_ey
 
         converged = ex**2 + ey**2 < tol_sq
         return x, y, z, L, M, N, converged, had_initial_nan
+
+    def _finite_difference_jacobian(
+        self,
+        x: Any,
+        y: Any,
+        z: Any,
+        L: Any,
+        M: Any,
+        N: Any,
+        wavelengths: Any,
+        stop_idx: int,
+        is_inf: bool,
+        lx: Any,
+        ly: Any,
+        eps: float = 1e-6,
+    ) -> tuple:
+        """Per-ray 2x2 Jacobian ``d(local stop x, y)/d(free dof)`` by finite
+        differences.
+
+        The free degrees of freedom are ``(x, y)`` for infinite conjugates and
+        ``(L, M)`` for finite ones. Unlike the paraxial magnitude estimate,
+        this captures the sign and x-y cross-coupling of tilted or decentered
+        stops, which is required for the Newton step to be a descent direction
+        on such systems (issue #654). Rays whose perturbed trace is degenerate
+        (NaN, or a collapsed determinant) fall back to the paraxial diagonal so
+        the solve still has a usable seed.
+
+        Args:
+            x, y, z, L, M, N: Current ray launch state.
+            wavelengths: Ray wavelengths.
+            stop_idx: Index of the stop surface.
+            is_inf: Whether the object is at infinity.
+            lx, ly: Unperturbed local-stop coordinates of the current state.
+            eps: Finite-difference step size.
+
+        Returns:
+            tuple: ``(J11, J12, J21, J22)`` per-ray Jacobian entries, with
+            ``J = [[d lx/d p1, d lx/d p2], [d ly/d p1, d ly/d p2]]``.
+        """
+        if is_inf:
+            r1 = self._trace_subset(
+                x + eps, y, z, L, M, N, wavelengths, stop_idx, is_inf
+            )
+            lx1, ly1 = self._get_local_stop_coords(r1, stop_idx)
+            r2 = self._trace_subset(
+                x, y + eps, z, L, M, N, wavelengths, stop_idx, is_inf
+            )
+            lx2, ly2 = self._get_local_stop_coords(r2, stop_idx)
+        else:
+            r1 = self._trace_subset(
+                x, y, z, L + eps, M, N, wavelengths, stop_idx, is_inf
+            )
+            lx1, ly1 = self._get_local_stop_coords(r1, stop_idx)
+            r2 = self._trace_subset(
+                x, y, z, L, M + eps, N, wavelengths, stop_idx, is_inf
+            )
+            lx2, ly2 = self._get_local_stop_coords(r2, stop_idx)
+
+        J11 = (lx1 - lx) / eps
+        J21 = (ly1 - ly) / eps
+        J12 = (lx2 - lx) / eps
+        J22 = (ly2 - ly) / eps
+
+        # Paraxial diagonal fallback for rays where the finite difference is
+        # unusable (a perturbed ray missed a surface -> NaN, or the local
+        # sensitivity collapsed to a near-singular Jacobian).
+        num_rays = len(x)
+        wl_mean = (
+            be.mean(wavelengths) if hasattr(wavelengths, "__len__") else wavelengths
+        )
+        j_par = float(
+            be.to_numpy(
+                self._get_paraxial_jacobian(float(wl_mean), stop_idx, is_inf)
+            ).ravel()[0]
+        )
+        if abs(j_par) < 1e-12:
+            j_par = 1e-12
+        j_par_arr = be.full(num_rays, j_par)
+        zeros = be.zeros(num_rays)
+
+        det = J11 * J22 - J12 * J21
+        bad = be.logical_or(be.isnan(det), be.abs(det) < 1e-12)
+        J11 = be.where(bad, j_par_arr, J11)
+        J22 = be.where(bad, j_par_arr, J22)
+        J12 = be.where(bad, zeros, J12)
+        J21 = be.where(bad, zeros, J21)
+        return J11, J12, J21, J22
 
     def _get_paraxial_jacobian(
         self, wavelength: float, stop_idx: int, is_inf: bool
@@ -339,9 +469,16 @@ class IterativeRayAimer(BaseRayAimer):
         """
         para = self.optic.paraxial
         if is_inf:
+            # skip=1 drops the object surface, so the returned array is indexed
+            # by (surface_index - skip): surface k lives at heights[k - 1].
+            # Indexing with the bare stop_idx reads the surface *after* the
+            # stop, which collapses to ~0 whenever that surface sits near a
+            # focus (stop on/near the last surface) -- yielding a near-zero
+            # Jacobian and a Newton step that overshoots to NaN (issue #654).
+            skip = 1
             z_start = para.surfaces.positions[1]
-            y, _ = para.trace_generic(1.0, 0.0, z_start, wavelength, skip=1)
-            return y[stop_idx]
+            y, _ = para.trace_generic(1.0, 0.0, z_start, wavelength, skip=skip)
+            return y[stop_idx - skip]
         else:
             obj_z = self.optic.object_surface.geometry.cs.z
             y, _ = para.trace_generic(0.0, 1.0, obj_z, wavelength)

--- a/tests/test_ray_aiming.py
+++ b/tests/test_ray_aiming.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.materials.ideal import IdealMaterial
 from optiland.optic import Optic
 from optiland.rays import RealRays
 from optiland.rays.ray_aiming.iterative import IterativeRayAimer
@@ -782,3 +784,187 @@ def test_robust_aimer_autograd_matches_finite_difference(set_test_backend):
     grad_fd = (loss_p - loss_m) / (2 * eps)
 
     assert abs(grad_autograd - grad_fd) / abs(grad_fd) < 1e-2
+
+
+# ---------------------------------------------------------------------------
+# Issue #654: ray aiming with non-trivial stop geometry (tilted / decentered /
+# back-surface stops). All three of these systems drove the Newton/Broyden
+# aiming core to NaN before the fix.
+# ---------------------------------------------------------------------------
+
+
+def _issue_654_tilted_mirror(tilt_rx=0.0):
+    """Single parabolic mirror used directly as the stop (issue #654, bug 4).
+
+    The surface after the stop is at focus, so the pre-fix off-by-one paraxial
+    Jacobian collapsed to exactly zero and the Newton step blew up to NaN.
+    """
+    mirror = Optic()
+    mirror.surfaces.add(index=0, thickness=np.inf)
+    mirror.surfaces.add(
+        index=1,
+        radius=-100,
+        thickness=-50,
+        conic=-1,
+        material="mirror",
+        is_stop=True,
+    )
+    mirror.surfaces.add(index=2)
+    mirror.wavelengths.add(value=0.55, is_primary=True)
+    mirror.set_aperture(aperture_type="EPD", value=20)
+    mirror.fields.set_type(field_type="angle")
+    mirror.fields.add(x=0, y=0)
+    mirror.fields.add(x=5, y=5)
+    if tilt_rx:
+        mirror.surfaces[1].geometry.cs = CoordinateSystem(rx=tilt_rx)
+    return mirror
+
+
+def _issue_654_back_surface_stop():
+    """Infinite-conjugate singlet whose stop is the last lens surface, sitting
+    just before focus (issue #654, bug 2)."""
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=np.inf)
+    optic.surfaces.add(
+        index=1, radius=50.0, thickness=5.0, material=IdealMaterial(n=1.5)
+    )
+    optic.surfaces.add(
+        index=2, radius=-50.0, thickness=48.0, is_stop=True, aperture=10.0
+    )
+    optic.surfaces.add(index=3)
+    optic.fields.set_type("angle")
+    optic.fields.add(y=0)
+    optic.fields.add(y=2)
+    optic.set_aperture("EPD", 20.0)
+    optic.wavelengths.add(0.55)
+    return optic
+
+
+def _issue_654_tilted_finite_stop(tilt_deg=120.0):
+    """Finite-conjugate system with a strongly tilted stop (issue #654, bug 1).
+
+    A large tilt flips the stop's local y-axis relative to the launch DOF, so
+    the pre-fix paraxial diagonal Jacobian had the wrong *sign* on M and the
+    Broyden step diverged to NaN for the off-axis (diagonal) pupil rays.
+    """
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=60.0)
+    optic.surfaces.add(
+        index=1, radius=40.0, thickness=8.0, material=IdealMaterial(n=1.5)
+    )
+    optic.surfaces.add(index=2, radius=-40.0, thickness=20.0)
+    optic.surfaces.add(index=3, thickness=30.0, is_stop=True, aperture=8.0)
+    optic.surfaces.add(index=4)
+    optic.fields.set_type("angle")
+    optic.fields.add(y=0)
+    optic.fields.add(y=3)
+    optic.set_aperture("EPD", 16.0)
+    optic.wavelengths.add(0.55)
+    optic.surfaces[3].geometry.cs.rx = np.deg2rad(tilt_deg)
+    return optic
+
+
+def _disk_pupil(n=5):
+    """Return the (Px, Py) of an ``n x n`` grid clipped to the unit disk."""
+    t = np.linspace(-1, 1, n)
+    Px, Py = np.meshgrid(t, t)
+    keep = (Px**2 + Py**2) <= 1.0 + 1e-9
+    return Px[keep].ravel(), Py[keep].ravel()
+
+
+@pytest.mark.parametrize(
+    "build", [CookeTriplet, _issue_654_tilted_mirror], ids=["CookeTriplet", "mirror"]
+)
+def test_paraxial_jacobian_matches_finite_difference_issue654(set_test_backend, build):
+    """The paraxial-Jacobian seed for the aiming solver must match a finite
+    difference of the real launch->stop response.
+
+    A prior off-by-one in the ``skip=1`` (infinite-conjugate) branch read the
+    surface *after* the stop; that collapses to ~0 whenever the following
+    surface sits near a focus, giving a near-zero Jacobian and a Newton step
+    that overshoots to NaN (issue #654, bugs 2 & 4). Even on an ordinary Cooke
+    triplet the pre-fix value was wrong by ~10%.
+    """
+    optic = build()
+    stop_idx = optic.surfaces.stop_index
+    is_inf = getattr(optic.object_surface, "is_infinite", False)
+    wl = float(optic.wavelengths.primary_wavelength.value)
+    aimer = IterativeRayAimer(optic)
+
+    j = float(
+        be.to_numpy(aimer._get_paraxial_jacobian(wl, stop_idx, is_inf)).ravel()[0]
+    )
+
+    seed = aimer._paraxial_aimer.aim_rays(
+        (be.array([0.0]), be.array([0.0])),
+        be.array([wl]),
+        (be.array([0.0]), be.array([0.0])),
+    )
+    x, y, z, L, M, N = (be.as_array_1d(v) for v in seed)
+    wl_a = be.array([wl])
+    h = 1e-5
+
+    def stop_x(xx, ll):
+        rays = aimer._trace_subset(xx, y, z, ll, M, N, wl_a, stop_idx, is_inf)
+        lx, _ = aimer._get_local_stop_coords(rays, stop_idx)
+        return float(be.to_numpy(lx).ravel()[0])
+
+    if is_inf:
+        j_fd = (stop_x(x + h, L) - stop_x(x, L)) / h
+    else:
+        j_fd = (stop_x(x, L + h) - stop_x(x, L)) / h
+
+    assert_allclose(j, j_fd, atol=1e-3, rtol=1e-2)
+
+
+def test_tilted_mirror_stop_aims_without_nan_issue654(set_test_backend):
+    """A slightly tilted mirror-stop must aim without producing NaN, and the
+    marginal ray must reach the aperture edge (issue #654, bug 4)."""
+    mirror = _issue_654_tilted_mirror(tilt_rx=np.pi / 64)
+    mirror.ray_tracer.set_aiming("robust")
+
+    Hx = be.array([0.0, 1.0, 0.0, 1.0])
+    Hy = be.array([0.0, 0.0, 0.0, 0.0])
+    Px = be.array([0.0, 0.0, 1.0, 1.0])
+    Py = be.array([0.0, 0.0, 0.0, 0.0])
+    mirror.trace_generic(Hx, Hy, Px, Py, 0.55)
+
+    s = mirror.surfaces[1]
+    assert not be.any(be.isnan(s.x))
+    assert not be.any(be.isnan(s.y))
+    # marginal rays (Px = 1) land at ~ EPD/2 = 10 mm in x
+    x = be.to_numpy(s.x).ravel()
+    assert abs(abs(float(x[2])) - 10.0) < 0.1
+
+
+def test_back_surface_stop_fills_pupil_issue654(set_test_backend):
+    """With the stop on the last surface (near a focus), every pupil ray must
+    aim to the stop -- not just the chief ray (issue #654, bug 2)."""
+    optic = _issue_654_back_surface_stop()
+    optic.ray_tracer.set_aiming("robust")
+    stop_idx = optic.surfaces.stop_index
+    Px, Py = _disk_pupil(5)
+    zeros = be.zeros(len(Px))
+
+    optic.trace_generic(zeros, zeros, be.array(Px), be.array(Py), 0.55)
+
+    sx = be.to_numpy(optic.surfaces[stop_idx].x).ravel()
+    sy = be.to_numpy(optic.surfaces[stop_idx].y).ravel()
+    assert not np.any(np.isnan(sx))
+    assert not np.any(np.isnan(sy))
+
+
+def test_tilted_finite_stop_converges_all_pupil_rays_issue654(set_test_backend):
+    """A finite-conjugate system with a strongly tilted stop must converge for
+    every pupil ray, including the diagonal corners whose local-frame sign flip
+    defeated the diagonal paraxial Jacobian (issue #654, bug 1)."""
+    optic = _issue_654_tilted_finite_stop(tilt_deg=120.0)
+    optic.ray_tracer.set_aiming("robust")
+    stop_idx = optic.surfaces.stop_index
+    Px, Py = _disk_pupil(5)
+    zeros = be.zeros(len(Px))
+
+    optic.trace_generic(zeros, zeros, be.array(Px), be.array(Py), 0.55)
+
+    sx = be.to_numpy(optic.surfaces[stop_idx].x).ravel()
+    assert not np.any(np.isnan(sx))


### PR DESCRIPTION
Addresses #654 — the tilted-stop, back-surface-stop and folded-system cases. The offset-stop case is separate (see bottom).

Three of the reported systems failed in the Newton/Broyden aiming core (`optiland/rays/ray_aiming/iterative.py`), for two reasons.

**Off-by-one paraxial Jacobian.** For infinite conjugates the seed trace runs with `skip=1`, which shifts the returned height array by one, but `_get_paraxial_jacobian` read `y[stop_idx]` — the surface *after* the stop — instead of `y[stop_idx - 1]`. That height drops to ~0 whenever the following surface sits near a focus, so the Jacobian came out near-zero and the Newton step overshot to NaN. Against a finite-difference check the old value is wrong on every infinite system (Cooke triplet: 0.83 vs 0.76 true) and exactly 0 when the stop is the last powered surface. This is what broke the triplet with the stop on the back surface and the tilted parabolic mirror.

**Diagonal Jacobian with no step control.** The seed Jacobian was forced to `J11 = J22 = +J_factor`, off-diagonal zero. A tilted or decentered stop flips the sign of ∂e_y/∂M (measured −59, assumed +59) and couples the two axes, so the step was not a descent direction; Broyden then pushed a direction cosine past 1, the trace returned NaN, and the NaN was absorbed with no way back. Replaced the seed with a per-ray finite-difference 2×2 Jacobian and added a per-ray backtracking line search that rejects any step that produces NaN or grows the error. This fixes the folded system with the 90° tilted stop — the case that made `ImageSimulationEngine` raise `Iterative aimer failed to converge`.

The finite-difference Jacobian costs two extra traces per solve; the paraxial value (now correctly indexed) stays as the fallback for degenerate rays.

## After the fix

Each system below: layout first, then the analysis that was failing.

**Triplet, stop on the back surface** — through-focus spot diagram:

![triplet layout](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug2_triplet_layout.png)

![through-focus spot diagram](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug2_triplet_through_focus_spot.png)

**Folded system, 90° tilted stop** — `ImageSimulationEngine` (previously raised `Iterative aimer failed to converge`):

![folded system layout](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug1_folded_layout.png)

![image simulation output](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug1_folded_image_simulation.png)

**Tilted parabolic mirror** — spot diagram (`trace_generic` previously returned all NaN):

![tilted mirror layout](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug4_tilted_mirror_layout.png)

![tilted mirror spot diagram](https://raw.githubusercontent.com/optiland/optiland/issue-654-assets/bug4_tilted_mirror_spot.png)

## Tests

Five regression tests in `tests/test_ray_aiming.py`, run on both backends: paraxial Jacobian vs finite difference, tilted mirror, back-surface stop, and tilted finite-conjugate stop. Each fails on `master` and passes here. The existing ray-aiming and image-simulation suites are unchanged.

## Offset-stop case (not in this PR)

EPD is 20 but the stop's physical aperture is radius 5, so aiming fills the EPD-derived radius and the physical aperture then vignettes everything but the center. That is a system-definition inconsistency rather than a solver bug. There is also a separate crash on that file — the aperture value is stored as `[20.0]`, which breaks `RealReferenceStrategy`. Both belong in their own issue.
