### PR TITLE
Update readthedocs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
-    python: "mambaforge-23.11"
+    python: "miniforge3-26.3"
 
 conda:
   environment: docs/build-environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,9 +9,10 @@ dependencies:
   - pyyaml
   - scipy
   - seaborn
+  - tabulate
+  - vtk
   - xeus-python
   - pip:
     - ./jupyterlite/mock_libraries/numba
-    - ./jupyterlite/mock_libraries/vtk
-    - tabulate
+    # - ./jupyterlite/mock_libraries/vtk
     - ..

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,9 +10,8 @@ dependencies:
   - scipy
   - seaborn
   - tabulate
-  - vtk
   - xeus-python
   - pip:
     - ./jupyterlite/mock_libraries/numba
-    # - ./jupyterlite/mock_libraries/vtk
+    - ./jupyterlite/mock_libraries/vtk
     - ..

--- a/docs/jupyterlite/mock_libraries/numba/pyproject.toml
+++ b/docs/jupyterlite/mock_libraries/numba/pyproject.toml
@@ -7,5 +7,5 @@ name = "numba"
 description = "Numba stub for running Optiland in WASM environments"
 readme = { content-type = "text/markdown", text = "" }
 license = { text = "" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 version = "0.61.2"

--- a/docs/jupyterlite/mock_libraries/vtk/pyproject.toml
+++ b/docs/jupyterlite/mock_libraries/vtk/pyproject.toml
@@ -7,5 +7,5 @@ name = "vtk"
 description = "VTK stub for running Optiland in WASM environments"
 readme = { content-type = "text/markdown", text = "" }
 license = { text = "" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 version = "9.4.2"


### PR DESCRIPTION
- Update Python to `miniforge3-26.3`
- Use `vtk` from `emscripten-forge`

VTK could be installed for emscripten-wasm32 but somehow not imported, so I kept the stub for VTK.