### PR TITLE
Add nan_policy option to rms_spot_size operand (#396)

### DIFF
--- a/optiland/optimization/operand/ray.py
+++ b/optiland/optimization/operand/ray.py
@@ -305,6 +305,7 @@ class RayOperand:
         num_rays,
         wavelength,
         distribution="hexapolar",
+        nan_policy="propagate",
     ):
         """Calculates the root mean square (RMS) spot size on a specific surface.
 
@@ -316,11 +317,37 @@ class RayOperand:
             num_rays: The number of rays to trace.
             wavelength: The wavelength of the rays.
             distribution: The distribution of the rays. Default is 'hexapolar'.
+            nan_policy: How to handle NaN ray intersections, which typically
+                arise from total internal reflection or vignetted rays. One
+                of "propagate" (default, return NaN if any intersection is
+                NaN), "omit" (ignore NaN intersections and compute the RMS
+                from the remaining valid rays), or "raise" (raise a
+                ValueError if any intersection is NaN).
 
         Returns:
             The RMS spot size on the specified surface.
 
+        Raises:
+            ValueError: If nan_policy is "raise" and a NaN ray intersection
+                is encountered, or if nan_policy is not a recognized value.
+
         """
+        valid_nan_policies = ("propagate", "omit", "raise")
+        if nan_policy not in valid_nan_policies:
+            raise ValueError(
+                f"Invalid nan_policy '{nan_policy}'. Must be one of "
+                f"{valid_nan_policies}."
+            )
+
+        def _has_nan(*arrays):
+            return any(be.any(be.isnan(a)) for a in arrays)
+
+        # Note: reductions always use the NaN-omitting `be.nanmean`, rather
+        # than `be.mean`, because `be.mean` is not NaN-consistent across
+        # backends (the torch backend's `mean` already silently ignores
+        # NaNs, while numpy's propagates them). Using `nanmean` everywhere
+        # and handling `nan_policy` explicitly via `_has_nan` keeps behavior
+        # identical on both backends.
         if wavelength == "all":
             x = []
             y = []
@@ -328,16 +355,33 @@ class RayOperand:
                 optic.trace(Hx, Hy, wave, num_rays, distribution)
                 x.append(optic.surfaces.x[surface_number, :].flatten())
                 y.append(optic.surfaces.y[surface_number, :].flatten())
+            has_nan = _has_nan(*x, *y)
             wave_idx = optic.wavelengths.primary_index
-            mean_x = be.mean(x[wave_idx])
-            mean_y = be.mean(y[wave_idx])
+            mean_x = be.nanmean(x[wave_idx])
+            mean_y = be.nanmean(y[wave_idx])
             r2 = [(x[i] - mean_x) ** 2 + (y[i] - mean_y) ** 2 for i in range(len(x))]
-            return be.sqrt(be.mean(be.concatenate(r2)))
-        optic.trace(Hx, Hy, wavelength, num_rays, distribution)
-        x = optic.surfaces.x[surface_number, :].flatten()
-        y = optic.surfaces.y[surface_number, :].flatten()
-        r2 = (x - be.mean(x)) ** 2 + (y - be.mean(y)) ** 2
-        return be.sqrt(be.mean(r2))
+            rms = be.sqrt(be.nanmean(be.concatenate(r2)))
+        else:
+            optic.trace(Hx, Hy, wavelength, num_rays, distribution)
+            x = optic.surfaces.x[surface_number, :].flatten()
+            y = optic.surfaces.y[surface_number, :].flatten()
+            has_nan = _has_nan(x, y)
+            r2 = (x - be.nanmean(x)) ** 2 + (y - be.nanmean(y)) ** 2
+            rms = be.sqrt(be.nanmean(r2))
+
+        if has_nan:
+            if nan_policy == "raise":
+                raise ValueError(
+                    "rms_spot_size encountered a NaN ray intersection on "
+                    f"surface {surface_number}. This typically indicates "
+                    "total internal reflection or a vignetted ray. Use "
+                    "nan_policy='omit' to compute the RMS from valid rays "
+                    "only, or leave nan_policy='propagate' (default) to "
+                    "return NaN."
+                )
+            if nan_policy == "propagate":
+                return rms * be.nan
+        return rms
 
     @staticmethod
     def OPD_difference(

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -327,6 +327,75 @@ class TestRayOperand:
             0.025626727777956947,
         )
 
