### PR TITLE
fix: size Zernike normalization radius from real ray footprints on off-axis systems (#578)

### DIFF
--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -9,16 +9,27 @@ Kramer Harrison, 2024
 
 from __future__ import annotations
 
+import contextlib
+import itertools
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
 from optiland.apodization import BaseApodization
 from optiland.geometries import StandardGeometry
 from optiland.materials import IdealMaterial
+from optiland.rays import RealRays
 
 if TYPE_CHECKING:
     from optiland.materials.base import BaseMaterial
     from optiland.rays import PolarizationState
+    from optiland.surfaces.standard_surface import Surface
+
+# Field/pupil grid used to probe the real-ray footprint on off-axis
+# surfaces (see OpticUpdater._real_ray_footprint). A 3x3 field grid crossed
+# with the 5 cardinal pupil points is enough to catch the tangential and
+# sagittal extremes without tracing a full pupil distribution.
+_FOOTPRINT_FIELDS = tuple(itertools.product((-1.0, 0.0, 1.0), repeat=2))
+_FOOTPRINT_PUPILS = ((0.0, 0.0), (1.0, 0.0), (-1.0, 0.0), (0.0, 1.0), (0.0, -1.0))
 
 
 class OpticUpdater:
@@ -213,11 +224,32 @@ class OpticUpdater:
         """Update the semi-aperture of all surfaces based on paraxial marginal
         and chief ray heights. Also updates normalization radii for relevant
         surface types.
+
+        The paraxial marginal/chief ray heights are an inherently axisymmetric
+        estimate: they assume the ray footprint on a surface is centered on
+        the local optical axis. That assumption breaks down once any surface
+        in the system is decentered or tilted (see optiland/optiland#578), so
+        for surfaces off the optical axis the normalization radius is refined
+        with a bounded real-ray footprint estimate (`_real_ray_footprint`).
+        The physical semi-aperture (used for drawing, vignetting, etc.) is
+        left on the paraxial estimate, unchanged.
         """
         ya, _ = self.optic.paraxial.marginal_ray()
         yb, _ = self.optic.paraxial.chief_ray()
         ya = be.abs(be.ravel(ya))
         yb = be.abs(be.ravel(yb))
+
+        footprints = {}
+        if self._is_off_axis():
+            probe_surfaces = [
+                surface
+                for surface in self.optic.surfaces
+                if hasattr(surface.geometry, "norm_radius")
+                and not getattr(surface, "is_norm_radius_variable", False)
+            ]
+            if probe_surfaces:
+                footprints = self._real_ray_footprints(probe_surfaces)
+
         for k, surface in enumerate(self.optic.surfaces):
             r_max = ya[k] + yb[k]
             if surface.aperture is not None:
@@ -226,21 +258,116 @@ class OpticUpdater:
                     r_max = be.max(be.array([r_max, extent_max]))
 
             surface.set_semi_aperture(r_max=r_max)
-            self.update_normalization(surface)
 
-    def update_normalization(self, surface) -> None:
+            norm_r_max = r_max
+            footprint = footprints.get(surface)
+            if footprint is not None:
+                norm_r_max = be.max(be.array([norm_r_max, footprint]))
+
+            self.update_normalization(surface, norm_r_max)
+
+    def _is_off_axis(self) -> bool:
+        """Check whether any surface in the system is decentered or tilted.
+
+        Used by `update_paraxial` to decide whether the axisymmetric
+        marginal/chief ray heights need refining with a real-ray footprint
+        estimate (optiland/optiland#578).
+        """
+        for surface in self.optic.surfaces:
+            cs = surface.geometry.cs
+            if cs.rx != 0 or cs.ry != 0 or cs.x != 0 or cs.y != 0:
+                return True
+        return False
+
+    def _real_ray_footprints(self, surfaces: list[Surface]) -> dict[Surface, float]:
+        """Estimate the real-ray footprint radius on each of `surfaces`.
+
+        Traces a bounded grid of extreme field/pupil combinations
+        (`_FOOTPRINT_FIELDS` x `_FOOTPRINT_PUPILS`) once through the actual
+        system, and for each surface returns the largest radial distance, in
+        that surface's local coordinates, that any of those rays land at.
+        Unlike the paraxial marginal/chief ray heights, real ray tracing
+        correctly accounts for every surface's decenter and tilt, so this is
+        used to refine the normalization radius on off-axis systems (see
+        optiland/optiland#578).
+
+        Each surface's own normalization radius is temporarily relaxed to
+        infinity for the duration of the probe, so the probe rays are not
+        rejected before their true footprint is known (this reduces each
+        surface to its base conic for the probe, since the normalized
+        Zernike coordinates collapse to the origin -- an acceptable
+        approximation for estimating the footprint).
+
+        Surfaces for which no probe ray was recorded (e.g. every combination
+        vignettes or fails to trace) are omitted from the returned dict, so
+        callers can fall back to the paraxial estimate.
+
+        Args:
+            surfaces (list[Surface]): The surfaces to probe. Each must have a
+                `norm_radius` attribute on its geometry.
+
+        Returns:
+            dict[Surface, float]: The estimated footprint radius per surface.
+        """
+        originals = {surface: surface.geometry.norm_radius for surface in surfaces}
+        for surface in surfaces:
+            surface.geometry.norm_radius = float("inf")
+
+        wavelength = self.optic.primary_wavelength
+        max_r: dict[Surface, float] = {}
+        try:
+            for Hx, Hy in _FOOTPRINT_FIELDS:
+                for Px, Py in _FOOTPRINT_PUPILS:
+                    for surface in surfaces:
+                        surface.reset()
+                    with contextlib.suppress(Exception):
+                        self.optic.trace_generic(Hx, Hy, Px, Py, wavelength)
+
+                    for surface in surfaces:
+                        if be.size(surface.x) == 0:
+                            continue
+
+                        probe = RealRays(
+                            be.copy(surface.x),
+                            be.copy(surface.y),
+                            be.copy(surface.z),
+                            be.zeros_like(surface.x),
+                            be.zeros_like(surface.x),
+                            be.ones_like(surface.x),
+                            be.ones_like(surface.x),
+                            wavelength,
+                        )
+                        surface.geometry.cs.localize(probe)
+                        r2 = probe.x**2 + probe.y**2
+                        if not bool(be.all(be.isfinite(r2))):
+                            continue
+                        r = float(be.sqrt(be.max(r2)))
+                        if r > max_r.get(surface, 0.0):
+                            max_r[surface] = r
+        finally:
+            for surface in surfaces:
+                surface.geometry.norm_radius = originals[surface]
+
+        return max_r
+
+    def update_normalization(self, surface, r_max=None) -> None:
         """Update the normalization radius/factors of a given non-spherical surface.
 
         Args:
             surface (Surface): The surface whose normalization factors are to be
                 updated.
+            r_max (float, optional): The aperture value to normalize against.
+                Defaults to `surface.semi_aperture`.
         """
         # Skip updating normalization when the normalization radius is a variable
         if getattr(surface, "is_norm_radius_variable", False):
             return
 
+        if r_max is None:
+            r_max = surface.semi_aperture
+
         # Delegate updating normalization directly to the geometry
-        surface.geometry.update_normalization(surface.semi_aperture)
+        surface.geometry.update_normalization(r_max)
 
     def update(self) -> None:
         """Update the optical system by applying all defined pickups and solves.

--- a/tests/test_norm_radius.py
+++ b/tests/test_norm_radius.py
@@ -110,6 +110,86 @@ def test_reversibility(zernike_optic, set_test_backend):
     assert norm_radius_val != custom_norm_radius
 
 
+def _build_tma_578(dy_last):
+    """Three-mirror Zernike TMA from optiland/optiland#578.
+
+    Reproduces the reporter's example: three off-axis (tilted + decentered)
+    Zernike mirrors with no coefficients (i.e. spherical/conic in shape).
+    With `dy_last=-75` the system traces cleanly; decentering the last
+    mirror by only 5 mm (`dy_last=-70`) previously raised
+    ``ValueError: Zernike coordinates must be normalized to [-1, 1]`` because
+    the paraxial marginal/chief ray heights used to size the normalization
+    radius are an axisymmetric estimate that under-represents the true ray
+    footprint once surfaces are decentered/tilted.
+    """
+    optic = Optic()
+    optic.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    optic.surfaces.add(index=1, radius=be.inf, thickness=120, is_stop=True)
+    optic.surfaces.add(
+        index=2,
+        radius=-400,
+        thickness=-125,
+        conic=0,
+        material="mirror",
+        rx=be.radians(-10.0),
+        surface_type="zernike",
+        zernike_type="fringe",
+        coefficients=[],
+    )
+    optic.surfaces.add(
+        index=3,
+        radius=300,
+        thickness=125,
+        conic=0,
+        material="mirror",
+        rx=be.radians(-3.0),
+        dy=-45,
+        surface_type="zernike",
+        zernike_type="fringe",
+        coefficients=[],
+    )
+    optic.surfaces.add(
+        index=4,
+        radius=-100,
+        thickness=-135,
+        conic=0,
+        material="mirror",
+        rx=be.radians(2.0),
+        dy=dy_last,
+        surface_type="zernike",
+        zernike_type="fringe",
+        coefficients=[],
+    )
+    optic.surfaces.add(index=5, dy=-100)
+    optic.set_aperture(aperture_type="EPD", value=30)
+    optic.fields.set_type("angle")
+    optic.fields.add(x=0, y=-5)
+    optic.fields.add(x=0, y=0)
+    optic.fields.add(x=0, y=5)
+    optic.wavelengths.add(value=0.7, is_primary=True)
+    return optic
+
+
+def test_off_axis_zernike_normalization_regression_578(set_test_backend):
+    """Decentering an off-axis Zernike TMA by 5 mm must not raise (#578)."""
+    optic = _build_tma_578(dy_last=-70)
+    optic.updater.update_paraxial()
+
+    # This is the exact field/pupil combination that previously overflowed
+    # the auto-sized normalization radius of the last (most off-axis)
+    # mirror.
+    optic.trace_generic(Hx=0, Hy=-1, Px=0, Py=1, wavelength=0.7)
+
+
+def test_off_axis_zernike_normalization_working_baseline_578(set_test_backend):
+    """The reporter's original (working) decenter must keep tracing cleanly."""
+    optic = _build_tma_578(dy_last=-75)
+    optic.updater.update_paraxial()
+
+    optic.trace_generic(Hx=0, Hy=-1, Px=0, Py=1, wavelength=0.7)
+    optic.trace_generic(Hx=0, Hy=1, Px=0, Py=-1, wavelength=0.7)
+
+
 def test_optimizer_precedence(zernike_optic, set_test_backend):
     # Fix it
     custom_norm_radius = 42.0


### PR DESCRIPTION
<!-- PR title: fix: size Zernike normalization radius from real ray footprints on off-axis systems (#578) -->

**You set the work.** #578: Zernike normalization fails on off-axis systems — a small decenter change makes an otherwise-fine lens throw `ValueError: Zernike coordinates must be normalized to [-1, 1]`.

**It's done.** Following your own root-cause comment: the paraxial estimate is inherently axisymmetric, so for off-axis systems the normalization radius now comes from tracing real rays instead. Regression tests written before the fix, on both the numpy and torch backends.

**Here's the evidence.**

- Fresh clone at `d04fbc1e`, patch applied, dependencies installed (with torch, to test both backends), then the network was disconnected.
- Full suite in a clean `python:3.12-bookworm` container, run in chunks to fit the verification machine's memory: **7,123 pass**. Two pre-existing `wide_fov` snapshot failures confirmed identical on unpatched base. One unrelated vectorial-diffraction torch test exceeds the container's memory ceiling even alone — cited from the native full-suite pass instead (7,248 passed).
- The regression test fails with your exact reported error on unpatched base, passes with the fix, on both backends.
- **Worth weighing before merging:** the off-axis path costs ~50ms per call on this TMA (centred systems unaffected) — the trade your own comment allowed for, but worth your sign-off.

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `d04fbc1e496a8e544cdcfcbd173fc201dc26ac38` |
| Container | `python:3.12-bookworm@sha256:9bed8554…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f01551220f02c1beaf2f8e3a191ad83d30ce7d43bd6b808ccb2b81df3c0e2bb00303a648b) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f01551220377c7aab561327674c43f51e7c524dbd8ddbae1becba0568284f9f864a73142b) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0x32e6972b881eb196b7407b25aed66faa384cb17f66ee8d057aa70c75a775e9ba) → [work delivered](https://sepolia.basescan.org/tx/0x6553148ef0655f4811e75e57a2e25a963ded793a37717cda1748cd2ae021f801) → [checks passed](https://sepolia.basescan.org/tx/0x184b5051c1f5c2871150afb0e9a65fcad427748b5d7cfd8b184e6442f5889c8a) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the fix is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Fixes #578.

Reproduced with your TMA script: decentering the last mirror from `dy=-75` to `dy=-70` triggers the error. Surface 4's auto-computed `norm_radius` was 19.11mm while the real ray at `Hy=-1, Py=+1` lands at local `y=-21.17mm` — the paraxial estimate (`ParaxialRayTracer.trace_generic`) uses only radii and axial positions, never a surface's `cs.x/y/rx/ry`, so it can't see decenter/tilt-driven footprint growth. A single-surface algebraic correction was tried and rejected empirically — the error is the cumulative effect of upstream mirrors' tilts, which only a real trace captures. This follows @HarrisonKramer's comment ("using real rays might be fine too, if required").

**The fix** (`optic_updater.py`): `update_paraxial()` detects off-axis systems (any surface with nonzero `cs.x/y/rx/ry`, the same check `Surface.is_rotationally_symmetric()` uses) and, only for them, traces a bounded 3×3 field × 5-pupil-point probe grid (45 rays), recording each surface's local footprint. Each probed surface's `norm_radius` is temporarily `inf` during the probe and restored after. The normalization input becomes `max(paraxial_estimate, real_footprint)` — never below today's value. `surface.semi_aperture` is untouched; Chebyshev/NURBS surfaces unaffected; centred systems skip the probe entirely.

### Notes for the reviewer (honest limits)

- The 3×3×5 probe grid is a bounded heuristic, not a proven worst-case bound — an asymmetric system could in principle peak between grid points.
- `norm_radius = inf` during probing is exact when Zernike coefficients are empty (the reported case); for nonzero coefficients it measures the base conic's footprint — reasonable, not rigorously bounded.
- Two `test_golden_snapshot[…wide_fov]` failures in the full suite are pre-existing on the base commit (confirmed byte-identical before any change) and unrelated to this fix.
