### PR TITLE
Minor improvements to the file IO system

### DIFF
--- a/optiland/fileio/codev/reader/converter.py
+++ b/optiland/fileio/codev/reader/converter.py
@@ -187,11 +187,11 @@ class CodeVToOpticConverter(BaseOpticReader):
             "is_stop": surf.get("is_stop", False),
             "material": material,
         }
-        
+
         # Is paraxial?
         if "mfl" in surf:
             params["surface_type"] = "paraxial"
-            params["f"] = surf["mfl"]       
+            params["f"] = surf["mfl"]
 
         coefficients = surf.get("coefficients")
         if coefficients:

--- a/optiland/fileio/codev/reader/converter.py
+++ b/optiland/fileio/codev/reader/converter.py
@@ -187,6 +187,11 @@ class CodeVToOpticConverter(BaseOpticReader):
             "is_stop": surf.get("is_stop", False),
             "material": material,
         }
+        
+        # Is paraxial?
+        if "mfl" in surf:
+            params["surface_type"] = "paraxial"
+            params["f"] = surf["mfl"]       
 
         coefficients = surf.get("coefficients")
         if coefficients:

--- a/optiland/fileio/codev/reader/parser.py
+++ b/optiland/fileio/codev/reader/parser.py
@@ -127,7 +127,7 @@ class CodeVDataParser:
             "HOR": lambda t: None,
             "HCT": lambda t: None,
             "HCO": lambda t: None,
-            "MFL": self._read_paraxial,            
+            "MFL": self._read_paraxial,
         }
         # Aspheric coefficient keys
         for _key in _ASPH_KEYS:
@@ -419,9 +419,9 @@ class CodeVDataParser:
 
     def _read_cde(self, tokens: list[str]) -> None:
         self._current_surf_data["cde"] = float(tokens[1])
-        
+
     def _read_paraxial(self, tokens: list[str]) -> None:
-        self._current_surf_data["mfl"] = float(tokens[1])        
+        self._current_surf_data["mfl"] = float(tokens[1])
 
     def _read_asph_coeff(self, tokens: list[str]) -> None:
         key_letter = tokens[0].upper()

--- a/optiland/fileio/codev/reader/parser.py
+++ b/optiland/fileio/codev/reader/parser.py
@@ -127,6 +127,7 @@ class CodeVDataParser:
             "HOR": lambda t: None,
             "HCT": lambda t: None,
             "HCO": lambda t: None,
+            "MFL": self._read_paraxial,            
         }
         # Aspheric coefficient keys
         for _key in _ASPH_KEYS:
@@ -418,6 +419,9 @@ class CodeVDataParser:
 
     def _read_cde(self, tokens: list[str]) -> None:
         self._current_surf_data["cde"] = float(tokens[1])
+        
+    def _read_paraxial(self, tokens: list[str]) -> None:
+        self._current_surf_data["mfl"] = float(tokens[1])        
 
     def _read_asph_coeff(self, tokens: list[str]) -> None:
         key_letter = tokens[0].upper()

--- a/optiland/fileio/codev/writer/encoder.py
+++ b/optiland/fileio/codev/writer/encoder.py
@@ -156,6 +156,7 @@ class CodeVFileEncoder:
         self._encode_asphere_coeffs(lines, raw)
         self._encode_decenters_tilts(lines, raw)
         self._encode_physical_aperture(lines, raw)
+        self._encode_paraxial(lines, raw)
 
     def _encode_surface_line(self, raw: dict[str, Any]) -> str:
         surf_type = raw.get("type", "standard")
@@ -209,6 +210,11 @@ class CodeVFileEncoder:
             lines.append(f"  CIR CLR {_fmt(r_max)}")
         except AttributeError:
             pass
