### PR TITLE
fix(fileio): disambiguate .zmx glass catalog by Nd/Vd on round trip

### DIFF
--- a/optiland/fileio/zemax/reader/parser.py
+++ b/optiland/fileio/zemax/reader/parser.py
@@ -13,7 +13,12 @@ from typing import Any
 import optiland.backend as be
 from optiland.fileio.zemax.model import ZemaxDataModel
 from optiland.materials import AbbeMaterial, BaseMaterial, Material
+from optiland.materials.material_spec import MatchPolicy
 from optiland.physical_apertures import RadialAperture
+
+# Fraunhofer d-line (um), used to evaluate a candidate glass's index for
+# comparison against the Nd recorded on a GLAS line.
+_WL_D = 0.5875618
 
 
 class ZemaxDataParser:
@@ -230,19 +235,24 @@ class ZemaxDataParser:
             self._current_surf_data["index"] = None
             self._current_surf_data["abbe"] = None
 
-        # Try to resolve to a real Material from the glass catalog
-        try:
-            self._current_surf_data["material"] = Material(material_name)
-        except ValueError:
-            if self.data_model.glass_catalogs:
-                for mfg in self.data_model.glass_catalogs:
-                    try:
-                        self._current_surf_data["material"] = Material(
-                            material_name, mfg.lower()
-                        )
-                        break
-                    except ValueError:
-                        continue
+        resolved = self._resolve_glass_by_catalog_and_index(material_name)
+
+        if resolved is not None:
+            self._current_surf_data["material"] = resolved
+        else:
+            # Try to resolve to a real Material from the glass catalog
+            try:
+                self._current_surf_data["material"] = Material(material_name)
+            except ValueError:
+                if self.data_model.glass_catalogs:
+                    for mfg in self.data_model.glass_catalogs:
+                        try:
+                            self._current_surf_data["material"] = Material(
+                                material_name, mfg.lower()
+                            )
+                            break
+                        except ValueError:
+                            continue
 
         # Fall back to AbbeMaterial if catalog lookup failed
         if not isinstance(self._current_surf_data["material"], BaseMaterial):
@@ -251,6 +261,57 @@ class ZemaxDataParser:
                 self._current_surf_data["abbe"],
                 model="buchdahl",
             )
+
+    def _resolve_glass_by_catalog_and_index(
+        self, material_name: str
+    ) -> BaseMaterial | None:
+        """Disambiguate a glass name against the file's declared GCAT catalogs.
+
+        A bare ``Material(name)`` lookup silently returns a single "best
+        match" without regard to which catalogs this file actually declares,
+        so a name present in several catalogs (e.g. "F2" in both Schott and
+        Hikari) can resolve to the wrong one on reload. When the GLAS line
+        carries an Nd/Vd pair, use it to pick whichever catalog candidate is
+        the closest match instead.
+
+        Returns:
+            The resolved material, or None if disambiguation isn't
+            applicable (no declared catalogs, no Nd/Vd on the line, or no
+            candidate found in any declared catalog).
+        """
+        index = self._current_surf_data.get("index")
+        abbe = self._current_surf_data.get("abbe")
+        if not self.data_model.glass_catalogs or index is None or index <= 1.0:
+            return None
+
+        candidates = []
+        for mfg in self.data_model.glass_catalogs:
+            try:
+                candidates.append(
+                    Material(material_name, mfg.lower(), match_policy=MatchPolicy.BEST)
+                )
+            except ValueError:
+                continue
+
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+
+        def _scalar(value) -> float:
+            return float(be.atleast_1d(be.array(value)).ravel()[0])
+
+        def _distance(candidate: BaseMaterial) -> float:
+            try:
+                d_n = _scalar(candidate.n(_WL_D)) - index
+                d_v = 0.0
+                if abbe is not None:
+                    d_v = (_scalar(candidate.abbe()) - abbe) / 100.0
+                return d_n**2 + d_v**2
+            except Exception:
+                return float("inf")
+
+        return min(candidates, key=_distance)
 
     def _read_stop(self, data: list[str]) -> None:
         self._current_surf_data["is_stop"] = True

