### PR TITLE
Fix finite-conjugate aberrations for object-height fields

### DIFF
--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
-from optiland.fields import ParaxialImageHeightField
+from optiland.fields import ObjectHeightField, ParaxialImageHeightField
 from optiland.raytrace.paraxial_ray_tracer import ParaxialRayTracer
 
 if TYPE_CHECKING:
@@ -405,12 +405,20 @@ class Paraxial:
         y_obj_unit = y_rev_unit[-1]
         u_obj_unit = u_rev_unit[-1]
 
+        field_definition = self.optic.fields.field_definition
+        if not self.optic.object_surface.is_infinite and isinstance(
+            field_definition, ObjectHeightField
+        ):
+            first_surface_z = self.surfaces.positions[1, 0]
+            object_z = self.optic.object_surface.geometry.cs.z
+            y_obj_unit = y_obj_unit + (first_surface_z - object_z) * u_obj_unit
+
         # Scale based on field definition
-        if self.optic.fields.field_definition is None:
+        if field_definition is None:
             # TODO: make some nice error message
             raise ValueError()
 
-        scaling_factor = self.optic.fields.field_definition.scale_chief_ray_for_field(
+        scaling_factor = field_definition.scale_chief_ray_for_field(
             self.optic, y_obj_unit, u_obj_unit, y_img_unit
         )
 

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -58,6 +58,29 @@ def simple_singlet():
     return lens
 
 
+@pytest.fixture
+def finite_conjugate_singlet():
+    """Finite-conjugate singlet from issue #683."""
+    lens = Optic(name="Convex/Plano")
+    lens.surfaces.add(index=0, thickness=50.0)
+    lens.surfaces.add(
+        index=1,
+        thickness=7.0,
+        radius=20.0,
+        is_stop=True,
+        material="N-SF11",
+    )
+    lens.surfaces.add(index=2, thickness=43.0)
+    lens.surfaces.add(index=3)
+
+    lens.wavelengths.add(value=0.55, is_primary=True)
+    lens.set_aperture(aperture_type="EPD", value=10.0)
+    lens.fields.set_type(field_type="object_height")
+    lens.fields.add(x=0, y=0)
+    lens.fields.add(x=0, y=5)
+    return lens
+
+
 class TestDoubleGaussAberrations:
     def test_init(self, set_test_backend, double_gauss):
         aberrations = Aberrations(double_gauss)
@@ -259,6 +282,26 @@ class TestSimpleSinglet:
 
         # Other Seidel coefficients are expected to be zero for on-axis field
         assert_allclose(S[1:], [0, 0, 0, 0], atol=1e-8)
+
+
+class TestFiniteConjugateAberrations:
+    """Regression coverage for issue #683."""
+
+    def test_chief_ray_is_finite(self, set_test_backend, finite_conjugate_singlet):
+        y, u = finite_conjugate_singlet.paraxial.chief_ray()
+
+        assert not be.any(~be.isfinite(y))
+        assert not be.any(~be.isfinite(u))
+        assert_allclose(y[0], -5.0)
+        assert_allclose(y[1], 0.0, atol=1e-12)
+
+    def test_third_order_coefficients_are_finite(
+        self, set_test_backend, finite_conjugate_singlet
+    ):
+        coefficients = finite_conjugate_singlet.aberrations.third_order()
+
+        for coefficient in coefficients:
+            assert not be.any(~be.isfinite(coefficient))
 
 
 class TestReflectiveSystemSeidels:


### PR DESCRIPTION
## Summary

- correct finite-conjugate chief-ray scaling for object-height fields
- add regression coverage for the finite-conjugate singlet reported in #683
- verify that the chief ray remains finite, crosses the stop center, and produces finite third-order aberration coefficients

## Root cause

`Paraxial.chief_ray()` obtains an object-side unit ray by tracing backward from the stop. The generic paraxial tracer intentionally treats `ObjectSurface` as a no-op, so the returned ray height is measured at the first physical surface rather than at the finite object plane.

For an object-height field with the stop on surface 1, that unit height is zero. Scaling by the requested object height then divides by zero, and the resulting non-finite chief ray propagates into the Lagrange invariant and third-order aberration coefficients.

This change propagates the unit chief ray across the missing first-surface-to-object distance only for finite-conjugate `ObjectHeightField` systems. Other field definitions and the generic paraxial tracer retain their existing behavior.

## Validation

- `python -m pytest -q tests/test_aberrations.py tests/test_field_types.py tests/test_paraxial.py tests/test_ray_aiming.py tests/test_aperture.py tests/test_solves.py` (`1321 passed, 1 skipped`)
- `python -m pytest -q tests/test_aberrations.py::TestFiniteConjugateAberrations`
- `python -m ruff check optiland/ tests/test_aberrations.py`
- `python -m ruff format --check optiland/paraxial.py tests/test_aberrations.py`

Closes #683
