### PR TITLE
Fix toroidal radius optimization variables

### DIFF
--- a/optiland/geometries/toroidal.py
+++ b/optiland/geometries/toroidal.py
@@ -83,6 +83,33 @@ class ToroidalGeometry(NewtonRaphsonGeometry):
         )
         self.eps = 1e-14  # safe div
 
+    def set_radius_x(self, value: float) -> None:
+        """Set the X-Z radius of rotation.
+
+        Args:
+            value: New X-Z radius of rotation.
+        """
+        self.R_rot = be.array(value)
+
+    def set_radius(self, value: float) -> None:
+        """Set the default radius, which is the Y-Z profile radius.
+
+        Args:
+            value: New Y-Z profile radius.
+        """
+        self.set_radius_y(value)
+
+    def set_radius_y(self, value: float) -> None:
+        """Set the Y-Z profile radius and dependent geometry state.
+
+        Args:
+            value: New Y-Z profile radius.
+        """
+        radius = be.array(value)
+        self.R_yz = radius
+        self.radius = radius
+        self.c_yz = 1.0 / radius if be.isfinite(radius) and radius != 0 else 0.0
+
     def _calculate_zy(self, y: be.ndarray) -> be.ndarray:
         """Calculates the sag of the base Y-Z curve.
 

--- a/optiland/optimization/variable/radius.py
+++ b/optiland/optimization/variable/radius.py
@@ -9,6 +9,7 @@ Kramer Harrison, 2024
 
 from __future__ import annotations
 
+from optiland.geometries import ToroidalGeometry
 from optiland.optimization.scaling.linear import LinearScaler
 from optiland.optimization.variable.base import VariableBehavior
 
@@ -19,6 +20,8 @@ class RadiusVariable(VariableBehavior):
     Args:
         optic (Optic): The optic object that contains the surface.
         surface_number (int): The index of the surface in the optic.
+        axis (str, optional): Radius axis for a toroidal surface. Must be
+            ``"x"`` or ``"y"`` for toroidal geometry and omitted otherwise.
         scaler (Scaler): The scaler to use for the variable. Defaults to
             a linear scaler with factor=1/100 and offset=-1.0.
         **kwargs: Additional keyword arguments.
@@ -33,10 +36,26 @@ class RadiusVariable(VariableBehavior):
 
     """
 
-    def __init__(self, optic, surface_number, scaler=None, **kwargs):
+    def __init__(self, optic, surface_number, axis=None, scaler=None, **kwargs):
         if scaler is None:
             scaler = LinearScaler(factor=1 / 100.0, offset=-1.0)
         super().__init__(optic, surface_number, scaler=scaler, **kwargs)
+        self.axis = axis
+
+        geometry = self._surfaces[self.surface_number].geometry
+        if isinstance(geometry, ToroidalGeometry):
+            if self.axis is None:
+                raise ValueError(
+                    "An axis is required for radius variables on ToroidalGeometry."
+                )
+            if self.axis not in ("x", "y"):
+                raise ValueError(
+                    f'Invalid axis "{self.axis}" for toroidal radius variable.'
+                )
+        elif self.axis is not None:
+            raise ValueError(
+                "The axis argument is only supported for toroidal radius variables."
+            )
 
     def get_value(self):
         """Returns the current value of the radius.
@@ -45,6 +64,11 @@ class RadiusVariable(VariableBehavior):
             float: The current value of the radius.
 
         """
+        geometry = self._surfaces[self.surface_number].geometry
+        if isinstance(geometry, ToroidalGeometry):
+            if self.axis == "x":
+                return geometry.R_rot
+            return geometry.R_yz
         return self._surfaces.radii[self.surface_number]
 
     def update_value(self, new_value):
@@ -54,6 +78,13 @@ class RadiusVariable(VariableBehavior):
             new_value (float): The new value of the radius.
 
         """
+        geometry = self._surfaces[self.surface_number].geometry
+        if isinstance(geometry, ToroidalGeometry):
+            if self.axis == "x":
+                geometry.set_radius_x(new_value)
+            else:
+                geometry.set_radius_y(new_value)
+            return
         self.optic.updater.set_radius(new_value, self.surface_number)
 
     def __str__(self):
@@ -63,4 +94,7 @@ class RadiusVariable(VariableBehavior):
             str: A string representation of the variable.
 
         """
+        geometry = self._surfaces[self.surface_number].geometry
+        if isinstance(geometry, ToroidalGeometry):
+            return f"Radius {self.axis.upper()}, Surface {self.surface_number}"
         return f"Radius of Curvature, Surface {self.surface_number}"

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -45,6 +45,94 @@ class TestRadiusVariable:
         self.radius_var.update_value(5.0)
         assert_allclose(self.radius_var.get_value(), 5.0)
 
