### PR TITLE
Fixes flip for OddAsphere 

### DIFF
--- a/optiland/geometries/odd_asphere.py
+++ b/optiland/geometries/odd_asphere.py
@@ -141,3 +141,12 @@ class OddAsphere(EvenAsphere):
         nz = -1 / mag
 
         return nx, ny, nz
+
+    def flip(self):
+        """Flip the geometry.
+
+        Changes the sign of the radius of curvature and the signs of coefficients.
+        The conic constant remains unchanged.
+        """
+        self.radius = -self.radius
+        self.coefficients = [-c for c in self.coefficients]

--- a/tests/test_flip_geometries.py
+++ b/tests/test_flip_geometries.py
@@ -138,7 +138,7 @@ def test_flip_odd_asphere_geometry():
 
     assert geom.radius == -initial_radius
     assert geom.k == initial_conic
-    assert geom.coefficients == initial_coeffs
+    assert geom.coefficients == [-c for c in initial_coeffs]
 
 
 def test_flip_polynomial_geometry():


### PR DESCRIPTION
This addresses .flip not working correctly for OddAspheres (bug #668 ) by changing the sign of the coefficients when running .flip. 

Note: I have a suspicion that the issues lie a bit deep, i.e., that the same changes are needed for EvenAsphere as well.

Fixes #668 