### PR TITLE
fix(aberrations): use the ray height at the surface in the chromatic terms

### DIFF
--- a/optiland/aberrations/third_order.py
+++ b/optiland/aberrations/third_order.py
@@ -231,21 +231,27 @@ class ThirdOrderAberrations:
         )
         return spherical + self._get_conic_term(k, p_ya=1, p_yb=3)
 
-    def _TAchC_term(self, k: int) -> BEArray:
+    def _chromatic_prefactor(self, k: int) -> BEArray:
+        """Shared factor of the two chromatic terms at surface ``k``.
+
+        Note the two different index bases in play. ``_ya`` is the full
+        marginal-ray array returned by ``paraxial.marginal_ray()``, indexed by
+        surface with ``_ya[0]`` at the object, so the height *at* surface ``k``
+        is ``_ya[k]``. ``_i`` and ``_ip`` are lists built over
+        ``range(1, N - 1)``, so the value for surface ``k`` is ``_i[k - 1]``.
+        Mixing the two up costs a one-surface shift in the ray height.
+        """
         return (
-            -self._ya[k - 1]
-            * self._i[k - 1]
+            -self._ya[k]
             / (self._n[-1] * self._ua[-1])
             * (self._dn[k - 1] - self._n[k - 1] / self._n[k] * self._dn[k])
         )
 
+    def _TAchC_term(self, k: int) -> BEArray:
+        return self._chromatic_prefactor(k) * self._i[k - 1]
+
     def _TchC_term(self, k: int) -> BEArray:
-        return (
-            -self._ya[k - 1]
-            * self._ip[k - 1]
-            / (self._n[-1] * self._ua[-1])
-            * (self._dn[k - 1] - self._n[k - 1] / self._n[k] * self._dn[k])
-        )
+        return self._chromatic_prefactor(k) * self._ip[k - 1]
 
     def _sum_seidels(
         self,

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -369,7 +369,7 @@ class TestChromaticRayHeightIndex:
     def _at_wavelength(self, factory, wavelength):
         optic = factory()
         optic.wavelengths.wavelengths = []
-        optic.add_wavelength(value=wavelength, is_primary=True)
+        optic.wavelengths.add(value=wavelength, is_primary=True)
         return optic
 
     def test_axial_colour_matches_the_focus_shift(self, set_test_backend):

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -111,9 +111,9 @@ class TestDoubleGaussAberrations:
         assert_allclose(be.sum(TPC), -0.08132376867613199)
         assert_allclose(be.sum(PC), -0.8132376867613212)
         assert_allclose(be.sum(DC), -0.2324205373837797)
-        assert_allclose(be.sum(TAchC), 0.0295705512988189)
-        assert_allclose(be.sum(LchC), 0.2957055129881888)
-        assert_allclose(be.sum(TchC), -0.01804376318260833)
+        assert_allclose(be.sum(TAchC), -0.01400173301485554)
+        assert_allclose(be.sum(LchC), -0.1400173301485556)
+        assert_allclose(be.sum(TchC), 0.01227340687764573)
         assert_allclose(S[0], -0.003929457875534847)
         assert_allclose(S[1], 0.0003954597633218682)
         assert_allclose(S[2], 0.0034239055031729947)
@@ -143,9 +143,9 @@ class TestDoubleGaussAberrations:
         assert_allclose(be.sum(TPC), -0.08132376867613199)
         assert_allclose(be.sum(PC), -0.8132376867613212)
         assert_allclose(be.sum(DC), -0.2324205373837797)
-        assert_allclose(be.sum(TAchC), 0.0295705512988189)
-        assert_allclose(be.sum(LchC), 0.2957055129881888)
-        assert_allclose(be.sum(TchC), -0.01804376318260833)
+        assert_allclose(be.sum(TAchC), -0.01400173301485554)
+        assert_allclose(be.sum(LchC), -0.1400173301485556)
+        assert_allclose(be.sum(TchC), 0.01227340687764573)
 
 
 class TestEdmundSinglet:
@@ -173,9 +173,9 @@ class TestEdmundSinglet:
         assert_allclose(be.sum(TPC), -0.2211799550187673)
         assert_allclose(be.sum(PC), -0.4423180410800838)
         assert_allclose(be.sum(DC), -0.020852935715656093)
-        assert_allclose(be.sum(TAchC), -0.4947549112756089)
-        assert_allclose(be.sum(LchC), -0.9894161663592405)
-        assert_allclose(be.sum(TchC), 0.0)
+        assert_allclose(be.sum(TAchC), -0.461160264307712)
+        assert_allclose(be.sum(LchC), -0.922233231828142)
+        assert_allclose(be.sum(TchC), -0.01675058689178294)
         assert_allclose(S[0], -1.730769175588275)
         assert_allclose(S[1], 0.14253720449059704)
         assert_allclose(S[2], -0.352955446544233)
@@ -205,9 +205,9 @@ class TestEdmundSinglet:
         assert_allclose(be.sum(TPC), -0.2211799550187673)
         assert_allclose(be.sum(PC), -0.4423180410800838)
         assert_allclose(be.sum(DC), -0.020852935715656093)
-        assert_allclose(be.sum(TAchC), -0.4947549112756089)
-        assert_allclose(be.sum(LchC), -0.9894161663592405)
-        assert_allclose(be.sum(TchC), 0.0)
+        assert_allclose(be.sum(TAchC), -0.461160264307712)
+        assert_allclose(be.sum(LchC), -0.922233231828142)
+        assert_allclose(be.sum(TchC), -0.01675058689178294)
 
 
 class TestSingletStopTwo:
@@ -235,9 +235,9 @@ class TestSingletStopTwo:
         assert_allclose(be.sum(TPC), -0.028095789481046744)
         assert_allclose(be.sum(PC), -0.22814191470407064)
         assert_allclose(be.sum(DC), 0.006717305986964978)
-        assert_allclose(be.sum(TAchC), -0.2286190741226864)
-        assert_allclose(be.sum(LchC), -1.8564202776151473)
-        assert_allclose(be.sum(TchC), 0.011126795737552403)
+        assert_allclose(be.sum(TAchC), -0.2235002692149465)
+        assert_allclose(be.sum(LchC), -1.814854834030223)
+        assert_allclose(be.sum(TchC), 0.006580025033160172)
         assert_allclose(S[0], -0.0326050034268675)
         assert_allclose(S[1], -0.0004386784359568394)
         assert_allclose(S[2], -0.01142479550599207)
@@ -267,9 +267,9 @@ class TestSingletStopTwo:
         assert_allclose(be.sum(TPC), -0.028095789481046744)
         assert_allclose(be.sum(PC), -0.22814191470407064)
         assert_allclose(be.sum(DC), 0.006717305986964978)
-        assert_allclose(be.sum(TAchC), -0.2286190741226864)
-        assert_allclose(be.sum(LchC), -1.8564202776151473)
-        assert_allclose(be.sum(TchC), 0.011126795737552403)
+        assert_allclose(be.sum(TAchC), -0.2235002692149465)
+        assert_allclose(be.sum(LchC), -1.814854834030223)
+        assert_allclose(be.sum(TchC), 0.006580025033160172)
 
 
 class TestSimpleSinglet:
@@ -338,4 +338,81 @@ class TestReflectiveSystemSeidels:
                 -1.28411858e-02,
                 7.59541065e-04,
             ],
