### PR TITLE
Fix real-ray stop radius for decentered stops (#654)

### DIFF
--- a/optiland/rays/ray_aiming/initialization.py
+++ b/optiland/rays/ray_aiming/initialization.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import optiland.backend as be
 from optiland.aperture import FloatByStopAperture
 from optiland.rays import RealRays
+from optiland.rays.ray_aiming.pupil_map import to_float
 
 if TYPE_CHECKING:
     from optiland.optic import Optic
@@ -73,7 +74,7 @@ class RealReferenceStrategy(StopSizeStrategy):
     """Strategy using real ray trace to determine stop radius.
 
     Traces a Real Ray from the center of the object toward the edge of the
-    Paraxial Entrance Pupil. Fallbacks to ParaxialReferenceStrategy on failure.
+    Entrance Pupil. Fallbacks to ParaxialReferenceStrategy on failure.
     """
 
     def calculate_stop_radius(self) -> float:
@@ -94,65 +95,63 @@ class RealReferenceStrategy(StopSizeStrategy):
         EPD = float(self.optic.paraxial.EPD())
 
         stop_index = self.optic.surfaces.stop_index
-
-        # Determine launch ray parameters (x, y, z, L, M, N)
         obj_surf = self.optic.object_surface
-        if obj_surf and obj_surf.is_infinite:
-            # For infinite objects, we launch a ray parallel to the axis
-            # starting slightly before surface 1 to ensure robust intersection.
-            z_surf1 = self.optic.surfaces[1].geometry.cs.z
-            z_start = z_surf1 - 100.0
+        is_inf = bool(obj_surf and obj_surf.is_infinite)
 
-            y_start = EPD / 2.0
-            x_start = 0.0
+        # The entrance pupil is the image of the stop, so a decentered stop has
+        # a decentered entrance pupil. Offsetting by EPD/2 from the axis would
+        # then launch a ray that never goes near the pupil, and the height it
+        # lands at is a distance from the stop center that has nothing to do
+        # with the stop radius (issue #654). Locate the pupil center first and
+        # offset from there.
+        cx, cy, cz, cL, cM, cN = self._solve_pupil_center(stop_index, is_inf)
 
+        if is_inf:
+            # Object-space rays run parallel to the axis, so the launch height
+            # is the entrance-pupil coordinate and can be offset directly.
             rays = RealRays(
-                x=be.array([x_start]),
-                y=be.array([y_start]),
-                z=be.array([z_start]),
-                L=be.array([0.0]),
-                M=be.array([0.0]),
-                N=be.array([1.0]),
+                x=be.array([cx]),
+                y=be.array([cy + EPD / 2.0]),
+                z=be.array([cz]),
+                L=be.array([cL]),
+                M=be.array([cM]),
+                N=be.array([cN]),
                 wavelength=be.array([wavelength]),
                 intensity=be.array([1.0]),
             )
-            start_surf_idx = 1
         else:
-            # Finite object: Ray starts at (0, 0, obj_z) pointing to pupil edge
-            obj_z = obj_surf.geometry.cs.z
+            # Offset the chief ray's pupil crossing, then re-aim at it from the
+            # same object point.
+            t = (EPL - cz) / cN
+            target_x = cx + cL * t
+            target_y = cy + cM * t + EPD / 2.0
 
-            # Target point: (0, EPD/2, EPL)
-            target_y = EPD / 2.0
-            target_z = EPL
-
-            dy = target_y - 0.0
-            dz = target_z - obj_z
-            mag = be.sqrt(dy**2 + dz**2)
-
-            L = 0.0
-            M = dy / mag
-            N = dz / mag
+            dx = target_x - cx
+            dy = target_y - cy
+            dz = EPL - cz
+            mag = float(be.sqrt(be.array(dx**2 + dy**2 + dz**2)))
 
             rays = RealRays(
-                x=be.array([0.0]),
-                y=be.array([0.0]),
-                z=be.array([obj_z]),
-                L=be.array([L]),
-                M=be.array([M]),
-                N=be.array([N]),
+                x=be.array([cx]),
+                y=be.array([cy]),
+                z=be.array([cz]),
+                L=be.array([dx / mag]),
+                M=be.array([dy / mag]),
+                N=be.array([dz / mag]),
                 wavelength=be.array([wavelength]),
                 intensity=be.array([1.0]),
             )
-            start_surf_idx = 1
 
-        # Trace from start surface up to the stop surface
-        for i in range(start_surf_idx, stop_index + 1):
+        # Trace from the first surface up to the stop surface
+        for i in range(1, stop_index + 1):
             self.optic.surfaces[i].trace(rays)
             if be.any(be.isnan(rays.x)):
                 raise ValueError("Ray trace resulted in NaNs (TIR or missed surface).")
 
-        # Localize rays to the stop surface's local frame so the radial
-        # height is measured from the stop center, not the global origin.
+        # Localize rays to the stop surface's local frame so the radial height
+        # is measured from the stop center, not the global origin. The pupil
+        # center solve puts the chief ray on that origin, so the marginal ray's
+        # local radius is its separation from the chief ray.
         stop_cs = self.optic.surfaces[stop_index].geometry.cs
         local_rays = RealRays(
             be.copy(rays.x),
@@ -168,6 +167,100 @@ class RealReferenceStrategy(StopSizeStrategy):
 
         # Return intersection radial height at Stop in local coords
         return float(be.sqrt(local_rays.x[0] ** 2 + local_rays.y[0] ** 2))
+
+    def _solve_pupil_center(self, stop_index: int, is_inf: bool) -> tuple:
+        """Solve the launch state of the axial ray landing on the stop center.
+
+        For a centered system this is the on-axis launch and the solve is a
+        no-op, but for a decentered or tilted stop it is what locates the
+        entrance pupil, which is the reference the marginal probe is offset
+        from.
+
+        Args:
+            stop_index: Index of the stop surface.
+            is_inf: Whether the object is at infinity.
+
+        Returns:
+            tuple: ``(x, y, z, L, M, N)`` launch state of the axial ray that
+            lands on the stop surface's local origin.
+
+        Raises:
+            ValueError: If the solve does not converge.
+        """
+        # Imported here: iterative.py pulls this module in at call time, so a
+        # module-level import would be circular.
+        from optiland.rays.ray_aiming.iterative import IterativeRayAimer
+
+        wavelength = self.optic.primary_wavelength
+        EPL = float(self.optic.paraxial.entrance_pupil_z())
+
+        # First-order seed: the pupil is the image of the stop, so the stop's
+        # decenter maps to the pupil scaled by the pupil magnification. Exact
+        # for a centered system ahead of the stop; elsewhere the Newton polish
+        # below carries it the rest of the way.
+        m = self._pupil_magnification()
+        stop_cs = self.optic.surfaces[stop_index].geometry.cs
+        gx, gy, _gz = stop_cs.position_in_gcs
+        ex = to_float(gx) * m
+        ey = to_float(gy) * m
+
+        if is_inf:
+            # Launch well ahead of surface 1 to ensure robust intersection.
+            z_start = to_float(self.optic.surfaces[1].geometry.cs.z) - 100.0
+            x0, y0, z0 = be.array([ex]), be.array([ey]), be.array([z_start])
+            L0, M0, N0 = be.array([0.0]), be.array([0.0]), be.array([1.0])
+        else:
+            obj_z = to_float(self.optic.object_surface.geometry.cs.z)
+            dz = EPL - obj_z
+            mag = float(be.sqrt(be.array(ex**2 + ey**2 + dz**2)))
+            x0, y0, z0 = be.array([0.0]), be.array([0.0]), be.array([obj_z])
+            L0 = be.array([ex / mag])
+            M0 = be.array([ey / mag])
+            N0 = be.array([dz / mag])
+
+        zero = be.array([0.0])
+        aimer = IterativeRayAimer(self.optic)
+        x, y, z, L, M, N, converged, _ = aimer._solve_core(
+            x0,
+            y0,
+            z0,
+            L0,
+            M0,
+            N0,
+            be.array([wavelength]),
+            stop_index,
+            is_inf,
+            zero,
+            zero,
+        )
+        if not bool(be.all(converged)):
+            raise ValueError("Could not solve for the entrance pupil center.")
+
+        return (
+            to_float(x),
+            to_float(y),
+            to_float(z),
+            to_float(L),
+            to_float(M),
+            to_float(N),
+        )
+
+    def _pupil_magnification(self) -> float:
+        """Signed paraxial magnification from the stop plane to the pupil plane.
+
+        Returns:
+            float: ``(EPD / 2) / y_stop``, where ``y_stop`` is the paraxial
+            marginal ray height at the stop.
+
+        Raises:
+            ValueError: If the paraxial marginal ray height at the stop is zero.
+        """
+        para = self.optic.paraxial
+        y_marginal, _ = para.marginal_ray()
+        y_stop = to_float(y_marginal[self.optic.surfaces.stop_index])
+        if abs(y_stop) < 1e-12:
+            raise ValueError("Paraxial marginal ray height at the stop is zero.")
+        return float(para.EPD()) / 2.0 / y_stop
 
 
 def get_stop_radius_strategy(optic: Optic, aiming_mode: str) -> StopSizeStrategy:

--- a/tests/test_ray_aiming.py
+++ b/tests/test_ray_aiming.py
@@ -9,7 +9,12 @@ import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.materials.ideal import IdealMaterial
 from optiland.optic import Optic
+from optiland.physical_apertures.radial import RadialAperture
 from optiland.rays import RealRays
+from optiland.rays.ray_aiming.initialization import (
+    ParaxialReferenceStrategy,
+    RealReferenceStrategy,
+)
 from optiland.rays.ray_aiming.iterative import IterativeRayAimer
 from optiland.rays.ray_aiming.paraxial import ParaxialRayAimer
 from optiland.rays.ray_aiming.robust import RobustRayAimer
@@ -864,6 +869,58 @@ def _issue_654_tilted_finite_stop(tilt_deg=120.0):
     return optic
 
 
+def _issue_654_decentered_stop(decenter_y=5.0):
+    """Infinite-conjugate system whose stop is a small decentered lens
+    (issue #654 follow-up).
+
+    The entrance pupil is the image of the stop, so decentering the stop
+    decenters the pupil too. The EPD is scaled so the paraxial marginal ray
+    exactly fills the stop's physical radius, as in the reported system.
+    """
+    glass = IdealMaterial(n=1.5168)
+    # Explicit RadialAperture: a scalar `aperture=` is a *diameter*, and these
+    # radii must match the reported system exactly.
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=np.inf)
+    optic.surfaces.add(index=1, thickness=0.0)
+    optic.surfaces.add(
+        index=2,
+        radius=61.0,
+        thickness=4.67,
+        material=glass,
+        aperture=RadialAperture(r_max=12.7),
+    )
+    optic.surfaces.add(
+        index=3, radius=-61.0, thickness=5.33, aperture=RadialAperture(r_max=12.7)
+    )
+    optic.surfaces.add(
+        index=4,
+        radius=5.0,
+        thickness=1.0,
+        material=glass,
+        is_stop=True,
+        aperture=RadialAperture(r_max=1.0),
+    )
+    optic.surfaces.add(
+        index=5, radius=-5.0, thickness=4.2, aperture=RadialAperture(r_max=1.0)
+    )
+    optic.surfaces.add(index=6)
+    optic.fields.set_type("angle")
+    optic.fields.add(y=0)
+    optic.fields.add(y=5)
+    optic.wavelengths.add(0.52, is_primary=True)
+    optic.set_aperture("EPD", 2.0)
+
+    # Shift the stop doublet off axis, then rescale the EPD so the paraxial
+    # marginal ray lands exactly on the stop's r_max = 1.0 edge.
+    optic.surfaces[4].geometry.cs.y = decenter_y
+    optic.surfaces[5].geometry.cs.y = decenter_y
+    y_marginal, _ = optic.paraxial.marginal_ray()
+    r_par = float(be.to_numpy(y_marginal[4]).ravel()[0])
+    optic.set_aperture("EPD", 2.0 / r_par)
+    return optic
+
+
 def _disk_pupil(n=5):
     """Return the (Px, Py) of an ``n x n`` grid clipped to the unit disk."""
     t = np.linspace(-1, 1, n)
@@ -968,3 +1025,62 @@ def test_tilted_finite_stop_converges_all_pupil_rays_issue654(set_test_backend):
 
     sx = be.to_numpy(optic.surfaces[stop_idx].x).ravel()
     assert not np.any(np.isnan(sx))
+
+
+def test_decentered_stop_radius_matches_paraxial_issue654(set_test_backend):
+    """The real-ray stop radius must be measured from the *decentered* entrance
+    pupil (issue #654 follow-up).
+
+    Probing from the on-axis pupil edge instead measured the distance from the
+    stop centre to a ray that never went near the pupil: ~4 mm against a true
+    radius of ~1 mm.
+    """
+    optic = _issue_654_decentered_stop(decenter_y=5.0)
+
+    real_r = RealReferenceStrategy(optic).calculate_stop_radius()
+    paraxial_r = ParaxialReferenceStrategy(optic).calculate_stop_radius()
+
+    # The paraxial marginal ray fills the stop edge by construction, so the
+    # real-ray radius may differ only by pupil aberration (a few percent).
+    assert_allclose(real_r, paraxial_r, atol=0.05)
+
+
+def test_decentered_stop_fills_pupil_issue654(set_test_backend):
+    """Every pupil ray of a decentered stop must aim inside the stop's clear
+    aperture and reach the image unvignetted (issue #654 follow-up).
+
+    With the stop radius mis-measured, the aimer targeted a radius several
+    times too large: the outer rays missed the stop surface entirely (NaN) and
+    the rest were vignetted by its physical aperture, leaving only the chief
+    ray.
+    """
+    optic = _issue_654_decentered_stop(decenter_y=5.0)
+    optic.ray_tracer.set_aiming("robust")
+    stop_idx = optic.surfaces.stop_index
+    Px, Py = _disk_pupil(5)
+    zeros = be.zeros(len(Px))
+
+    rays = optic.trace_generic(zeros, zeros, be.array(Px), be.array(Py), 0.52)
+
+    # Rays land on the stop, within its r_max = 1.0 clear aperture, measured
+    # in the stop's own (decentered) frame.
+    local = RealRays(
+        be.copy(optic.surfaces[stop_idx].x),
+        be.copy(optic.surfaces[stop_idx].y),
+        be.copy(optic.surfaces[stop_idx].z),
+        be.zeros(len(Px)),
+        be.zeros(len(Px)),
+        be.ones(len(Px)),
+        intensity=be.ones(len(Px)),
+        wavelength=be.full(len(Px), 0.52),
+    )
+    optic.surfaces[stop_idx].geometry.cs.localize(local)
+    r_local = np.hypot(be.to_numpy(local.x).ravel(), be.to_numpy(local.y).ravel())
+    assert not np.any(np.isnan(r_local))
+    assert np.all(r_local <= 1.0 + 1e-9)
+
+    # The pupil is actually filled, not collapsed onto the chief ray, and no
+    # ray is vignetted away.
+    assert r_local.max() > 0.9
+    assert not np.any(np.isnan(be.to_numpy(rays.y).ravel()))
+    assert np.all(be.to_numpy(rays.i).ravel() > 0.0)


### PR DESCRIPTION
Follow-up to #678, which fixed the tilted-stop, back-surface-stop and folded cases but left the offset-stop case out. That case is a real solver bug, not the system-definition inconsistency the earlier file suggested.

## The bug

The entrance pupil is the image of the stop, so a decentered stop has a decentered entrance pupil. `RealReferenceStrategy` measured the stop radius by launching a probe at `y = EPD/2`, on the axis, and reporting where it landed relative to the stop centre. When the pupil is off axis that probe never goes near it, so the reported radius is unrelated to the stop.

On the system reported in [the follow-up comment](https://github.com/optiland/optiland/issues/654#issuecomment-3527936826) (a small R=5 lens, `r_max` 1.0, decentered to y=+5 behind a singlet):

```
launch y -> local stop (x, y)      [R=5 sphere: |local r| must be < 5]
  y= 0.000 -> (nan, nan)             the on-axis probe misses the stop entirely
  y= 1.131 -> ( 0.0000, -4.0392)     EPD/2 probe: 4 mm from the stop centre
  y= 5.673 -> ( 0.0000,  0.0000)     the actual pupil centre
  y= 6.804 -> ( 0.0000,  0.9773)     the actual pupil edge
```

So `r_stop` came out 4.039 against a true radius of ~1.0. The aimer then targeted the full pupil four times too wide: the outer rays missed the stop surface (NaN) and the rest were vignetted by its physical aperture, leaving only the chief ray. That is the degenerate spot in the report.

Note the aperture is self-consistent here: EPD 2.2622 puts the paraxial marginal ray at exactly 1.0, which is the stop's `r_max`. The system is correctly defined, unlike the earlier file (EPD 20 against a radius-5 stop) that #678 set aside.

## The fix

Solve for the pupil centre first, the axial ray landing on the stop's own origin, which needs no stop radius, then offset `EPD/2` from there. The solve reuses `IterativeRayAimer._solve_core` against target (0, 0) and is seeded with the first-order pupil decenter (stop decenter times pupil magnification), which predicts 5.6555 against the true 5.6727 and converges immediately.

For a centered system the seed is zero and the solve is a no-op, so the measured radius is unchanged by construction.

## After the fix

Aimed rays land at local stop y `[-0.977, -0.489, 0.000, 0.489, 0.977]`: linear in `Py`, centred on the stop to 1e-9, all inside `r_max` 1.0. The full disk pupil traces unvignetted.

`r_stop` is bit-identical on every system that already worked:

| system | master | this PR |
| --- | --- | --- |
| CookeTriplet | 3.8575 | 3.8575 |
| ReverseTelephoto | 0.1821 | 0.1821 |
| tilted mirror (#654 bug 4) | 9.9876 | 9.9876 |
| back-surface stop (#654 bug 2) | 9.7954 | 9.7954 |
| tilted finite stop (#654 bug 1) | 7.6383 | 7.6383 |
| **decentered stop** | **4.0389** | **0.9775** |

No system falls back to the paraxial path, so the real-ray measurement is exercised throughout.

## Tests

Two regression tests in `tests/test_ray_aiming.py`, on both backends: the real-ray radius must match the paraxial reference for a decentered stop, and every pupil ray must aim inside the stop's clear aperture and reach the image unvignetted. Both fail on master and pass here. The existing ray-aiming, initialization, cached-aimer and image-simulation suites are unchanged (226 passing).

Refs #654
