### PR TITLE
Fix incorrect sign in clearance ray operand (#354)

### DIFF
--- a/optiland/optimization/operand/ray.py
+++ b/optiland/optimization/operand/ray.py
@@ -407,10 +407,13 @@ class RayOperand:
         This operand is useful for creating clearance or interference constraints,
         particularly in off-axis reflective systems.
 
-        The sign convention is such that for Line A propagating generally in the
-        +Z direction (N direction cosine > 0), the signed distance is positive
-        if Point B is on the +Y side of Line A. If Line A propagates generally
-        in the -Z direction (N direction cosine < 0), this sign is flipped.
+        The sign convention follows the direction of propagation of Line A: for
+        Line A propagating generally in the +Z direction (N direction cosine >
+        0), the signed distance is positive if Point B is on the +Y side of
+        Line A. For Line A propagating generally in the -Z direction (N
+        direction cosine < 0), the sign convention naturally flips (positive
+        indicates Point B is on the -Y side) -- no separate correction should
+        be applied for this case.
 
         Args:
             optic: The optical system model.
@@ -456,6 +459,4 @@ class RayOperand:
         else:
             numerator = nA * (yB - yA) - mA * (zB - zA)
             d = numerator / denominator
-            if nA < 0:
-                d = -d
         return d

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -415,7 +415,7 @@ class TestRayOperand:
             point_ray_pupil_coords=(0.0, 0.0),
             wavelength=wavelength,
         )
-        assert_allclose(dist1, -7.412094834746042)
+        assert_allclose(dist1, 7.4120948347460525)
 
         dist2 = RayOperand.clearance(
             optic=optic,
@@ -427,7 +427,7 @@ class TestRayOperand:
             point_ray_pupil_coords=(0.0, 0.0),
             wavelength=wavelength,
         )
-        assert_allclose(dist2, -13.065596389231768)
+        assert_allclose(dist2, 13.065596389231784)
 
         dist3 = RayOperand.clearance(
             optic=optic,
@@ -439,7 +439,28 @@ class TestRayOperand:
             point_ray_pupil_coords=(0.0, 0.0),
             wavelength=wavelength,
         )
-        assert_allclose(dist3, -15.730530102711754)
+        assert_allclose(dist3, 15.730530102711763)
+
+    def test_clearance_non_reflective(self, set_test_backend, cooke_triplet):
+        """Sign should not flip for a forward-propagating (N > 0) line ray.
+
+        This guards against reintroducing a blanket sign correction in
+        `clearance` (see issue #354): such a change would leave the
+        mirror-based `test_clearance` cases looking fixed while silently
+        flipping this case, which is expected to be unaffected since N > 0
+        throughout this system.
+        """
+        dist = RayOperand.clearance(
+            optic=cooke_triplet,
+            line_ray_surface_idx=1,
+            line_ray_field_coords=(0.0, 0.0),
+            line_ray_pupil_coords=(0.0, -1.0),
+            point_ray_surface_idx=7,
+            point_ray_field_coords=(0.0, 1.0),
+            point_ray_pupil_coords=(0.0, 0.0),
+            wavelength=0.55,
+        )
+        assert_allclose(dist, 17.765903028537014)
 
     def test_AOI(self, set_test_backend, cooke_triplet):
         """Test the angle of incidence operand using CookeTriplet."""


### PR DESCRIPTION
## Fix incorrect sign in clearance ray operand (#354)

RayOperand.clearance() applied an extra sign correction (if nA < 0: d = -d) on top of a signed-distance formula that already flips sign naturally with the ray's propagation direction, per its own docstring. The double flip canceled the intended behavior specifically when N < 0, which is why the bug only showed up in off-axis reflective systems (mirrors reverse propagation direction) rather than general field-angle tracing, not in AngleField.get_ray_origins(), which follows the same sign convention used consistently across all field types.

Fixes #354.

Changes:
- Remove the redundant sign flip in clearance() and clarify the docstring.
- Update the three existing test_clearance regression values (they simply flip sign).
- Add test_clearance_non_reflective, a non-reflective (N > 0) case guarding against ever reintroducing a blanket sign correction.

Test plan:
- [x] pytest tests/test_operand.py -k clearance passes on both backends
- [x] ruff check clean