### PR TITLE
feat: material gen robustness & clarity

### DIFF
--- a/optiland/materials/registry.py
+++ b/optiland/materials/registry.py
@@ -396,7 +396,7 @@ class MaterialRegistry:
             )
         else:
             self._apply_match_policy_without_catalog(
-                filtered_df, name, match_policy, best_score
+                filtered_df, name, match_policy, best_score, ambiguous_exact
             )
 
     def _apply_match_policy_with_catalog(
@@ -428,22 +428,49 @@ class MaterialRegistry:
         name: str,
         match_policy: MatchPolicy,
         best_score: float,
+        ambiguous_exact: bool = False,
     ) -> None:
         """Apply ``match_policy`` when resolution spans all catalogs."""
         if match_policy == MatchPolicy.STRICT:
+            if ambiguous_exact:
+                catalogs = sorted(
+                    filtered_df.loc[
+                        filtered_df["similarity_score"] == 0, "catalog_dir"
+                    ].unique()
+                )
+                raise ValueError(
+                    f"Material '{name}' matches exactly in multiple catalogs: "
+                    f"{catalogs}. Pass catalog=<name> to disambiguate."
+                )
             top = filtered_df.head(5)["name"].tolist()
             raise ValueError(
                 f"No exact match for material '{name}'. "
                 f"Top candidates: {top}. "
                 "Use match_policy='warn' or 'best' for fuzzy matching."
             )
-        if match_policy == MatchPolicy.WARN and best_score > 0:
-            resolved = filtered_df.iloc[0]["name"]
-            warnings.warn(
-                f"Material '{name}' resolved to '{resolved}' via fuzzy match.",
-                OptilandMaterialWarning,
-                stacklevel=6,
-            )
+        if match_policy == MatchPolicy.WARN:
+            if best_score > 0:
+                resolved = filtered_df.iloc[0]["name"]
+                warnings.warn(
+                    f"Material '{name}' resolved to '{resolved}' via fuzzy match.",
+                    OptilandMaterialWarning,
+                    stacklevel=6,
+                )
+            elif ambiguous_exact:
+                catalogs = sorted(
+                    filtered_df.loc[
+                        filtered_df["similarity_score"] == 0, "catalog_dir"
+                    ].unique()
+                )
+                resolved_catalog = filtered_df.iloc[0]["catalog_dir"]
+                warnings.warn(
+                    f"Material '{name}' matches exactly in multiple catalogs "
+                    f"{catalogs}; resolved to catalog '{resolved_catalog}'. "
+                    "Pass catalog=<name> to disambiguate and silence this "
+                    "warning.",
+                    OptilandMaterialWarning,
+                    stacklevel=6,
+                )
 
     def _row_to_path(self, row: dict) -> str:
         """Resolve a matched row's ``filename`` to an absolute path."""

--- a/tests/test_materials_pr1.py
+++ b/tests/test_materials_pr1.py
@@ -138,6 +138,36 @@ class TestMatchPolicy:
         mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
         assert len(mat_warns) == 0
 
+    def test_ambiguous_exact_match_warns_by_default(self):
+        """An exact name matching multiple catalogs (e.g. 'F5') warns under
+        the default WARN policy, even though the match itself is exact."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mat = Material("F5")
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) >= 1
+        assert "multiple catalogs" in str(mat_warns[0].message)
+        # Still resolves to a usable material (first match, deterministically).
+        assert mat.name == "F5"
+
+    def test_ambiguous_exact_match_strict_raises(self):
+        """An exact name matching multiple catalogs raises under STRICT."""
+        with pytest.raises(ValueError, match="multiple catalogs"):
+            Material("F5", match_policy=MatchPolicy.STRICT)
+
+    def test_ambiguous_exact_match_best_silent(self):
+        """match_policy='best' silently resolves an ambiguous exact match."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Material("F5", match_policy=MatchPolicy.BEST)
+        mat_warns = [x for x in w if issubclass(x.category, OptilandMaterialWarning)]
+        assert len(mat_warns) == 0
+
+    def test_ambiguous_exact_match_resolved_with_catalog(self):
+        """Passing catalog= disambiguates and yields the correct glass data."""
+        mat = Material("F5", catalog="cdgm")
+        assert pytest.approx(mat.n(0.5876), abs=1e-3) == 1.6243
+
 
 # ---------------------------------------------------------------------------
 # robust_search deprecation


### PR DESCRIPTION
- This PR simply adds a warning when a material is instantiated based on a given string and there aer multiple matches, making the material model ambigous. This avoids the situation where a user might expect they're using glass from a given manufacturer, when in fact the glass is based on some other manufacturer data.