+        
+    def _encode_paraxial(self, lines: list[str], raw: dict[str, Any]) -> None:
+        paraxial = raw.get("paraxial")
+        if paraxial is not None:
+            lines.append(f"  MFL {_fmt(float(paraxial))}")        
 
     def _encode_glass_inline(self, glass: dict[str, Any]) -> str:
         """Build the glass string for the surface line.

--- a/optiland/fileio/codev/writer/encoder.py
+++ b/optiland/fileio/codev/writer/encoder.py
@@ -210,11 +210,11 @@ class CodeVFileEncoder:
             lines.append(f"  CIR CLR {_fmt(r_max)}")
         except AttributeError:
             pass
-        
+
     def _encode_paraxial(self, lines: list[str], raw: dict[str, Any]) -> None:
         paraxial = raw.get("paraxial")
         if paraxial is not None:
-            lines.append(f"  MFL {_fmt(float(paraxial))}")        
+            lines.append(f"  MFL {_fmt(float(paraxial))}")
 
     def _encode_glass_inline(self, glass: dict[str, Any]) -> str:
         """Build the glass string for the surface line.

--- a/optiland/fileio/codev/writer/formatter.py
+++ b/optiland/fileio/codev/writer/formatter.py
@@ -218,6 +218,10 @@ class OpticToCodeVConverter:
         if surface.aperture is not None:
             raw["aperture"] = surface.aperture
 
