### PR TITLE
docs(authors): add missing contributors

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -43,6 +43,10 @@ We sincerely appreciate the contributions of the following individuals, whose ef
 - **Nikita Vladimirov** (`GitHub <https://github.com/nvladimus>`_)
 - **Michele Castriotta** (`GitHub <https://github.com/mikics>`_)
 - **Abu Hossain Foysal** (`GitHub <https://github.com/ahfoysal>`_)
+- **Georg Ramer** (`GitHub <https://github.com/GeorgRamer>`_)
+- **Sanjay Santhanam** (`GitHub <https://github.com/Sanjays2402>`_)
+- **Ashish Verma** (`GitHub <https://github.com/ashishv-git>`_)
+- **Anthony Beaucamp** (`GitHub <https://github.com/8bit-Dude>`_)
 
 
 Your contributions, whether in the form of code, documentation, feedback, or discussions, are what make **Optiland** better for everyone.


### PR DESCRIPTION
Adds Georg Ramer, Sanjay Santhanam, Ashish Verma, and Anthony Beaucamp to authors.rst — they had merged contributions per GitHub's contributor graph but weren't listed yet.