### PR TITLE
fix(aberrations): difference chromatic terms over the system's own wavelengths

### DIFF
--- a/optiland/aberrations/third_order.py
+++ b/optiland/aberrations/third_order.py
@@ -140,13 +140,35 @@ class ThirdOrderAberrations:
         terms = [term_func(k) for k in range(1, self._N - 1)]
         return be.array(terms)
 
+    def _dispersion_wavelengths(self) -> tuple[float, float]:
+        """Return the (short, long) wavelengths used for the chromatic terms.
+
+        The chromatic aberration coefficients differentiate the system between
+        two wavelengths. Those have to be wavelengths the system is actually
+        specified over: an infrared design differenced across the visible F and
+        C lines produces a meaningless number, and for many infrared glasses
+        there is no refractive index data at 0.4861 µm to evaluate in the first
+        place.
+
+        Uses the extremes of the system's own wavelength set, falling back to
+        the primary wavelength when only one is defined — in which case the
+        chromatic terms are identically zero, which is the correct answer for a
+        monochromatic system.
+        """
+        values = [float(be.to_numpy(w.value)) for w in self._optic.wavelengths]
+        if not values:  # pragma: no cover - an Optic always carries one
+            primary = float(self._optic.primary_wavelength)
+            return primary, primary
+        return min(values), max(values)
+
     def _precalculations(self) -> None:
         self._inv: float = self._optic.paraxial.invariant()
         self._on_axis = be.isclose(self._inv, be.array(0.0))
         self._n = self._signed_refractive_indices(self._optic.primary_wavelength)
-        n_F = self._signed_refractive_indices(0.4861)
-        n_C = self._signed_refractive_indices(0.6563)
-        self._dn = n_F - n_C
+        short, long = self._dispersion_wavelengths()
+        self._dn = self._signed_refractive_indices(
+            short
+        ) - self._signed_refractive_indices(long)
 
         self._N: int = self._optic.surfaces.num_surfaces
         self._C = 1 / self._optic.surfaces.radii

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -173,8 +173,8 @@ class TestEdmundSinglet:
         assert_allclose(be.sum(TPC), -0.2211799550187673)
         assert_allclose(be.sum(PC), -0.4423180410800838)
         assert_allclose(be.sum(DC), -0.020852935715656093)
-        assert_allclose(be.sum(TAchC), -0.4947549112756089)
-        assert_allclose(be.sum(LchC), -0.9894161663592405)
+        assert_allclose(be.sum(TAchC), -0.4945483282964331)
+        assert_allclose(be.sum(LchC), -0.9890030395066657)
         assert_allclose(be.sum(TchC), 0.0)
         assert_allclose(S[0], -1.730769175588275)
         assert_allclose(S[1], 0.14253720449059704)
@@ -205,8 +205,8 @@ class TestEdmundSinglet:
         assert_allclose(be.sum(TPC), -0.2211799550187673)
         assert_allclose(be.sum(PC), -0.4423180410800838)
         assert_allclose(be.sum(DC), -0.020852935715656093)
-        assert_allclose(be.sum(TAchC), -0.4947549112756089)
-        assert_allclose(be.sum(LchC), -0.9894161663592405)
+        assert_allclose(be.sum(TAchC), -0.4945483282964331)
+        assert_allclose(be.sum(LchC), -0.9890030395066657)
         assert_allclose(be.sum(TchC), 0.0)
 
 
@@ -235,9 +235,9 @@ class TestSingletStopTwo:
         assert_allclose(be.sum(TPC), -0.028095789481046744)
         assert_allclose(be.sum(PC), -0.22814191470407064)
         assert_allclose(be.sum(DC), 0.006717305986964978)
-        assert_allclose(be.sum(TAchC), -0.2286190741226864)
-        assert_allclose(be.sum(LchC), -1.8564202776151473)
-        assert_allclose(be.sum(TchC), 0.011126795737552403)
+        assert_allclose(be.sum(TAchC), -0.2285273536218734)
+        assert_allclose(be.sum(LchC), -1.85567549375039)
+        assert_allclose(be.sum(TchC), 0.01112233173873076)
         assert_allclose(S[0], -0.0326050034268675)
         assert_allclose(S[1], -0.0004386784359568394)
         assert_allclose(S[2], -0.01142479550599207)