+    def create_tir_optic(self):
+        """A finite-conjugate singlet whose marginal rays undergo total
+        internal reflection, producing NaN intersections on the image
+        surface (see issue #396).
+        """
+        lens = Optic()
+        lens.surfaces.add(index=0, thickness=10)
+        lens.surfaces.add(
+            index=1, thickness=7, radius=20.0, is_stop=True, material="N-SF11"
+        )
+        lens.surfaces.add(index=2, thickness=23.0)
+        lens.surfaces.add(index=3)
+        lens.set_aperture(aperture_type="EPD", value=20)
+        lens.fields.set_type(field_type="angle")
+        lens.fields.add(y=0)
+        lens.wavelengths.add(value=0.55, is_primary=True)
+        return lens
+
+    def test_rms_spot_size_nan_policy_propagate(self, set_test_backend):
+        data = {
+            "optic": self.create_tir_optic(),
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "wavelength": 0.55,
+            "num_rays": 5,
+        }
+        assert be.isnan(operand.RayOperand.rms_spot_size(**data))
+
+    def test_rms_spot_size_nan_policy_omit(self, set_test_backend):
+        data = {
+            "optic": self.create_tir_optic(),
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "wavelength": 0.55,
+            "num_rays": 5,
+            "nan_policy": "omit",
+        }
+        result = operand.RayOperand.rms_spot_size(**data)
+        assert not be.isnan(result)
+        assert_allclose(result, 10.27176337005003)
+
+    def test_rms_spot_size_nan_policy_raise(self, set_test_backend):
+        data = {
+            "optic": self.create_tir_optic(),
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "wavelength": 0.55,
+            "num_rays": 5,
+            "nan_policy": "raise",
+        }
+        with pytest.raises(ValueError, match="NaN ray intersection"):
+            operand.RayOperand.rms_spot_size(**data)
+
+    def test_rms_spot_size_invalid_nan_policy(self, set_test_backend, hubble):
+        data = {
+            "optic": hubble,
+            "surface_number": -1,
+            "Hx": 0.0,
+            "Hy": 1.0,
+            "wavelength": 0.55,
+            "num_rays": 100,
+            "nan_policy": "bogus",
+        }
+        with pytest.raises(ValueError, match="Invalid nan_policy"):
+            operand.RayOperand.rms_spot_size(**data)
+
     def test_opd_diff(self, set_test_backend, hubble):
         data = {
             "optic": hubble,


### PR DESCRIPTION
## Add nan_policy option to rms_spot_size operand (#396)

rms_spot_size returns NaN whenever some rays fail to reach the image surface (e.g. total internal reflection or vignetting), with no way to handle this short of manually filtering results outside the optimizer.

Adds a nan_policy kwarg, mirroring SciPy's convention:
- "propagate" (default): unchanged behavior -- returns NaN if any intersection is NaN.
- "omit": compute the RMS from the remaining valid rays.
- "raise": raise a ValueError instead of silently returning NaN.

While implementing this I found a latent backend inconsistency: the torch backend's be.mean() already silently ignores NaNs, while numpy's propagates them, so the old "propagate"-only behavior actually differed between backends on NaN input. rms_spot_size now reduces via be.nanmean and applies nan_policy explicitly, so all three policies are identical on both backends.

Closes #396.

Changes:
- RayOperand.rms_spot_size: add nan_policy param and backend-consistent NaN handling.
- Add regression tests for all three policies plus invalid-value handling, using the exact TIR repro from the issue.

Test plan:
- [x] pytest tests/test_operand.py -k rms_spot_size passes on both backends
- [x] ruff check clean on touched files