+        )
+
+
+class TestChromaticRayHeightIndex:
+    """The chromatic terms must use the ray height *at* the surface.
+
+    Regression: ``_TAchC_term`` and ``_TchC_term`` indexed the marginal ray as
+    ``_ya[k - 1]`` while indexing the angles of incidence as ``_i[k - 1]``.
+    Those two have different bases — ``_ya`` is the full per-surface array with
+    ``_ya[0]`` at the object, while ``_i`` is a list built over
+    ``range(1, N - 1)`` — so every surface was weighted by the ray height at the
+    *previous* surface.
+
+    Surface 1 came out right by accident whenever the object is at infinity,
+    since the marginal ray is then parallel and ``_ya[0] == _ya[1]``, which is
+    why the totals looked plausible rather than obviously broken.
+
+    Rather than pin another golden value, these check the coefficients against
+    what the aberrations physically are: the shift in focus and in chief-ray
+    image height between the extreme wavelengths. Third-order theory is an
+    approximation, so a few percent is expected; the pre-fix values were out by
+    a factor of two, and in one case reported exactly zero for an aberration
+    the system genuinely has.
+    """
+
+    def _sum(self, value):
+        return float(be.to_numpy(value).reshape(-1).sum())
+
+    def _at_wavelength(self, factory, wavelength):
+        optic = factory()
+        optic.wavelengths.wavelengths = []
+        optic.add_wavelength(value=wavelength, is_primary=True)
+        return optic
+
+    def test_axial_colour_matches_the_focus_shift(self, set_test_backend):
+        """``LchC`` is the longitudinal shift of focus between F and C."""
+        from optiland.samples.objectives import DoubleGauss
+
+        short, long = 0.4861, 0.6563
+        focus_short = float(
+            be.to_numpy(self._at_wavelength(DoubleGauss, short).paraxial.F2()).reshape(
+                -1
+            )[-1]
+        )
+        focus_long = float(
+            be.to_numpy(self._at_wavelength(DoubleGauss, long).paraxial.F2()).reshape(
+                -1
+            )[-1]
+        )
+        measured = focus_long - focus_short
+
+        predicted = self._sum(DoubleGauss().aberrations.LchC())
+        assert abs(predicted) == pytest.approx(abs(measured), rel=0.05), (
+            f"LchC is {predicted} but the focus moves {measured} between "
+            f"{short} and {long} um. Before the ray-height fix this ratio was "
+            f"2.03."
+        )
+
+    def test_lateral_colour_matches_the_chief_ray_shift(self, set_test_backend):
+        """``TchC`` is the transverse shift of the chief ray between F and C."""
+        from optiland.samples.simple import Edmund_49_847
+
+        short, long = 0.4861327, 0.6562725
+        heights = []
+        for wavelength in (short, long):
+            _, _ = None, None
+            chief_y, _ = self._at_wavelength(
+                Edmund_49_847, wavelength
+            ).paraxial.chief_ray()
+            heights.append(float(be.to_numpy(chief_y).reshape(-1)[-1]))
+        measured = heights[1] - heights[0]
+
+        predicted = self._sum(Edmund_49_847().aberrations.TchC())
+        assert abs(predicted) == pytest.approx(abs(measured), rel=0.05), (
+            f"TchC is {predicted} but the chief ray moves {measured} between "
+            f"{short} and {long} um. Before the ray-height fix this was "
+            f"reported as exactly zero."
         )


