### PR TITLE
Expose variable scaling in LeastSquares

### DIFF
--- a/optiland/optimization/optimizer/scipy/least_squares.py
+++ b/optiland/optimization/optimizer/scipy/least_squares.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import optiland.backend as be
 from scipy import optimize
@@ -12,6 +12,8 @@ from ..live_plotter import LiveOptimizationPlotter
 from .base import OptimizerGeneric
 
 if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
     from ...problem import OptimizationProblem
 
 
@@ -69,17 +71,19 @@ class LeastSquares(OptimizerGeneric):
         tol: float = 1e-3,
         callback: Any = None,
         method_choice: str = "lm",  # Default to 'lm' for DLS
-    ):
+        x_scale: ArrayLike | float | Literal["jac"] | None = None,
+    ) -> optimize.OptimizeResult:
         """
         Optimize the problem using a SciPy least squares method.
 
         Args:
-            max_nfev (int, optional): Maximum number of function evaluations (NFEV).
-                                      SciPy's least_squares uses max_nfev.
+            maxiter (int, optional): Maximum number of function evaluations.
+                SciPy's least_squares uses max_nfev.
             disp (bool, optional): Whether to display optimization progress.
-            plot: If True, update live plots during optimization.
+            plot (bool, optional): If True, update live plots during optimization.
             tol (float, optional): Tolerance for termination (ftol - tolerance for the
                                    change in the sum of squares). Defaults to 1e-3.
+            callback (callable, optional): Called after each optimization iteration.
             method_choice (str, optional): Method for scipy.optimize.least_squares.
                                          'lm': Levenberg-Marquardt (DLS,
                                          does not support bounds).
@@ -88,6 +92,14 @@ class LeastSquares(OptimizerGeneric):
                                          'dogbox': Dogleg algorithm
                                          (supports bounds).
                                          Defaults to 'lm'.
+            x_scale (array-like, float, "jac", or None, optional): Characteristic
+                scale of each optimizer-space variable, after any Optiland variable
+                scaling. If set to "jac", SciPy updates the scale using inverse
+                Jacobian column norms. If None, the argument is omitted so the
+                installed SciPy version uses its existing default.
+
+        Returns:
+            OptimizeResult: The SciPy optimization result.
         """
 
         x0_scaled_values = [var.value for var in self.problem.variables]
@@ -171,6 +183,10 @@ class LeastSquares(OptimizerGeneric):
             if live_plotter is not None:
                 live_plotter.update()
 
+        least_squares_kwargs: dict[str, Any] = {}
+        if x_scale is not None:
+            least_squares_kwargs["x_scale"] = x_scale
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             result = optimize.least_squares(
@@ -182,6 +198,7 @@ class LeastSquares(OptimizerGeneric):
                 verbose=scipy_verbose_level,
                 ftol=tol,
                 callback=_wrapped_callback,
+                **least_squares_kwargs,
             )
 
         for i, optiland_var_wrapper in enumerate(self.problem.variables):

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import warnings
 
 import pytest
@@ -380,6 +381,43 @@ class TestLeastSquares:
             "'trf' method."  # Updated expected warning
         )
         assert expected_warning in captured.out
+
+    @pytest.mark.parametrize("x_scale", [None, "jac", 2.0, [2.0]])
+    def test_x_scale_forwarding(self, monkeypatch, x_scale):
+        lens = Microscope20x()
+        problem = optimization.OptimizationProblem()
+        problem.add_variable(lens, "conic", surface_number=1)
+        problem.add_operand(
+            operand_type="f2",
+            target=90,
+            weight=1.0,
+            input_data={"optic": lens},
+        )
+        least_squares_module = importlib.import_module(
+            "optiland.optimization.optimizer.scipy.least_squares"
+        )
+        scipy_least_squares = least_squares_module.optimize.least_squares
+        captured_kwargs = {}
+
+        def spy_least_squares(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return scipy_least_squares(*args, **kwargs)
+
+        monkeypatch.setattr(
+            least_squares_module.optimize,
+            "least_squares",
+            spy_least_squares,
+        )
+
+        optimizer = optimization.LeastSquares(problem)
+        optimize_kwargs = {} if x_scale is None else {"x_scale": x_scale}
+        result = optimizer.optimize(method_choice="trf", maxiter=10, **optimize_kwargs)
+
+        assert result.success
+        if x_scale is None:
+            assert "x_scale" not in captured_kwargs
+        else:
+            assert captured_kwargs["x_scale"] == x_scale
 
 
 class MockOperandNaN:


### PR DESCRIPTION
## Summary

- expose SciPy's optional `x_scale` argument through `LeastSquares.optimize()`
- support Jacobian-based, scalar, and array-like scaling values
- omit the keyword when `x_scale=None` so existing SciPy-version defaults remain unchanged
- document that `x_scale` applies after Optiland's variable scalers and add focused forwarding coverage

This implements the focused Jacobian-scaling suggestion discussed in #617 without changing the broader DLS or constraint architecture.

## Benchmark

For a two-variable residual with target scales of `1` and `1,000,000`, using the Optiland wrapper with `method_choice="trf"` and `maxiter=10`:

- default scaling stopped at `x[1] = 6.55` with cost `4.9999e-1`
- `x_scale="jac"` reached `x[1] = 999999.998` in 3 function evaluations with cost `1.90e-18`

## Validation

- `python -m pytest tests/test_optimization.py -q` (`45 passed`)
- `python -m pytest tests/test_optimization.py::TestLeastSquares -q` (`11 passed`)
- `python -m ruff check optiland/`
- `python -m ruff format --check optiland/optimization/optimizer/scipy/least_squares.py`

GUI optimization-service tests were not collected locally because the optional `PySide6` dependency is not installed.