### PR TITLE
fix(paraxial): add descriptive messages to bare ValueError raises

### DIFF
--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -356,8 +356,11 @@ class Paraxial:
         obj_z = self.surfaces.positions[1] - 10  # 10 mm before first surface
 
         if self.optic.object_surface is None:
-            # TODO: make some nice error message
-            raise ValueError()
+            raise ValueError(
+                "No object surface is defined on the optical system. The marginal "
+                "ray starts at the object, so an object surface is required. Add "
+                "one with `optic.add_surface(index=0, ...)`."
+            )
 
         if self.optic.object_surface.is_infinite:
             ya = EPD / 2
@@ -415,8 +418,11 @@ class Paraxial:
 
         # Scale based on field definition
         if field_definition is None:
-            # TODO: make some nice error message
-            raise ValueError()
+            raise ValueError(
+                "No field definition is set on the optical system. The chief ray "
+                "is scaled by the field, so a field type is required. Set one with "
+                '`optic.fields.set_type(...)`, e.g. "angle" or "object_height".'
+            )
 
         scaling_factor = field_definition.scale_chief_ray_for_field(
             self.optic, y_obj_unit, u_obj_unit, y_img_unit

--- a/tests/test_paraxial.py
+++ b/tests/test_paraxial.py
@@ -29,6 +29,7 @@ from optiland.samples.simple import (
     TelescopeDoublet,
 )
 from optiland.samples.telescopes import HubbleTelescope
+from optiland.surfaces.object_surface import ObjectSurface
 
 from .utils import assert_allclose
 
@@ -1273,3 +1274,26 @@ def test_equivalence(paraxial_surfaces, real_surfaces, set_test_backend):
         _get_paraxial_items(paraxial_lens.paraxial),
         _get_paraxial_items(real_lens.paraxial),
     )
+
+
+def test_marginal_ray_without_object_surface_raises_descriptive_error(
+    set_test_backend,
+):
+    lens = CookeTriplet()
+    lens.surfaces.surfaces = [
+        surface
+        for surface in lens.surfaces.surfaces
+        if not isinstance(surface, ObjectSurface)
+    ]
+    assert lens.object_surface is None
+
+    with pytest.raises(ValueError, match="No object surface is defined"):
+        lens.paraxial.marginal_ray()
+
+
+def test_chief_ray_without_field_definition_raises_descriptive_error(set_test_backend):
+    lens = CookeTriplet()
+    lens.fields.field_definition = None
+
+    with pytest.raises(ValueError, match="No field definition is set"):
+        lens.paraxial.chief_ray()


### PR DESCRIPTION
Closes #700

`Paraxial.marginal_ray()` raised a bare `ValueError()` when the system had no object surface, and `Paraxial.chief_ray()` did the same when no field definition was set — both carried a `# TODO: make some nice error message` comment, so users saw an empty `ValueError:` with no clue what was missing. Each raise now names the missing piece and the API call that supplies it.

Two regression tests were added to `tests/test_paraxial.py` next to the existing paraxial tests; they fail on the original bare raises (empty message) and pass with the fix. Full `tests/test_paraxial.py` is green (1162 passed), `ruff check` and `ruff format` clean on the changed source.

This change was prepared with AI assistance; the regression tests were run locally and fail without the fix.
