### PR TITLE
fix(fileio): write .zmx floats at full float64 precision

### DIFF
--- a/optiland/fileio/zemax/writer/encoder.py
+++ b/optiland/fileio/zemax/writer/encoder.py
@@ -35,8 +35,16 @@ _FIELD_TYPE_TO_FTYP: dict[str, int] = {
 
 
 def _fmt(value: float) -> str:
-    """Format a float in Zemax scientific notation."""
-    return f"{value:.8E}"
+    """Format a float in Zemax scientific notation.
+
+    Uses 17 significant digits, the IEEE-754 binary64 round-trip guarantee, so
+    that ``save_zemax_file`` followed by ``load_zemax_file`` reproduces the
+    original system bit-for-bit. The previous ``%.8E`` (9 significant digits)
+    was lossy enough to matter: on ``HubbleTelescope`` (EFL ~5.76e4) a single
+    save/load shifted real-ray image-surface intercepts by 1.8e-06 mm, which
+    exceeds the 1e-06 mm agreement threshold used for cross-tool validation.
+    """
+    return f"{value:.16E}"
 
 
 def _fmt_vals(values: list[float]) -> str:

--- a/tests/test_fileio/test_zemax_writer.py
+++ b/tests/test_fileio/test_zemax_writer.py
@@ -387,7 +387,109 @@ class TestGlasEncoding:
         encoder = ZemaxFileEncoder(ZemaxDataModel())
         glas = {"name": "MODEL", "n": 1.5, "V": 50.0}
         res = encoder._encode_glas(glas)
-        # Use startswith to allow for exact scientific notation format
-        assert res.startswith(
-            "  GLAS MODEL 1 0 1.50000000E+00 5.00000000E+01 0 0 0 0 0 0"
-        )
+        # Compare parsed values rather than the rendered text, so the assertion
+        # survives a change to the formatter's digit count.
+        tokens = res.split()
+        assert tokens[:4] == ["GLAS", "MODEL", "1", "0"]
+        assert float(tokens[4]) == 1.5
+        assert float(tokens[5]) == 50.0
+        assert tokens[6:] == ["0"] * 6
+
+
+# ---------------------------------------------------------------------------
+# Writer precision
+# ---------------------------------------------------------------------------
+
+
+def _precision_sample(name: str) -> Optic:
+    """Build a sample system in memory (never via a file)."""
+    if name == "hubble":
+        from optiland.samples.telescopes import HubbleTelescope
+
+        return HubbleTelescope()
+    if name == "cooke":
+        from optiland.samples.objectives import CookeTriplet
+
+        return CookeTriplet()
+    from optiland.samples.objectives import DoubleGauss
+
+    return DoubleGauss()
+
+
+def _image_intercept(optic: Optic, Hx, Hy, Px, Py, wavelength):
+    """Trace one ray and return its (x, y, L, M) at the image surface."""
+    rays = optic.trace_generic(Hx, Hy, Px, Py, wavelength)
+    return tuple(
+        float(be.to_numpy(getattr(rays, attr)).reshape(-1)[-1]) for attr in "xyLM"
+    )
+
+
+# CookeTriplet is deliberately absent: its glasses are declared with explicit
+# catalogs (``("SK16", "hikari")``, ``("F2", "schott")``) but ``GLAS`` is written
+# without a catalog tag, so the reader re-resolves them ambiguously and the
+# reloaded system uses different dispersion data. That shifts EFL by ~1.2e-05
+# relative, three orders above anything the float formatter can cause, and is a
+# separate defect from the precision this class covers.
+_PRECISION_SAMPLES = ["hubble", "double_gauss"]
+
+# (Hx, Hy, Px, Py) — on-axis marginal, full-field chief, and a skew ray.
+_PRECISION_RAYS = [(0.0, 0.0, 0.0, 0.7), (0.0, 1.0, 0.0, 0.0), (0.0, 0.7, 0.7, 0.0)]
+
+
+class TestWriterPrecision:
+    """A saved .zmx must reproduce the system it was written from.
+
+    The other round-trip tests in this module start from a .zmx on disk, so both
+    sides of the comparison have already been through the writer's float
+    formatting once and any precision loss cancels out. These start from an
+    in-memory sample instead, which is what actually exercises the formatter.
+
+    Regression: ``_fmt`` used ``%.8E`` (9 significant digits). On
+    ``HubbleTelescope`` (EFL ~5.76e4, R = -11040.02286 so CURV =
+    9.05795225862422e-05 written as ``-9.05795226E-05``) one save/load shifted
+    EFL by 1.1e-03 mm and real-ray image-surface intercepts by 1.8e-06 mm. That
+    exceeds the 1e-06 mm threshold used when validating Optiland against
+    OpticStudio and CODE V, so the writer was manufacturing apparent
+    disagreements that had nothing to do with the tracing.
+    """
+
+    def _reload(self, optic: Optic, tmp_path) -> Optic:
+        out = tmp_path / "precision.zmx"
+        save_zemax_file(optic, str(out))
+        return load_zemax_file(str(out))
+
+    @pytest.mark.parametrize("sample_name", _PRECISION_SAMPLES)
+    def test_paraxial_survives_round_trip(
+        self, sample_name, tmp_path, set_test_backend
+    ):
+        original = _precision_sample(sample_name)
+        reloaded = self._reload(original, tmp_path)
+        for quantity in ("f2", "EPD", "FNO", "EPL", "XPD"):
+            assert_allclose(
+                getattr(original.paraxial, quantity)(),
+                getattr(reloaded.paraxial, quantity)(),
+                rtol=1e-12,
+            )
+
+    @pytest.mark.parametrize("sample_name", _PRECISION_SAMPLES)
+    def test_real_rays_survive_round_trip(
+        self, sample_name, tmp_path, set_test_backend
+    ):
+        original = _precision_sample(sample_name)
+        reloaded = self._reload(original, tmp_path)
+        wavelength = original.primary_wavelength
+        for Hx, Hy, Px, Py in _PRECISION_RAYS:
+            before = _image_intercept(original, Hx, Hy, Px, Py, wavelength)
+            after = _image_intercept(reloaded, Hx, Hy, Px, Py, wavelength)
+            for a, b in zip(before, after, strict=True):
+                assert math.isclose(a, b, rel_tol=0.0, abs_tol=1e-9), (
+                    f"{sample_name} H=({Hx},{Hy}) P=({Px},{Py}): "
+                    f"{a!r} != {b!r} after save/load"
+                )
+
+    def test_formatter_round_trips_a_hard_value(self):
+        """The formatter itself must not lose bits."""
+        from optiland.fileio.zemax.writer.encoder import _fmt
+
+        for value in (9.05795225862422e-05, -11040.02286, 1.0 / 3.0, 6365.20955):
+            assert float(_fmt(value)) == value


### PR DESCRIPTION
Found while working on #710. The `.zmx` writer is lossy enough that the validation files attached to that issue produce apparent disagreements which have nothing to do with the tracing.

## The problem

`_fmt` in `optiland/fileio/zemax/writer/encoder.py` formats every float as `%.8E` — 9 significant digits. For `HubbleTelescope`, R = -11040.02286 gives CURV = 9.05795225862422e-05, written as `-9.05795226E-05`. With EFL ≈ 5.76e+04 that truncation is amplified into:

| Quantity | sample | after one `save_zemax_file` → `load_zemax_file` | Δ |
|---|---|---|---|
| EFL | 57600.0809984 | 57600.0799477 | -1.05e-03 |
| ray y, H=(0,0) P=(0,0.7) | 2.2433657045e-04 | 2.2255091906e-04 | **-1.786e-06** |

That last figure exceeds the 1e-06 mm agreement threshold #710 sets for real-ray intercepts. `CONI`, `DISZ` and the aperture values go through the same formatter, so this is not specific to curvature.

## Why it matters for #710

The reference column in #710 is generated from the Python samples, but contributors trace the attached `.zmx`. Those are not quite the same system. Cross-checking the Hubble against **Ansys Zemax OpticStudio 2023 R1.02** over the six rays in that issue's table:

| Comparison | max Δ |
|---|---|
| OpticStudio ↔ Optiland, both reading `hubble.zmx` | **5.0e-09** |
| OpticStudio ↔ the sample values printed in #710 | up to **2.6e-06** |

Five of the six rows appear to miss the tolerance, while the two independent implementations actually agree to 5e-09. The natural reading of that table is "Optiland's mirror handling is off by a couple of microns", which is backwards.

## The fix, verified end-to-end

Switch `_fmt` to `%.16E`. 17 significant decimal digits is the IEEE-754 binary64 round-trip guarantee, so the writer becomes lossless by construction rather than merely accurate enough. Measured residual on the Hubble H=(0,0) P=(0,0.7) intercept after one save/load:

| `_fmt` | significant digits | Δ vs sample |
|---|---|---|
| `.8E` (current) | 9 | -1.79e-06 |
| `.10E` | 11 | +2.04e-08 |
| `.12E` | 13 | +2.17e-10 |
| `.14E` | 15 | +1.35e-12 |
| **`.16E`** | **17** | **0 — exact** |

`.12E` would already be comfortable; `.16E` retires the question.

This is confirmed outside Optiland, not just in a round-trip. I regenerated `hubble.zmx` with the patched writer and re-traced all six rays in OpticStudio, comparing against the sample values in #710:

| H, P | Δ with the attached file | Δ with the `.16E` file |
|---|---|---|
| (0,0) (0,1) | 2.52e-06 | **2.4e-12** |
| (0,0) (0,0.7) | 1.79e-06 | **3.2e-11** |
| (0,1) (0,0) | 6.76e-08 | 2.4e-09 |
| (0,1) (0,1) | 2.56e-06 | **3.0e-09** |
| (0,1) (0,-1) | 2.43e-06 | **2.0e-09** |
| (0,0.7) (0.7,0) | 1.78e-06 | **5.4e-10** |

Every row now lands inside 3e-09; the remaining residual is OpticStudio's own print precision. OpticStudio parses the longer mantissa without complaint.

## Tests

Added `TestWriterPrecision`, which builds its systems **in memory** rather than loading a `.zmx` first. That distinction is the whole point: every existing round-trip test in the module starts from a file, so both sides of the comparison have already been through the formatter and the loss cancels out. `TestRoundTripMirror::test_roundtrip_preserves_focal_length` does start in memory, but at `rtol=1e-6` it cannot see a 1.8e-08 relative shift. That is why this went unnoticed.

The new tests assert paraxial quantities to `rtol=1e-12` and real-ray intercepts to `atol=1e-9`, plus a direct check that `_fmt` itself round-trips a few hard values. Verified they fail on `%.8E` (7 failures) and pass on `%.16E`.

`CookeTriplet` is deliberately excluded from the parametrization, with the reason recorded in the test. Its glasses carry explicit catalogs — `("SK16", "hikari")`, `("F2", "schott")` — but the catalog binding is per-file (`GCAT`) rather than per-surface, so on reload `F2` re-resolves to Hikari and the system's EFL moves by ~1.2e-05 relative, three orders above anything the formatter can cause. That is a separate defect, now filed as #713 — which also covers the fact that the `cooke_triplet.zmx` attached to #710 declares `GCAT SCHOTT` while its SK16 elements need Hikari, putting its real-ray rows ~69x outside that issue's tolerance.

Also changed the `GLAS MODEL` encoding assertion to compare parsed values rather than the rendered string, so it no longer depends on the formatter's digit count.

## Checks

- `ruff check optiland/` — passes
- `ruff format --check optiland/` — passes
- `pytest tests/test_fileio/` — 209 passed

Branched from `master` at 6e53f16d.
