### PR TITLE
fix(psf): use array peak instead of center pixel in strehl_ratio()

### DIFF
--- a/optiland/psf/base.py
+++ b/optiland/psf/base.py
@@ -432,9 +432,7 @@ class BasePSF(Wavefront):
         if self.psf is None:
             raise RuntimeError("PSF has not been computed.")
 
-        center_x = self.psf.shape[0] // 2
-        center_y = self.psf.shape[1] // 2
-        strehl = self.psf[center_x, center_y] / 100
+        strehl = be.max(self.psf) / 100
         return float(be.to_numpy(strehl).item())
 
     def _get_working_FNO(self):

--- a/tests/test_huygens_psf.py
+++ b/tests/test_huygens_psf.py
@@ -247,11 +247,9 @@ class TestHuygensPSF:
             f"out of expected range [{expected_strehl_min}, 1.005]. "
         )
 
-        # Verify Strehl calculation from BasePSF: peak at center / 100
-        center_x = psf_instance.psf.shape[0] // 2
-        center_y = psf_instance.psf.shape[1] // 2
-        expected_sr_from_psf_center = psf_instance.psf[center_x, center_y] / 100.0
-        assert np.isclose(sr, expected_sr_from_psf_center), (
+        # Verify Strehl calculation from BasePSF: array peak / 100
+        expected_sr_from_psf_peak = np.max(be.to_numpy(psf_instance.psf)) / 100.0
+        assert np.isclose(sr, expected_sr_from_psf_peak), (
             "Strehl ratio mismatch with definition"
         )
 
@@ -260,31 +258,31 @@ class TestHuygensPSF:
     ):
         EXPECTED_STREHL_VALUES = {
             "CookeTriplet": {
-                (0, 0): 0.3023159962682067,
+                (0, 0): 0.30215346284681016,
                 (
                     0.7,
                     0.0,
-                ): 0.019029390469840174,
+                ): 0.023345559659099676,
             },
             "DoubleGauss": {
                 (
                     0,
                     0,
-                ): 0.07405715702199461,
+                ): 0.07332452538749026,
                 (
                     0.7,
                     0.0,
-                ): 0.0063032279399868095,
+                ): 0.00723398494179964,
             },
             "ReverseTelephoto": {
                 (
                     0,
                     0,
-                ): 0.9785343625747402,
+                ): 0.9785149658601526,
                 (
                     0.7,
                     0.0,
-                ): 0.881275354472487,
+                ): 0.8828802278745688,
             },
         }
         # Tolerance for Strehl comparison


### PR DESCRIPTION
## Bug

`BasePSF.strehl_ratio()` read a single, fixed pixel at the array's geometric center (`self.psf[shape[0]//2, shape[1]//2]`) instead of the array's true maximum. This is shared by every `BasePSF` subclass (`FFTPSF`, `HuygensPSF`).

For fields with negligible aberration this is harmless, the diffraction peak coincides with the center to well under a pixel. For fields with significant coma the true peak is physically displaced from that reference point, and the center pixel can land in near-zero intensity. No exception, warning, or NaN, `strehl_ratio()` just silently returns a number with no relation to the system's actual image quality.

## Fix

Use `be.max(self.psf)` instead of the center-pixel lookup.

`MMDFTPSF.strehl_ratio()` already guards against exactly this, with the comment "Make sure to use max! The PSF may not be centered in the image plane." This brings the shared `BasePSF` implementation in line with that existing precedent.

## Tests

Two `HuygensPSF` tests had baked the buggy behavior in as the expected definition:
- `test_strehl_ratio_general` asserted `strehl_ratio()` against the center pixel directly, now asserts against the array max.
- `test_strehl_ratio_specific_values` pinned golden Strehl values computed under the old bug, recomputed against the fix.

Verified against the repro in #716 (a fast, annularly obstructed two-mirror telescope): off-axis `strehl_ratio()` goes from `0.0063` (wrong) to `0.3453` (matches the true peak), exactly as expected in the issue.

`pytest tests/ -k "psf or strehl or mtf"`: 436 passed.

Fixes #716