@@ -267,9 +267,9 @@ class TestSingletStopTwo:
         assert_allclose(be.sum(TPC), -0.028095789481046744)
         assert_allclose(be.sum(PC), -0.22814191470407064)
         assert_allclose(be.sum(DC), 0.006717305986964978)
-        assert_allclose(be.sum(TAchC), -0.2286190741226864)
-        assert_allclose(be.sum(LchC), -1.8564202776151473)
-        assert_allclose(be.sum(TchC), 0.011126795737552403)
+        assert_allclose(be.sum(TAchC), -0.2285273536218734)
+        assert_allclose(be.sum(LchC), -1.85567549375039)
+        assert_allclose(be.sum(TchC), 0.01112233173873076)
 
 
 class TestSimpleSinglet:
@@ -339,3 +339,78 @@ class TestReflectiveSystemSeidels:
                 7.59541065e-04,
             ],
         )
+
+
+class TestChromaticDispersionWavelengths:
+    """The chromatic terms must differentiate over the system's own wavelengths.
+
+    Regression: ``_precalculations`` evaluated the dispersion as
+    ``n(0.4861) - n(0.6563)`` regardless of what the system defined. That is
+    silently wrong for anything not specified on the visible F and C lines, and
+    for an infrared design it is worse than wrong — most infrared glasses carry
+    no refractive index data at 0.4861 µm to evaluate at all.
+
+    ``CookeTriplet`` is specified at 0.48 / 0.55 / 0.65, close enough to the
+    hardcoded lines to look plausible and far enough to matter: its ``LchC``
+    moved by 7.9% when the hardcoding was removed.
+    """
+
+    def _sum(self, value):
+        return float(be.to_numpy(value).reshape(-1).sum())
+
+    def test_uses_defined_wavelengths_not_fc_lines(self, set_test_backend):
+        """Shifting the wavelength set must move the chromatic terms."""
+        from optiland.samples.objectives import CookeTriplet
+
+        wide = CookeTriplet()
+        narrow = CookeTriplet()
+        narrow.wavelengths.wavelengths = []
+        for value, primary in ((0.53, False), (0.55, True), (0.57, False)):
+            narrow.add_wavelength(value=value, is_primary=primary)
+
+        wide_lchc = self._sum(wide.aberrations.LchC())
+        narrow_lchc = self._sum(narrow.aberrations.LchC())
+
+        # A quarter of the spectral interval must not give the same answer.
+        assert abs(narrow_lchc) < abs(wide_lchc) / 2, (
+            f"LchC barely moved when the wavelength range shrank from "
+            f"0.48-0.65 to 0.53-0.57: {wide_lchc} vs {narrow_lchc}. The "
+            f"dispersion is probably being evaluated at fixed wavelengths "
+            f"again."
+        )
+
+    def test_monochromatic_system_has_no_chromatic_aberration(self, set_test_backend):
+        """One wavelength means no dispersion to difference across."""
+        from optiland.samples.telescopes import HubbleTelescope
+
+        hubble = HubbleTelescope()  # single wavelength, 0.55 µm
+        assert self._sum(hubble.aberrations.LchC()) == pytest.approx(0.0, abs=1e-12)
+        assert self._sum(hubble.aberrations.TchC()) == pytest.approx(0.0, abs=1e-12)
+
+    def test_infrared_system_is_not_evaluated_on_visible_lines(self, set_test_backend):
+        """A long-wave infrared system must use its own wavelengths.
+
+        Germanium is essentially non-dispersive over 8-12 um in the shipped
+        data, so the correct axial colour for this lens is zero. Evaluating the
+        dispersion on the visible F and C lines instead borrows a refractive
+        index swing the system never sees and reports 5.76 mm of axial colour
+        -- with no error and no warning, which is the dangerous part.
+        """
+        from optiland.optic import Optic
+
+        lens = Optic()
+        lens.add_surface(index=0, thickness=be.inf)
+        lens.add_surface(
+            index=1, radius=100.0, thickness=6.0, material="germanium", is_stop=True
+        )
+        lens.add_surface(index=2, radius=-300.0, thickness=95.0)
+        lens.add_surface(index=3)
+        lens.set_aperture(aperture_type="EPD", value=20)
+        lens.set_field_type(field_type="angle")
+        lens.add_field(y=0)
+        lens.add_field(y=2)
+        lens.add_wavelength(value=8.0)
+        lens.add_wavelength(value=10.0, is_primary=True)
+        lens.add_wavelength(value=12.0)
+
+        assert self._sum(lens.aberrations.LchC()) == pytest.approx(0.0, abs=1e-9)