### PR DESCRIPTION
This is the root cause of the chromatic mismatch I was chasing on #710, and it turned out to be an off-by-one rather than anything about conventions.

## The bug

`_TAchC_term` and `_TchC_term` index the marginal ray as `_ya[k - 1]` while indexing the angle of incidence as `_i[k - 1]`. Those two have different bases:

| | built as | value for surface `k` |
|---|---|---|
| `_ya` | full per-surface array from `paraxial.marginal_ray()`, `_ya[0]` at the object | `_ya[k]` |
| `_i`, `_ip` | lists built over `range(1, N - 1)` | `_i[k - 1]` |

So every surface was weighted by the ray height at the **previous** surface. The monochromatic terms are unaffected: they go through `_B`, which is built inside that same loop and correctly uses `_ya[k]`.

Surface 1 came out right by accident — with the object at infinity the marginal ray is parallel, so `_ya[0] == _ya[1]`. That is why the totals looked plausible rather than obviously broken, and it is why the first surface was the one row that matched when I started comparing.

## Verification against OpticStudio

Per surface on the Double Gauss, against OpticStudio 2023 R1.02:

| | max abs. difference before | after |
|---|---|---|
| `TAchC` vs `TAXC` | 1.6e-02 | **4.2e-07** |
| `TchC` vs `TLAC` | 3.1e-02 | **7.8e-06** |

4.2e-07 is the printed resolution of the listing — the same agreement the monochromatic terms already had. Totals now line up too: `LchC` = -0.1400173 against `LAXC` = -0.140017, sign included.

## Verification against the aberrations themselves

Independent of any other code, since the coefficients have physical meanings:

**Axial colour** is the longitudinal shift of focus between F and C. On the Double Gauss that shift is 0.145931 mm. `LchC` was 0.295706 — 2.03x too large. It is now -0.140017, i.e. within 4%, which is the same margin OpticStudio's `LAXC` sits at and is the third-order approximation rather than an error.

**Lateral colour** is worse than a scale factor. On `Edmund_49_847` the two surface contributions cancelled exactly under the wrong indexing, and the suite asserted:

```python
assert_allclose(be.sum(TchC), 0.0)
```

for a system whose chief ray actually moves 0.01662 mm between F and C. The corrected coefficient gives 0.01675, within 0.8%. The bug had been frozen into the tests as a known good value, which is the part I'd flag hardest — it would have survived any amount of self-comparison.

## Tests

Updated the chromatic golden values on the three affected samples. **Every monochromatic coefficient (TSC, SC, CC, TCC, TAC, AC, TPC, PC, DC) is bit-identical**, which is the check that the change is confined to the chromatic path rather than perturbing the paraxial trace.

Added `TestChromaticRayHeightIndex`, which deliberately does *not* pin another golden number — it checks the coefficients against the focus shift and the chief-ray height shift computed from the paraxial trace at each wavelength, with a 5% tolerance for the third-order approximation. Both fail with the indexing restored.

## Relationship to #715

#715 fixes a different bug in the same two functions — the dispersion was differenced across hardcoded visible F and C lines rather than the system's own wavelengths. The two are independent (this one is *which ray height*, that one is *which wavelengths*) but they touch the same golden values, so whichever lands second will need its numbers regenerated. Happy to do that, or to fold them into one PR if you'd rather review them together. For reference, `DoubleGauss` is unaffected by #715 — it is specified at exactly 0.4861 / 0.6563 — so the OpticStudio agreement shown above holds with or without it.

## Checks

- `ruff check optiland/` / `ruff format` — pass
- `pytest tests/test_aberrations.py` — 36 passed

Branched from `master` at bc9566a5.