--- a/optiland/fileio/zemax/writer/encoder.py
+++ b/optiland/fileio/zemax/writer/encoder.py
@@ -229,8 +229,12 @@ class ZemaxFileEncoder:
         name = glas.get("name", "")
         if name == "MIRROR":
             return "  GLAS MIRROR 0 0 0 0 0 0 0 0 0 0"
-        if "n" in glas and "V" in glas:
+        if "catalog" not in glas and "n" in glas and "V" in glas:
             # MODEL glass
             return f"  GLAS MODEL 1 0 {_fmt(glas['n'])} {_fmt(glas['V'])} 0 0 0 0 0 0"
-        # Catalog glass
+        if "n" in glas and "V" in glas:
+            # Catalog glass: record Nd/Vd so an ambiguous name (present in
+            # multiple GCAT catalogs) can be disambiguated on reload.
+            return f"  GLAS {name} 0 0 {_fmt(glas['n'])} {_fmt(glas['V'])} 0 0 0 0 0 0"
+        # Catalog glass without index data (e.g. round-tripped from another format)
         return f"  GLAS {name} 0 0 0 0 0 0 0 0 0 0"

--- a/optiland/fileio/zemax/writer/formatter.py
+++ b/optiland/fileio/zemax/writer/formatter.py
@@ -13,7 +13,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
-from optiland.fileio.common import compute_abbe_number, field_type_string, is_air
+from optiland.fileio.common import WL_D, compute_abbe_number, field_type_string, is_air
 from optiland.fileio.zemax.model import ZemaxDataModel
 from optiland.fileio.zemax.surfaces import (
     CoordinateBreakSurfaceHandler,
@@ -334,7 +334,8 @@ class OpticToZemaxConverter:
         if isinstance(mat, Material) and mat.reference:
             catalog = mat.reference.upper()
             glass_catalogs.append(catalog)
-            return {"name": mat.name.upper(), "catalog": catalog}
+            n_d, v_d = compute_abbe_number(mat, WL_D)
+            return {"name": mat.name.upper(), "catalog": catalog, "n": n_d, "V": v_d}
 
         # Named glass without explicit reference — try to use name only
         if isinstance(mat, Material):

--- a/tests/test_fileio/test_zemax_writer.py
+++ b/tests/test_fileio/test_zemax_writer.py
@@ -397,6 +397,46 @@ class TestGlasEncoding:
 
 
 # ---------------------------------------------------------------------------
+# Glass catalog disambiguation (#713)
+# ---------------------------------------------------------------------------
+
+
+class TestGlassCatalogDisambiguation:
+    """A name present in several declared catalogs must round-trip to the
+    catalog it was originally declared in, not whichever one a bare,
+    catalog-unaware lookup happens to prefer.
+
+    Regression: the writer recorded catalogs only at file level (``GCAT``),
+    so on reload a name like "F2" (present in ``cdgm``, ``hikari`` and
+    ``schott``) resolved to whichever catalog a global fuzzy-match landed on,
+    silently swapping the glass and shifting EFL by ~1.2e-05 relative on
+    ``CookeTriplet``.
+    """
+
+    def test_cooke_triplet_preserves_per_surface_catalog(
+        self, tmp_path, set_test_backend
+    ):
+        from optiland.samples.objectives import CookeTriplet
+
+        original = CookeTriplet()
+        out = tmp_path / "cooke.zmx"
+        save_zemax_file(original, str(out))
+        reloaded = load_zemax_file(str(out))
+
+        for i in range(original.surfaces.num_surfaces):
+            mat = original.surfaces[i].material_post
+            catalog = getattr(mat, "reference", None)
+            if not catalog:
+                continue
+            reloaded_mat = reloaded.surfaces[i].material_post
+            assert getattr(reloaded_mat, "reference", None) == catalog, (
+                f"Surface {i}: catalog {catalog!r} did not survive round trip"
+            )
+
+        assert_allclose(original.paraxial.f2(), reloaded.paraxial.f2(), rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
 # Writer precision
 # ---------------------------------------------------------------------------
 
@@ -424,13 +464,7 @@ def _image_intercept(optic: Optic, Hx, Hy, Px, Py, wavelength):
     )
 
 
-# CookeTriplet is deliberately absent: its glasses are declared with explicit
-# catalogs (``("SK16", "hikari")``, ``("F2", "schott")``) but ``GLAS`` is written
-# without a catalog tag, so the reader re-resolves them ambiguously and the
-# reloaded system uses different dispersion data. That shifts EFL by ~1.2e-05
-# relative, three orders above anything the float formatter can cause, and is a
-# separate defect from the precision this class covers.
-_PRECISION_SAMPLES = ["hubble", "double_gauss"]
+_PRECISION_SAMPLES = ["hubble", "double_gauss", "cooke"]
 
 # (Hx, Hy, Px, Py) — on-axis marginal, full-field chief, and a skew ray.
 _PRECISION_RAYS = [(0.0, 0.0, 0.0, 0.7), (0.0, 1.0, 0.0, 0.0), (0.0, 0.7, 0.7, 0.0)]


### PR DESCRIPTION
## Bug

`GCAT` records catalogs only at file level, so a glass name present in several of a file's declared catalogs (e.g. "F2" in both `hikari` and `schott`) resolved to whichever one a global fuzzy-match preferred on reload, regardless of which catalog the surface actually used. `CookeTriplet`'s F2 (surface 3, `schott`) silently became the `hikari` glass, shifting EFL by 1.2e-05 relative.

## Fix

The writer now records each catalog glass's Nd/Vd (evaluated at the d-line) on its `GLAS` line, reusing the existing `compute_abbe_number` helper. The reader uses that Nd/Vd, when present, to pick whichever declared-catalog candidate is the nearest match, instead of a bare catalog-unaware lookup. Falls back to the previous behavior when the line carries no index data, so third-party `.zmx` files (which typically leave these fields zero) are unaffected.

## Why Nd/Vd and not something more explicit

This does not, and cannot, fix cross-catalog ambiguity in general: when two surfaces in the same file each need a different catalog to win for the same glass name (`SK16` needs `hikari`, `F2` needs `schott`), no single ordering of `GCAT` can satisfy both. Real Zemax OpticStudio has the identical limitation, it resolves by catalog load order and silently takes the first match, so a file like this would be ambiguous in OpticStudio too. Nd/Vd fixes this specifically for Optiland's own round trip, where the same catalog data is available on both ends, without inventing a non-standard extension. The Nd/Vd fields themselves aren't invented either: real Zemax exports (see `tests/zemax_files/circular_aperture_example_with_aperture.zmx`) already populate them on catalog `GLAS` lines under a nonzero "code" field; this writes them under code 0, which existing readers (including this one, previously) already treat as informational rather than authoritative.

## Tests

- New `TestGlassCatalogDisambiguation`: round-trips `CookeTriplet` and asserts every surface's catalog reference is preserved exactly, plus an EFL check at `rtol=1e-12`.
- `TestWriterPrecision` previously excluded `CookeTriplet` from its parametrized samples with a comment describing this exact bug; the exclusion is removed and it now passes at `rtol=1e-12`, the tightest tolerance in that suite.
- Verified by hand against the hardest case in the built-in catalogs: `SK16` exists in `schott`/`hikari`/`sumita` with Nd differing only in the 5th-6th decimal; still resolves correctly at full float64 precision.

`pytest tests/test_fileio tests/test_variable.py`: 412 passed.

Fixes #713 (problem 1; the wrong `GCAT` on the file attached to #710 is a data fix on that issue, not covered here)