### PR TITLE
fix(fileio): write reflective surfaces as GLAS MIRROR in .zmx export

### DIFF
--- a/optiland/fileio/zemax/writer/formatter.py
+++ b/optiland/fileio/zemax/writer/formatter.py
@@ -286,9 +286,12 @@ class OpticToZemaxConverter:
         if surface.aperture is not None:
             raw["CLAP"] = surface.aperture
 
-        # Glass
+        # Glass — check the reflective flag first (mirror)
+        is_reflective = getattr(
+            getattr(surface, "interaction_model", None), "is_reflective", False
+        )
         glass_entry = self._format_glass(
-            surface.material_post, output_idx, glass_catalogs
+            surface.material_post, output_idx, glass_catalogs, is_reflective
         )
         if glass_entry is not None:
             raw["GLAS"] = glass_entry
@@ -300,6 +303,7 @@ class OpticToZemaxConverter:
         mat: Any,
         surf_idx: int,
         glass_catalogs: list[str],
+        is_reflective: bool = False,
     ) -> dict[str, Any] | None:
         """Build a GLAS operand dict for a material.
 
@@ -307,15 +311,22 @@ class OpticToZemaxConverter:
             mat: The surface material (post).
             surf_idx: Output surface index (used in warnings).
             glass_catalogs: Mutable list to accumulate catalog names.
+            is_reflective: True if the surface is a reflective (mirror) surface.
 
         Returns:
             A dict with keys ``name`` and optionally ``catalog``,
             or None for air.
         """
+        # Mirror surface — detected via interaction_model.is_reflective. This must
+        # precede the air check: the material following a mirror is the ambient
+        # medium, so is_air() is True for a mirror in air.
+        if is_reflective:
+            return {"name": "MIRROR"}
+
         if is_air(mat):
             return None
 
-        # Mirror
+        # Mirror material string fallback
         if isinstance(mat, str) and mat.lower() == "mirror":
             return {"name": "MIRROR"}
 

--- a/tests/test_fileio/test_zemax_writer.py
+++ b/tests/test_fileio/test_zemax_writer.py
@@ -159,6 +159,51 @@ class TestRoundTripFloaAperture:
 
 
 # ---------------------------------------------------------------------------
+# Round-trip: reflective (mirror) surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripMirror:
+    """Reflective surfaces must be written as ``GLAS MIRROR``.
+
+    Regression: mirrors were previously detected only by comparing the material
+    against the string ``"mirror"``, which never matched because the material has
+    already been resolved to an object by then. The mirrors were silently dropped
+    and the reloaded system was not an imaging system at all.
+    """
+
+    def test_mirror_surfaces_written(self, set_test_backend):
+        from optiland.samples.telescopes import HubbleTelescope
+
+        model = OpticToZemaxConverter(HubbleTelescope()).convert()
+        mirrors = [
+            s
+            for s in model.surfaces.values()
+            if s.get("GLAS", {}).get("name") == "MIRROR"
+        ]
+        assert len(mirrors) == 2
+
+    def test_roundtrip_preserves_focal_length(self, tmp_path, set_test_backend):
+        from optiland.samples.telescopes import HubbleTelescope
+
+        original = HubbleTelescope()
+        out = tmp_path / "hubble.zmx"
+        save_zemax_file(original, str(out))
+        reloaded = load_zemax_file(str(out))
+
+        assert_allclose(original.paraxial.f2(), reloaded.paraxial.f2(), rtol=1e-6)
+
+    def test_roundtrip_preserves_surfaces(self, tmp_path, set_test_backend):
+        from optiland.samples.telescopes import HubbleTelescope
+
+        original = HubbleTelescope()
+        out = tmp_path / "hubble.zmx"
+        save_zemax_file(original, str(out))
+        reloaded = load_zemax_file(str(out))
+        _surfaces_match(original, reloaded)
+
+
+# ---------------------------------------------------------------------------
 # Warning: MODEL glass
 # ---------------------------------------------------------------------------
 
@@ -315,6 +360,7 @@ class TestOpticToZemaxConverterExtended:
 # GLAS encoding
 # ---------------------------------------------------------------------------
 
+
 class TestGlasEncoding:
     def test_encode_catalog_glass(self):
         from optiland.fileio.zemax.writer.encoder import ZemaxFileEncoder
@@ -342,4 +388,6 @@ class TestGlasEncoding:
         glas = {"name": "MODEL", "n": 1.5, "V": 50.0}
         res = encoder._encode_glas(glas)
         # Use startswith to allow for exact scientific notation format
-        assert res.startswith("  GLAS MODEL 1 0 1.50000000E+00 5.00000000E+01 0 0 0 0 0 0")
+        assert res.startswith(
+            "  GLAS MODEL 1 0 1.50000000E+00 5.00000000E+01 0 0 0 0 0 0"
+        )


### PR DESCRIPTION
## Problem

`save_zemax_file` silently drops mirrors. The formatter detected them with:

```python
if isinstance(mat, str) and mat.lower() == "mirror":
```

but by that point the material has been resolved to an object, not a string, so the branch was dead. Reflective surfaces were written with no `GLAS` operand at all — i.e. as air.

The exported file is therefore not the same optical system. Round-tripping the Hubble sample:

```python
save_zemax_file(HubbleTelescope(), "hubble.zmx")
load_zemax_file("hubble.zmx").paraxial.f2()   # -inf, vs 57600.081 for the original
```

Found while preparing reference systems for a community validation exercise against commercial tools — the attached `.zmx` files for reflective systems would have been unusable.

## Fix

Detect reflective surfaces via `interaction_model.is_reflective`, which is what the CODE V writer already does (`codev/writer/formatter.py`), and check it **before** `is_air()`. That ordering matters: the material following a mirror is the ambient medium, so `is_air()` returns `True` for a mirror in air and would return early. The string comparison is kept as a fallback.

The encoder already knew how to emit `GLAS MIRROR` — only the formatter needed changing.

## Verification

Hubble round-trip EFL now `57600.0810` → `57600.0799` (1.8e-8 relative; the residual is `CURV` write precision, not the mirror path).

Three new tests in `TestRoundTripMirror`: both mirrors present in the converted model, EFL preserved on round-trip, and surface radii/thicknesses preserved. `tests/test_fileio/` passes in full (200 tests, both backends); `ruff check optiland/` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)