+        # Paraxial surface
+        if surface.interaction_model.interaction_type == "thin_lens":
+            raw["paraxial"] = float(surface.interaction_model.f)
+            
         # Glass — check reflective flag first (mirror)
         is_reflective = getattr(
             getattr(surface, "interaction_model", None), "is_reflective", False

--- a/optiland/fileio/codev/writer/formatter.py
+++ b/optiland/fileio/codev/writer/formatter.py
@@ -221,7 +221,7 @@ class OpticToCodeVConverter:
         # Paraxial surface
         if surface.interaction_model.interaction_type == "thin_lens":
             raw["paraxial"] = float(surface.interaction_model.f)
-            
+
         # Glass — check reflective flag first (mirror)
         is_reflective = getattr(
             getattr(surface, "interaction_model", None), "is_reflective", False

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -172,11 +172,11 @@ class OsloToOpticConverter(BaseOpticReader):
         if th >= 9.9e9:
             th = be.inf
         surface_params["thickness"] = th
-        
+
         # Is paraxial?
         if "PFL" in data:
             surface_params["surface_type"] = "paraxial"
-            surface_params["f"] = data["PFL"]        
+            surface_params["f"] = data["PFL"]
 
         # Handle material
         material_raw = data.get("material", "AIR")

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -172,6 +172,11 @@ class OsloToOpticConverter(BaseOpticReader):
         if th >= 9.9e9:
             th = be.inf
         surface_params["thickness"] = th
+        
+        # Is paraxial?
+        if "PFL" in data:
+            surface_params["surface_type"] = "paraxial"
+            surface_params["f"] = data["PFL"]        
 
         # Handle material
         material_raw = data.get("material", "AIR")

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -65,6 +65,7 @@ class OsloDataParser:
             "FNO": self._read_fno,
             "NAO": self._read_nao,
             "DES": self._read_des,
+            "PFL": self._read_paraxial,
         }
 
     def parse(self) -> OsloDataModel:
@@ -170,6 +171,9 @@ class OsloDataParser:
         # GLA 1.573 1.573 1.573
         # GLA MOD G1 1.6489 1.662...
         self._current_surf_data["material"] = "GLA " + " ".join(tokens[1:])
+
+    def _read_paraxial(self, tokens: list[str]) -> None:
+        self._current_surf_data["PFL"] = float(tokens[1])
 
     def _read_rd(self, tokens: list[str]) -> None:
         self._current_surf_data["RD"] = float(tokens[1])

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -128,6 +128,7 @@ class OpticToOsloEncoder:
             # Material — detect mirror via interaction_model.is_reflective
             im = getattr(surface, "interaction_model", None)
             is_mirror = bool(getattr(im, "is_reflective", False))
+            is_paraxial = bool(im.interaction_type == "thin_lens")
             material_to_encode = "mirror" if is_mirror else surface.material_post
             surf_data["material"] = self._encode_material(material_to_encode)
 
@@ -150,6 +151,10 @@ class OpticToOsloEncoder:
                 # fields; without it only the chief ray is plotted.
                 with contextlib.suppress(Exception):
                     surf_data["AP"] = float(self.optic.paraxial.EPD()) / 2.0
+                    
+            # Paraxial case
+            if is_paraxial:
+                surf_data["PFL"] = float(surface.interaction_model.f)
 
             # Decenter/Tilt
             for k in ["DCX", "DCY", "DCZ", "TLA", "TLB", "TLC"]:
@@ -161,20 +166,20 @@ class OpticToOsloEncoder:
 
     def _encode_material(self, material: Any) -> str:
         if material == "air" or material is None:
-            return "AIR"
+            return "  AIR"
         if material == "mirror":
-            return "RFL"
+            return "  RFL"
 
         if isinstance(material, Material):
-            return f"GLA {material.name}"
+            return f"  GLA {material.name}"
 
         if isinstance(material, IdealMaterial):
             n = float(material.index.item())
             # IdealMaterial with n≈1.0 is air - write AIR, not GLA 1.0 1.0 1.0
             if abs(n - 1.0) < 1e-6:
-                return "AIR"
+                return "  AIR"
             ns = f"{n:.7g}"
-            return f"GLA {ns} {ns} {ns}"
+            return f"  GLA {ns} {ns} {ns}"
 
         if isinstance(material, AbbeMaterial):
             nd = float(material.index.item())
@@ -184,14 +189,14 @@ class OpticToOsloEncoder:
                 n_d = f"{float(material.n(w_d).item()):.7g}"
                 n_F = f"{float(material.n(w_F).item()):.7g}"
                 n_C = f"{float(material.n(w_C).item()):.7g}"
-                return f"GLA {n_d} {n_F} {n_C}"
+                return f"  GLA {n_d} {n_F} {n_C}"
             except Exception:
                 ns = f"{nd:.7g}"
-                return f"GLA {ns} {ns} {ns}"
+                return f"  GLA {ns} {ns} {ns}"
 
         # Fallback
         try:
             name = getattr(material, "name", str(material))
-            return f"GLA {name}"
+            return f"  GLA {name}"
         except Exception:
-            return "AIR"
+            return "  AIR"

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -151,7 +151,7 @@ class OpticToOsloEncoder:
                 # fields; without it only the chief ray is plotted.
                 with contextlib.suppress(Exception):
                     surf_data["AP"] = float(self.optic.paraxial.EPD()) / 2.0
-                    
+
             # Paraxial case
             if is_paraxial:
                 surf_data["PFL"] = float(surface.interaction_model.f)

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -111,18 +111,21 @@ class OsloDataFormatter:
 
     def _format_surface_geometry(self, lines: list[str], data: dict[str, Any]) -> None:
         if "RD" in data and not math.isinf(data["RD"]):
-            lines.append(f"RD {self._fmt(data['RD'])}")
+            lines.append(f"  RD {self._fmt(data['RD'])}")
 
         if "TH" in data:
             th = 1e10 if math.isinf(data["TH"]) else data["TH"]
-            lines.append(f"TH {self._fmt(th)}")  # 1e10 is OSLO's infinity convention
+            lines.append(f"  TH {self._fmt(th)}")  # 1e10 is OSLO's infinity convention
 
         if "AP" in data:
-            lines.append(f"AP {self._fmt(data['AP'])}")
+            lines.append(f"  AP {self._fmt(data['AP'])}")
 
         if data.get("AST"):
-            lines.append("AST")
+            lines.append("  AST")
 
+        if data.get("PFL"):
+            lines.append(f"  PFL {self._fmt(data['PFL'])}")
+            
         if "CC" in data and data["CC"] != 0:
             lines.append(f"CC {self._fmt(data['CC'])}")
 

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -125,7 +125,7 @@ class OsloDataFormatter:
 
         if data.get("PFL"):
             lines.append(f"  PFL {self._fmt(data['PFL'])}")
-            
+
         if "CC" in data and data["CC"] != 0:
             lines.append(f"CC {self._fmt(data['CC'])}")
 

--- a/optiland/fileio/zemax/reader/parser.py
+++ b/optiland/fileio/zemax/reader/parser.py
@@ -32,6 +32,7 @@ class ZemaxDataParser:
         self.data_model = ZemaxDataModel()
         self._current_surf = -1
         self._current_surf_data: dict[str, Any] = {}
+        self._ftyp = None
 
         # Operand dispatch table — maps operand string to handler method
         self._operand_table = {
@@ -41,8 +42,11 @@ class ZemaxDataParser:
             "OBNA": self._read_object_na,
             "FLOA": self._read_floating_stop,
             "FTYP": self._read_config_data,
+            "XFLD": self._read_x_fields,
+            "YFLD": self._read_y_fields,
             "XFLN": self._read_x_fields,
             "YFLN": self._read_y_fields,
+            "WAVL": self._read_wavelength,
             "WAVM": self._read_wavelength,
             "PWAV": self._read_primary_wave,
             "SURF": self._read_surface,
@@ -142,6 +146,9 @@ class ZemaxDataParser:
             except ValueError:
                 return default
 
+        # Safety for losely compatible files (e.g: optalix exports)
+        if data == [0]:
+            return
         fields = self.data_model.fields
         fields["num_fields"] = _safe_int(3, 0)
         fields["type"] = {
@@ -164,19 +171,28 @@ class ZemaxDataParser:
             fields["num_fields"] = 1
 
     def _read_x_fields(self, data: list[str]) -> None:
-        n = self.data_model.fields["num_fields"]
+        if self._ftyp:
+            n = self.data_model.fields["num_fields"]
+        else:
+            n = len(data)
         self.data_model.fields["x"] = [float(v) for v in data[1 : n + 1]]
 
     def _read_y_fields(self, data: list[str]) -> None:
-        n = self.data_model.fields["num_fields"]
+        if self._ftyp:
+            n = self.data_model.fields["num_fields"]
+        else:
+            n = len(data)
         self.data_model.fields["y"] = [float(v) for v in data[1 : n + 1]]
 
     def _read_wavelength(self, data: list[str]) -> None:
         val = float(data[2])
         weight = float(data[3]) if len(data) > 3 else 1.0
+        if self._ftyp:
+            n = self.data_model.wavelengths["num_wavelengths"]
+        else:
+            n = len(data)
         if (
-            len(self.data_model.wavelengths["data"])
-            < self.data_model.wavelengths["num_wavelengths"]
+            len(self.data_model.wavelengths["data"]) < n
         ):
             self.data_model.wavelengths["data"].append(val)
             self.data_model.wavelengths["weights"].append(weight)

--- a/optiland/fileio/zemax/reader/parser.py
+++ b/optiland/fileio/zemax/reader/parser.py
@@ -171,29 +171,18 @@ class ZemaxDataParser:
             fields["num_fields"] = 1
 
     def _read_x_fields(self, data: list[str]) -> None:
-        if self._ftyp:
-            n = self.data_model.fields["num_fields"]
-        else:
-            n = len(data)
+        n = self.data_model.fields["num_fields"] if self._ftyp else len(data)
         self.data_model.fields["x"] = [float(v) for v in data[1 : n + 1]]
 
     def _read_y_fields(self, data: list[str]) -> None:
-        if self._ftyp:
-            n = self.data_model.fields["num_fields"]
-        else:
-            n = len(data)
+        n = self.data_model.fields["num_fields"] if self._ftyp else len(data)
         self.data_model.fields["y"] = [float(v) for v in data[1 : n + 1]]
 
     def _read_wavelength(self, data: list[str]) -> None:
         val = float(data[2])
         weight = float(data[3]) if len(data) > 3 else 1.0
-        if self._ftyp:
-            n = self.data_model.wavelengths["num_wavelengths"]
-        else:
-            n = len(data)
-        if (
-            len(self.data_model.wavelengths["data"]) < n
-        ):
+        n = self.data_model.wavelengths["num_wavelengths"] if self._ftyp else len(data)
+        if len(self.data_model.wavelengths["data"]) < n:
             self.data_model.wavelengths["data"].append(val)
             self.data_model.wavelengths["weights"].append(weight)
 

--- a/optiland/fileio/zemax/surfaces.py
+++ b/optiland/fileio/zemax/surfaces.py
@@ -181,8 +181,8 @@ class StandardSurfaceHandler(BaseSurfaceHandler):
             "CURV": _curvature(float(geom.radius)),
             "CONI": float(getattr(geom, "k", 0.0)),
         }
-    
-    
+
+
 @register
 class ParaxialSurfaceHandler(BaseSurfaceHandler):
     """Handler for PARAXIAL surfaces."""
@@ -217,7 +217,7 @@ class ParaxialSurfaceHandler(BaseSurfaceHandler):
         return {
             "TYPE": self.zemax_type,
             "CURV": _curvature(float(geom.radius)),
-            "PARM_1": float(surface.interaction_model.f)
+            "PARM_1": float(surface.interaction_model.f),
         }
 
 

--- a/optiland/fileio/zemax/surfaces.py
+++ b/optiland/fileio/zemax/surfaces.py
@@ -181,6 +181,44 @@ class StandardSurfaceHandler(BaseSurfaceHandler):
             "CURV": _curvature(float(geom.radius)),
             "CONI": float(getattr(geom, "k", 0.0)),
         }
+    
+    
+@register
+class ParaxialSurfaceHandler(BaseSurfaceHandler):
+    """Handler for PARAXIAL surfaces."""
+
+    zemax_type: ClassVar[str] = "PARAXIAL"
+    optiland_type: ClassVar[str] = "paraxial"
+
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Parse a PARAXIAL surface raw dict.
+
+        Args:
+            raw: Raw surface dict from ZemaxDataParser.
+
+        Returns:
+            Kwargs for ``optic.surfaces.add()``.
+        """
+        return {
+            "surface_type": self.optiland_type,
+            "radius": raw.get("radius", float(be.inf)),
+        }
+
+    def format(self, surface: Surface) -> dict[str, Any]:
+        """Format a paraxial surface to Zemax operand dict.
+
+        Args:
+            surface: The Optiland surface.
+
+        Returns:
+            Raw operand dict for ZemaxFileEncoder.
+        """
+        geom = surface.geometry
+        return {
+            "TYPE": self.zemax_type,
+            "CURV": _curvature(float(geom.radius)),
+            "PARM_1": float(surface.interaction_model.f)
+        }
 
 
 @register

--- a/optiland/fileio/zemax/writer/encoder.py
+++ b/optiland/fileio/zemax/writer/encoder.py
@@ -204,10 +204,10 @@ class ZemaxFileEncoder:
         clap = raw.get("CLAP")
         if clap is None:
             return
-        if hasattr(clap, 'r_min'):
+        if hasattr(clap, "r_min"):
             lines.append(f"  CLAP {_fmt(float(clap.r_min))} {_fmt(float(clap.r_max))}")
-        elif hasattr(clap, 'x_min'):
-            lines.append(f"  CLAP {_fmt(float(0.0))} {_fmt(float(clap.x_max))}")
+        elif hasattr(clap, "x_min"):
+            lines.append(f"  CLAP {_fmt(0.0)} {_fmt(float(clap.x_max))}")
 
     def _encode_parameters(self, lines: list[str], raw: dict[str, Any]) -> None:
         for i in range(1, 17):

--- a/optiland/fileio/zemax/writer/encoder.py
+++ b/optiland/fileio/zemax/writer/encoder.py
@@ -204,10 +204,10 @@ class ZemaxFileEncoder:
         clap = raw.get("CLAP")
         if clap is None:
             return
-        try:
+        if hasattr(clap, 'r_min'):
             lines.append(f"  CLAP {_fmt(float(clap.r_min))} {_fmt(float(clap.r_max))}")
-        except AttributeError:
-            lines.append("  CLAP 0")
+        elif hasattr(clap, 'x_min'):
+            lines.append(f"  CLAP {_fmt(float(0.0))} {_fmt(float(clap.x_max))}")
 
     def _encode_parameters(self, lines: list[str], raw: dict[str, Any]) -> None:
         for i in range(1, 17):

--- a/optiland/fileio/zemax/writer/formatter.py
+++ b/optiland/fileio/zemax/writer/formatter.py
@@ -230,7 +230,7 @@ class OpticToZemaxConverter:
     def _resolve_geometry_type(self, surface: Any, output_idx: int) -> str:
         """Map a surface's geometry to a Zemax-supported Optiland type string."""
         geom_str = str(surface.geometry)
-        if (surface.interaction_model.interaction_type == "thin_lens"):
+        if surface.interaction_model.interaction_type == "thin_lens":
             optiland_type = "paraxial"
         else:
             optiland_type = _GEOM_STR_TO_TYPE.get(geom_str)

--- a/optiland/fileio/zemax/writer/formatter.py
+++ b/optiland/fileio/zemax/writer/formatter.py
@@ -230,7 +230,10 @@ class OpticToZemaxConverter:
     def _resolve_geometry_type(self, surface: Any, output_idx: int) -> str:
         """Map a surface's geometry to a Zemax-supported Optiland type string."""
         geom_str = str(surface.geometry)
-        optiland_type = _GEOM_STR_TO_TYPE.get(geom_str)
+        if (surface.interaction_model.interaction_type == "thin_lens"):
+            optiland_type = "paraxial"
+        else:
+            optiland_type = _GEOM_STR_TO_TYPE.get(geom_str)
         if optiland_type is None:
             raise NotImplementedError(
                 f"Surface {output_idx}: geometry type '{geom_str}' "


### PR DESCRIPTION
This are minor changes, just to get warmed up:

- Added support for paraxial (thin lens) import/export with CodeV, OSLO and Zemax.
- Added fix for zemax files missing the FTYP information blob (for example, files exported from Optalix).
- Fixed formatting of exported OSLO files (indentation matching exports from OSLO).

Note 1: The contents of "encoder.py" and "formatter.py" seem to be inverted between OSLO and CODEV writers. This is confusing and should be fixed at some point...

Note 2: The IO for Zemax uses a different approach that the other 2 systems. Any reason for this?

To test these changes, you can run the following round-trip read/writes with the attached file (the output has been checked to load in relevant target softwares):

[paraxial_system.json](https://github.com/user-attachments/files/30149072/paraxial_system.json)

``from optiland.fileio import (load_optiland_file, load_zemax_file, load_codev_file, load_oslo_file, 
                             save_optiland_file, save_zemax_file, save_codev_file, save_oslo_file)

filename = "paraxial_system"

optic = load_optiland_file("JSON/"+filename+".json")
optic.draw()

save_zemax_file(optic, "ZEMAX/"+filename+".zmx")
save_codev_file(optic, "CODEV/"+filename+".seq")
save_oslo_file(optic, "OSLO/"+filename+".len")

optic = load_zemax_file("ZEMAX/"+filename+".zmx")
optic.draw()

optic = load_codev_file("CODEV/"+filename+".seq")
optic.draw()

optic = load_oslo_file("OSLO/"+filename+".len")
optic.draw()``