### PR DESCRIPTION
Found while cross-checking the Seidel sums against OpticStudio for #710.

`_precalculations` evaluates the dispersion as `n(0.4861) - n(0.6563)` regardless of what the optic defines:

```python
n_F = self._signed_refractive_indices(0.4861)
n_C = self._signed_refractive_indices(0.6563)
self._dn = n_F - n_C
```

The chromatic coefficients are a difference between two wavelengths, so those have to be wavelengths the system is actually specified over.

## Two ways this goes wrong, both silent

**Visible systems that aren't on the F and C lines.** `CookeTriplet` is specified at 0.48 / 0.55 / 0.65 — close enough to the hardcoded lines to look fine, far enough to matter:

| | `LchC` | `TchC` |
|---|---|---|
| Hardcoded 0.4861 / 0.6563 | 0.238325 | -0.026779 |
| The system's own 0.48 / 0.65 | **0.257127** | **-0.027873** |
| | 7.9% | 4.1% |

The first row is what's published as the System 2 reference in #710.

**Systems outside the visible.** A long-wave infrared germanium singlet at 8 / 10 / 12 µm has essentially no axial colour, because germanium is non-dispersive across that band in the shipped data (n = 4.653 at all three). Evaluating on the visible lines borrows an index swing of 0.4 that the system never sees:

| | `LchC` |
|---|---|
| The system's own 8–12 µm | **0.000000** — correct, no dispersion means no colour |
| Hardcoded visible lines | **5.759895** |

No error, no warning, just a number that looks like an answer. And germanium is the benign case: for many infrared glasses there is no refractive index data at 0.4861 µm at all.

## The fix

Use the extremes of `optic.wavelengths`, falling back to the primary wavelength when only one is defined — which makes the chromatic terms identically zero, the correct answer for a monochromatic system.

## Reference values that move

| Sample | Change | Why |
|---|---|---|
| `CookeTriplet` | 7.9% / 4.1% | Specified at 0.48 / 0.65 |
| `Edmund_49_847`, `SingletStopSurf2` | 0.04% | Specified on the *precise* F and C lines (0.4861327 / 0.6562725) while the hardcoded literals were rounded |
| `DoubleGauss` | none | Specified at exactly 0.4861 / 0.6563, so the two intervals coincide |

I've updated the affected golden values in `tests/test_aberrations.py` — only the three chromatic assertions per system. **Every monochromatic coefficient (TSC, SC, CC, TCC, TAC, AC, TPC, PC, DC) is bit-identical on every sample**, which is the check that the change is confined to the chromatic path rather than perturbing the paraxial trace.

You may want to regenerate the chromatic rows for System 1 and System 2 in #710 after this lands.

## Tests

`TestChromaticDispersionWavelengths` pins three properties:

- Shrinking a system's spectral range must shrink its axial colour (quarter the interval, less than half the aberration).
- A monochromatic system reports exactly zero.
- The LWIR case above does not pick up visible-band dispersion.

Verified all three fail with the hardcoding restored.

## Checks

- `ruff check optiland/` / `ruff format` — pass
- `pytest tests/test_aberrations.py` — 38 passed
- `pytest tests/ -k "aberration or seidel or chromatic or third_order"` — 110 passed, 1 skipped

Branched from `master` at bc9566a5.

---

Separately, and not part of this PR: I still can't reconcile `LchC` / `TchC` against OpticStudio's chromatic columns on the Double Gauss, and the remaining difference isn't explained by this fix — that system's wavelengths are exactly the hardcoded ones, so its values don't change here. I'll write that up on #710 with what I've eliminated; the short version is that per-surface `TSC` matches your `TSPH` to the printed resolution on every surface while the chromatic rows are off by 900 to 31,000 times that, and the ratio isn't constant across surfaces with identical media, so it isn't a convention factor either.