+    def test_rejects_axis_for_standard_geometry(self, set_test_backend):
+        with pytest.raises(ValueError, match="only supported for toroidal"):
+            variable.RadiusVariable(self.optic, 1, axis="x")
+
+
+class TestToroidalRadiusVariable:
+    @pytest.fixture
+    def optic(self, set_test_backend):
+        optic = Optic()
+        optic.surfaces.add(index=0, thickness=be.inf)
+        optic.surfaces.add(
+            index=1,
+            surface_type="toroidal",
+            radius_x=30.0,
+            radius_y=40.0,
+        )
+        return optic
+
+    def test_requires_axis(self, optic):
+        with pytest.raises(ValueError, match="axis.*required"):
+            variable.RadiusVariable(optic, surface_number=1)
+
+    def test_rejects_invalid_axis(self, optic):
+        with pytest.raises(ValueError, match='Invalid axis "z"'):
+            variable.RadiusVariable(optic, surface_number=1, axis="z")
+
+    def test_get_value_by_axis(self, optic):
+        radius_x = variable.RadiusVariable(optic, surface_number=1, axis="x")
+        radius_y = variable.RadiusVariable(optic, surface_number=1, axis="y")
+
+        assert_allclose(radius_x.get_value(), 30.0)
+        assert_allclose(radius_y.get_value(), 40.0)
+
+    def test_update_x_radius(self, optic):
+        radius_x = variable.RadiusVariable(optic, surface_number=1, axis="x")
+        radius_x.update_value(35.0)
+
+        geometry = optic.surfaces[1].geometry
+        assert_allclose(geometry.R_rot, 35.0)
+        assert_allclose(geometry.R_yz, 40.0)
+        assert_allclose(geometry.radius, 40.0)
+
+    def test_update_y_radius_keeps_geometry_consistent(self, optic):
+        radius_y = variable.RadiusVariable(optic, surface_number=1, axis="y")
+        radius_y.update_value(50.0)
+
+        geometry = optic.surfaces[1].geometry
+        assert_allclose(geometry.R_rot, 30.0)
+        assert_allclose(geometry.R_yz, 50.0)
+        assert_allclose(geometry.radius, 50.0)
+        assert_allclose(geometry.c_yz, 1.0 / 50.0)
+
+    def test_generic_updater_keeps_y_radius_consistent(self, optic):
+        optic.updater.set_radius(60.0, surface_number=1)
+
+        geometry = optic.surfaces[1].geometry
+        assert_allclose(geometry.R_rot, 30.0)
+        assert_allclose(geometry.R_yz, 60.0)
+        assert_allclose(geometry.radius, 60.0)
+        assert_allclose(geometry.c_yz, 1.0 / 60.0)
+
+    def test_problem_registers_both_radii(self, optic):
+        problem = OptimizationProblem()
+        problem.add_variable(
+            optic,
+            "radius",
+            surface_number=1,
+            axis="x",
+            scaler=IdentityScaler(),
+        )
+        problem.add_variable(
+            optic,
+            "radius",
+            surface_number=1,
+            axis="y",
+            scaler=IdentityScaler(),
+        )
+
+        assert_allclose(problem.variables[0].value, 30.0)
+        assert_allclose(problem.variables[1].value, 40.0)
+
+        problem.variables[0].update(32.0)
+        problem.variables[1].update(45.0)
+
+        geometry = optic.surfaces[1].geometry
+        assert_allclose(geometry.R_rot, 32.0)
+        assert_allclose(geometry.R_yz, 45.0)
+
 
 class TestReciprocalRadiusVariable:
     @pytest.fixture(autouse=True)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -78,6 +78,18 @@ class TestToroidalRadiusVariable:
         assert_allclose(radius_x.get_value(), 30.0)
         assert_allclose(radius_y.get_value(), 40.0)
 
+    @pytest.mark.parametrize(
+        ("axis", "expected"),
+        [
+            ("x", "Radius X, Surface 1"),
+            ("y", "Radius Y, Surface 1"),
+        ],
+    )
+    def test_string_representation(self, optic, axis, expected):
+        radius = variable.RadiusVariable(optic, surface_number=1, axis=axis)
+
+        assert str(radius) == expected
+
     def test_update_x_radius(self, optic):
         radius_x = variable.RadiusVariable(optic, surface_number=1, axis="x")
         radius_x.update_value(35.0)


### PR DESCRIPTION
## Summary

- add an explicit `axis="x"` / `axis="y"` interface for radius variables on `ToroidalGeometry`
- keep ordinary single-radius surfaces backward compatible and reject unsupported axis arguments
- synchronize `R_yz`, the inherited `radius`, and `c_yz` when the Y-Z radius is updated
- add regression coverage for validation, reads, updates, `OptimizationProblem`, and the generic updater path

## Root cause

`RadiusVariable` used the generic surface radius collection, which only exposes the toroidal Y-Z radius. Updates then went through the inherited standard-geometry setter, changing `radius` without updating `R_yz` or `c_yz`. The X-Z radius (`R_rot`) could not be selected as an optimization variable.

## Validation

- targeted toroidal radius and geometry tests: 26 passed
- related NumPy regression tests: 172 passed
- `OptimizerGeneric` integration benchmark optimized both radii from a merit value of 50.0 to approximately 5e-17
- Ruff format and static checks passed

The local environment exposes only the NumPy backend; CI will provide the project matrix coverage.

Closes #686