### PR TITLE
fix(paraxial): make surface positions fold-aware

### DIFF
--- a/optiland/coordinate_system.py
+++ b/optiland/coordinate_system.py
@@ -161,6 +161,24 @@ class CoordinateSystem:
             self.reference_cs.globalize(rays)
 
     @property
+    def frame_in_gcs(
+        self,
+    ) -> tuple[tuple[BEArray, BEArray, BEArray], tuple[BEArray, BEArray, BEArray]]:
+        """Returns the origin and the local +z axis of the coordinate system,
+            both expressed in the global coordinate system.
+
+        A single globalized probe carries both: its position becomes the
+        origin and its direction cosines become the local +z axis, which is
+        the surface normal at the vertex.
+
+        Returns:
+            A tuple ``(origin, axis)``, each a tuple of x, y and z components.
+        """
+        vector = RealRays(0, 0, 0, 0, 0, 1, 1, 1)
+        self.globalize(vector)
+        return (vector.x, vector.y, vector.z), (vector.L, vector.M, vector.N)
+
+    @property
     def position_in_gcs(self) -> tuple[BEArray, BEArray, BEArray]:
         """Returns the position of the coordinate system in the global coordinate
             system.
@@ -168,9 +186,7 @@ class CoordinateSystem:
         Returns:
             A tuple containing the x, y, and z coordinates of the position.
         """
-        vector = RealRays(0, 0, 0, 0, 0, 1, 1, 1)
-        self.globalize(vector)
-        return vector.x, vector.y, vector.z
+        return self.frame_in_gcs[0]
 
     def get_rotation_matrix(self) -> BEArray:
         """Get the rotation matrix of the coordinate system

--- a/optiland/psf/huygens_fresnel.py
+++ b/optiland/psf/huygens_fresnel.py
@@ -267,7 +267,9 @@ class ScalarHuygensPSF(BasePSF):
         pupil_opd_ideal = be.zeros_like(data.opd)  # ideal case has no OPD
         image_x = be.zeros((1, 1))  # single point for normalization
         image_y = be.zeros((1, 1))
-        ideal_z = self.optic.surfaces.positions[-1]  # image plane position
+        # Real-space image plane position: this seeds a global-frame point, so
+        # it must be global z rather than the unfolded axial coordinate.
+        ideal_z = self.optic.surfaces.global_z_positions[-1]
         image_z = be.full((1, 1), ideal_z)
 
         psf_max = self._summation_strategy.compute(

--- a/optiland/psf/vectorial_huygens.py
+++ b/optiland/psf/vectorial_huygens.py
@@ -142,7 +142,8 @@ class VectorialHuygensPSF(ScalarHuygensPSF):
         pupil_opd_ideal = be.zeros_like(data.opd)
         image_x = be.zeros((1, 1))
         image_y = be.zeros((1, 1))
-        ideal_z = self.optic.surfaces.positions[-1]
+        # Global-frame image plane position, not the unfolded axial coordinate.
+        ideal_z = self.optic.surfaces.global_z_positions[-1]
         image_z = be.full((1, 1), ideal_z)
 
         is_valid = data.intensity > 0

--- a/optiland/surfaces/object_surface.py
+++ b/optiland/surfaces/object_surface.py
@@ -47,8 +47,19 @@ class ObjectSurface(Surface):
 
     @property
     def is_infinite(self):
-        """Returns True if the surface is infinitely far away, False otherwise."""
-        return be.isinf(self.geometry.cs.z)
+        """Returns True if the surface is infinitely far away, False otherwise.
+
+        Classic authoring spells an object at infinity as ``cs.z = -inf``,
+        because the axis is z. A system entered off that axis -- a collimated
+        source posed to fire along +x into a fold -- puts the same infinity in
+        x or y, so any infinite vertex coordinate says the same thing.
+        """
+        cs = self.geometry.cs
+        # Tested one axis at a time: under a multi-configuration the three
+        # can hold arrays of different lengths, which will not stack.
+        return any(
+            bool(be.any(be.isinf(be.array(coord)))) for coord in (cs.x, cs.y, cs.z)
+        )
 
     def set_aperture(self):
         """Sets the aperture of the surface."""

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
     from optiland._types import SurfaceType
     from optiland.materials import BaseMaterial
 
+# A mirror normal this close to ±z leaves the beam on the z axis, so the
+# system is still described by global z. Sized to admit round-off in the
+# rotation matrices while rejecting any fold a user meant to author.
+_AXIS_TOL = 1e-10
+
 
 class SurfaceGroup:
     """Represents a group of surfaces in an optical system.
@@ -214,11 +219,165 @@ class SurfaceGroup:
 
     @property
     def positions(self):
-        """np.array: z positions of surface vertices"""
+        """np.array: axial positions of surface vertices.
+
+        The axial coordinate is the one the paraxial model is written in: a
+        1-D coordinate along the unfolded optical axis, with each reflection
+        reversing the direction of travel (so spacings after an odd number of
+        mirrors are negative). While every leg of the beam path runs along
+        ±z -- straight systems and mirrors at normal incidence -- that is
+        exactly the global z of each vertex, and this property returns it
+        unchanged.
+
+        A mirror that folds the beam off the z axis breaks that equivalence:
+        two vertices on opposite sides of a 90° fold can share a z, so their
+        spacing would read as zero. For those systems the coordinate is
+        continued as signed cumulative vertex-to-vertex path length along the
+        beam, which is what the surrounding first-order machinery -- pupil
+        locations, paraxial ray heights, solves -- needs to stay correct
+        through a fold. Use ``global_z_positions`` for real-space z.
+        """
+        frames = [surf.geometry.cs.frame_in_gcs for surf in self.surfaces]
+        mirrors = [
+            bool(getattr(surf.interaction_model, "is_reflective", False))
+            for surf in self.surfaces
+        ]
+        entry = self._entry_direction(frames)
+        if self._is_folded(frames, mirrors, entry):
+            positions = self._unfolded_positions(frames, mirrors, entry)
+        else:
+            positions = be.array([origin[2] for origin, _ in frames])
+        return positions.reshape(-1, 1)
+
+    @property
+    def global_z_positions(self):
+        """np.array: global z coordinates of the surface vertices.
+
+        Unlike :attr:`positions` this is a real-space coordinate, never an
+        unfolded one. Use it for anything that has to place something in the
+        global frame (drawing limits, reference spheres); use ``positions``
+        for first-order calculations.
+        """
         positions = be.array(
             [surf.geometry.cs.position_in_gcs[2] for surf in self.surfaces]
         )
         return positions.reshape(-1, 1)
+
+    @staticmethod
+    def _off_axis(vector):
+        """Whether a unit vector points anywhere but along ±z.
+
+        ``positions`` is hot, so this compares on the arrays' own operators
+        rather than paying backend dispatch for a two-element test.
+        """
+        return bool(abs(vector[0]) > _AXIS_TOL) or bool(abs(vector[1]) > _AXIS_TOL)
+
+    @staticmethod
+    def _entry_direction(frames):
+        """Unit vector of the first leg, object vertex to first surface vertex.
+
+        Read off the two vertices rather than off the object surface's own
+        orientation: a tilted object plane does not steer the beam, so its
+        normal is not the axis. An object at infinity leaves an infinite
+        component in whichever axes the beam runs along, which carries the
+        direction on its own once the finite components are dropped.
+
+        Falls back to +z when there is nothing to read -- a lone surface, or
+        an object sitting on top of the first surface.
+        """
+        default = (be.array(0.0), be.array(0.0), be.array(1.0))
+        if len(frames) < 2:
+            return default
+        first, second = frames[0][0], frames[1][0]
+        step = [second[k] - first[k] for k in range(3)]
+        diverging = [bool(be.any(be.isinf(be.array(s)))) for s in step]
+        if any(diverging):
+            step = [
+                be.sign(s) if is_inf else be.array(0.0)
+                for s, is_inf in zip(step, diverging, strict=True)
+            ]
+        norm = be.sqrt(sum(s * s for s in step))
+        if not bool(be.all(norm > _AXIS_TOL)):
+            return default
+        return tuple(s / norm for s in step)
+
+    @classmethod
+    def _is_folded(cls, frames, mirrors, entry):
+        """Whether the beam path leaves the global z axis anywhere.
+
+        False -- the common case -- lets ``positions`` hand back global z
+        untouched, and bit-for-bit unchanged. Two things can take it off that
+        axis. The system may simply not be entered along z, which the first
+        leg reports. Or a mirror may fold it, which happens exactly when the
+        mirror normal is not parallel to the incoming beam direction; every
+        leg up to the first fold runs along ±z, so testing each mirror normal
+        against z is enough to decide the rest.
+        """
+        if cls._off_axis(entry):
+            return True
+        for (_, normal), is_mirror in zip(frames, mirrors, strict=True):
+            if is_mirror and cls._off_axis(normal):
+                return True
+        return False
+
+    @staticmethod
+    def _unfolded_positions(frames, mirrors, direction):
+        """Axial positions along the unfolded optical axis.
+
+        Walks the surface chain carrying the beam direction ``d`` (turned by
+        each mirror through ``d - 2(d·n)n``) and the reflection parity, and
+        accumulates ``parity * (Δvertex · d)`` per leg. Projecting onto ``d``
+        rather than taking the raw distance keeps the sign of legs authored
+        with a negative thickness; the parity keeps the sign convention of the
+        classic authoring, where spacings run backwards after a mirror.
+
+        The walk starts along the entry direction rather than along global +z:
+        a system can be entered off the z axis (a source posed to fire along
+        +x into a fold) and then no leg of it, not even the first, is a z
+        interval. For everything authored the classic way that direction is
+        +z and the walk is unchanged.
+
+        Args:
+            frames: Per-surface ``(origin, normal)`` in global coordinates.
+            mirrors: Per-surface reflectivity flags.
+            direction: Unit vector the beam travels along on entry.
+        """
+        if not frames:
+            return be.array([])
+
+        # The first vertex anchors the axis: nothing folds ahead of it.
+        previous = frames[0][0]
+        # An object at infinity has no z to anchor on when the entry axis is
+        # not z -- its infinity sits in x or y instead -- so read the anchor
+        # off the axis itself, which carries the sign the classic spelling
+        # (cs.z = -inf) would have given.
+        axial = [
+            previous[2]
+            if bool(be.all(be.isfinite(be.array([previous[k] for k in range(3)]))))
+            else sum(previous[k] * direction[k] for k in range(3))
+        ]
+        parity = 1.0
+
+        for (origin, normal), is_mirror in zip(frames[1:], mirrors[1:], strict=True):
+            step = sum((origin[k] - previous[k]) * direction[k] for k in range(3))
+            if be.all(be.isfinite(axial[-1])) and be.all(be.isfinite(step)):
+                axial.append(axial[-1] + parity * step)
+            else:
+                # A leg to or from infinity carries no fold, so re-anchor on
+                # global z instead of accumulating an inf that would go on to
+                # cancel into a nan.
+                axial.append(origin[2])
+
+            if is_mirror:
+                projection = sum(direction[k] * normal[k] for k in range(3))
+                direction = tuple(
+                    direction[k] - 2 * projection * normal[k] for k in range(3)
+                )
+                parity = -parity
+
+            previous = origin
+
+        return be.array(axial)
 
     @property
     def radii(self):

--- a/optiland/visualization/system/optic_viewer.py
+++ b/optiland/visualization/system/optic_viewer.py
@@ -209,7 +209,9 @@ class OpticViewer(BaseViewer):
             # A single cross-section at one z -- no object-segment issue.
             return None, None
 
-        positions = be.to_numpy(self.optic.surfaces.positions).reshape(-1)
+        # Axis limits are drawn in the global frame, so use global z rather
+        # than the unfolded axial coordinate ``positions`` reports.
+        positions = be.to_numpy(self.optic.surfaces.global_z_positions).reshape(-1)
         start_idx = 1 if self.optic.object_surface.is_infinite else 0
         if start_idx >= len(positions) - 1:
             return None, None

--- a/optiland/wavefront/strategy.py
+++ b/optiland/wavefront/strategy.py
@@ -157,7 +157,9 @@ class ChiefRayStrategy(ReferenceStrategy):
 
     def __init__(self, optic: Optic, distribution: BaseDistribution, **kwargs) -> None:
         super().__init__(optic, distribution, **kwargs)
-        self.pupil_z = optic.paraxial.XPL() + optic.surfaces.positions[-1]
+        # Reference sphere centre lives in the global frame, so anchor the
+        # exit pupil on global z (identical to ``positions`` unless folded).
+        self.pupil_z = optic.paraxial.XPL() + optic.surfaces.global_z_positions[-1]
         self._chief_ray = None  # Cache for single field calculation usage
 
     def compute_wavefront_data(

--- a/tests/test_folded_paraxial.py
+++ b/tests/test_folded_paraxial.py
@@ -1,0 +1,299 @@
+"""First-order behaviour of systems folded off the global z axis (issue #726).
+
+The same plano-convex singlet is built four ways: straight, retro (a flat
+mirror at normal incidence, a fold that global z can express), folded 90 deg by
+a 45 deg mirror, and a two-fold periscope. Each folded build unfolds across its
+mirrors onto the straight system, so every first-order quantity has a reference
+value to be checked against.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import optiland.backend as be
+from optiland.optic import Optic
+from optiland.rays import RealRays
+
+from .utils import assert_allclose, assert_array_equal
+
+
+def _finish(optic):
+    optic.set_aperture(aperture_type="EPD", value=10.0)
+    optic.fields.set_type("angle")
+    optic.fields.add(y=0.0)
+    optic.wavelengths.add(value=0.55, is_primary=True)
+    return optic
+
+
+def straight():
+    """Plano-convex singlet, image plane 46 mm behind the flat face."""
+    optic = Optic(name="straight")
+    optic.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    optic.surfaces.add(
+        index=1, radius=25.84, thickness=4.0, material="N-BK7", is_stop=True
+    )
+    optic.surfaces.add(index=2, radius=be.inf, thickness=46.0)
+    optic.surfaces.add(index=3)
+    return _finish(optic)
+
+
+def retro():
+    """Same singlet, folded back on itself by a mirror at normal incidence."""
+    optic = Optic(name="retro")
+    optic.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    optic.surfaces.add(
+        index=1, radius=25.84, thickness=4.0, material="N-BK7", is_stop=True
+    )
+    optic.surfaces.add(index=2, radius=be.inf, thickness=20.0)
+    optic.surfaces.add(index=3, radius=be.inf, material="mirror", thickness=-26.0)
+    optic.surfaces.add(index=4)
+    return _finish(optic)
+
+
+def folded():
+    """Same singlet, folded 90 deg into +y by a 45 deg mirror 20 mm back."""
+    optic = Optic(name="folded")
+    optic.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    optic.surfaces.add(
+        index=1, radius=25.84, thickness=4.0, material="N-BK7", is_stop=True
+    )
+    optic.surfaces.add(index=2, radius=be.inf, thickness=20.0)
+    optic.surfaces.add(index=3, x=0.0, y=0.0, z=24.0, rx=math.pi / 4, material="mirror")
+    # Image plane 26 mm along the folded axis (equivalent unfolded z = 50).
+    optic.surfaces.add(index=4, x=0.0, y=26.0, z=24.0, rx=-math.pi / 2)
+    return _finish(optic)
+
+
+def periscope():
+    """Same singlet, offset 13 mm in +y by two 45 deg mirrors.
+
+    The beam runs 20 mm to the first mirror, 13 mm across to the second and
+    13 mm on to the image: 46 mm of post-lens propagation, as in ``straight``.
+    Reflection parity is back to positive after the second mirror.
+    """
+    optic = Optic(name="periscope")
+    optic.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    optic.surfaces.add(
+        index=1, radius=25.84, thickness=4.0, material="N-BK7", is_stop=True
+    )
+    optic.surfaces.add(index=2, radius=be.inf, thickness=20.0)
+    optic.surfaces.add(index=3, x=0.0, y=0.0, z=24.0, rx=math.pi / 4, material="mirror")
+    optic.surfaces.add(
+        index=4, x=0.0, y=13.0, z=24.0, rx=math.pi / 4, material="mirror"
+    )
+    optic.surfaces.add(index=5, x=0.0, y=13.0, z=37.0)
+    return _finish(optic)
+
+
+def _trace_axial_marginal(optic):
+    """Trace an explicit y = +3 mm ray parallel to the axis, no pupil aiming."""
+    rays = RealRays(
+        be.array([0.0]),
+        be.array([3.0]),
+        be.array([-10.0]),
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([1.0]),
+        be.array([1.0]),
+        be.array([0.55]),
+    )
+    optic.surfaces.trace(rays)
+    return rays
+
+
+class TestPositionsOnAxis:
+    """Systems whose legs all run along +/-z keep reporting global z."""
+
+    @pytest.mark.parametrize(
+        ("builder", "expected"),
+        [
+            (straight, [-be.inf, 0.0, 4.0, 50.0]),
+            (retro, [-be.inf, 0.0, 4.0, 24.0, -2.0]),
+        ],
+        ids=["straight", "retro"],
+    )
+    def test_positions_unchanged(self, builder, expected, set_test_backend):
+        optic = builder()
+        assert_array_equal(be.ravel(optic.surfaces.positions), be.array(expected))
+
+    @pytest.mark.parametrize("builder", [straight, retro], ids=["straight", "retro"])
+    def test_positions_are_global_z(self, builder, set_test_backend):
+        optic = builder()
+        assert_array_equal(optic.surfaces.positions, optic.surfaces.global_z_positions)
+
+
+class TestSingleFold:
+    """A 90 deg fold must read exactly like the retro system it unfolds onto."""
+
+    def test_positions_continue_across_the_fold(self, set_test_backend):
+        optic = folded()
+        assert_allclose(
+            be.ravel(optic.surfaces.positions),
+            be.array([-be.inf, 0.0, 4.0, 24.0, -2.0]),
+        )
+
+    def test_global_z_positions_stay_in_the_global_frame(self, set_test_backend):
+        optic = folded()
+        assert_allclose(
+            be.ravel(optic.surfaces.global_z_positions),
+            be.array([-be.inf, 0.0, 4.0, 24.0, 24.0]),
+        )
+
+    def test_first_order_matches_retro(self, set_test_backend):
+        fold = folded()
+        reference = retro()
+
+        assert_allclose(fold.paraxial.f2(), reference.paraxial.f2())
+        assert_allclose(fold.paraxial.XPL(), reference.paraxial.XPL())
+        assert_allclose(fold.paraxial.EPD(), reference.paraxial.EPD())
+        assert_allclose(fold.paraxial.FNO(), reference.paraxial.FNO())
+
+        y_fold, u_fold = fold.paraxial.marginal_ray()
+        y_ref, u_ref = reference.paraxial.marginal_ray()
+        assert_allclose(y_fold, y_ref)
+        assert_allclose(u_fold, u_ref)
+
+    def test_real_ray_agrees_with_the_paraxial_axis(self, set_test_backend):
+        """The real marginal ray lands the same distance off the folded axis."""
+        rays = _trace_axial_marginal(folded())
+        # The folded axis runs along +y at z = 24, so the transverse residual
+        # is the ray's z offset from the mirror vertex.
+        residual = be.ravel(rays.z)[0] - 24.0
+
+        straight_rays = _trace_axial_marginal(straight())
+        assert_allclose(residual, be.ravel(straight_rays.y)[0])
+
+
+class TestTwoFolds:
+    """Reflection parity returns to positive after a second mirror."""
+
+    def test_positions_reverse_then_resume(self, set_test_backend):
+        optic = periscope()
+        assert_allclose(
+            be.ravel(optic.surfaces.positions),
+            be.array([-be.inf, 0.0, 4.0, 24.0, 11.0, 24.0]),
+        )
+
+    def test_first_order_matches_straight(self, set_test_backend):
+        scope = periscope()
+        reference = straight()
+
+        assert_allclose(scope.paraxial.f2(), reference.paraxial.f2())
+        assert_allclose(scope.paraxial.XPL(), reference.paraxial.XPL())
+        assert_allclose(scope.paraxial.FNO(), reference.paraxial.FNO())
+
+        y_scope, _ = scope.paraxial.marginal_ray()
+        y_ref, _ = reference.paraxial.marginal_ray()
+        assert_allclose(be.ravel(y_scope)[-1], be.ravel(y_ref)[-1])
+
+    def test_real_ray_agrees_with_the_paraxial_axis(self, set_test_backend):
+        rays = _trace_axial_marginal(periscope())
+        # After two folds the beam runs along +z again, offset 13 mm in +y.
+        residual = be.ravel(rays.y)[0] - 13.0
+
+        straight_rays = _trace_axial_marginal(straight())
+        assert_allclose(residual, be.ravel(straight_rays.y)[0])
+
+
+def entered_along_x():
+    """Same singlet, but the whole system is entered along +x.
+
+    A collimated source posed to fire along +x into a 45 deg mirror that turns
+    the beam onto -z. Nothing about the optics changes -- the lens is 20 mm
+    ahead of the mirror and the image 26 mm past it, as in ``retro`` -- so
+    every first-order quantity has to come back the same. What changes is that
+    not one leg of the path, not even the first, is a z interval.
+    """
+    optic = Optic(name="entered_along_x")
+    # Object at infinity down the -x arm; a flat object plane has no axis of
+    # its own to read, and the first leg says which way the light travels.
+    optic.surfaces.add(index=0, x=-be.inf, y=0.0, z=0.0, radius=be.inf)
+    # Lens axis along +x: local +z is the surface normal.
+    optic.surfaces.add(
+        index=1,
+        x=0.0,
+        y=0.0,
+        z=0.0,
+        ry=math.pi / 2,
+        radius=25.84,
+        material="N-BK7",
+        is_stop=True,
+    )
+    optic.surfaces.add(index=2, x=4.0, y=0.0, z=0.0, ry=math.pi / 2, radius=be.inf)
+    # 45 deg fold 20 mm on: normal bisects +x in and -z out.
+    optic.surfaces.add(
+        index=3, x=24.0, y=0.0, z=0.0, ry=-3 * math.pi / 4, material="mirror"
+    )
+    optic.surfaces.add(index=4, x=24.0, y=0.0, z=-26.0)
+    return _finish(optic)
+
+
+class TestOffAxisEntry:
+    """A system entered off the z axis, not merely folded part way through."""
+
+    def test_positions_run_along_the_entry_axis(self, set_test_backend):
+        optic = entered_along_x()
+        assert_allclose(
+            be.ravel(optic.surfaces.positions),
+            be.array([-be.inf, 0.0, 4.0, 24.0, -2.0]),
+        )
+
+    def test_global_z_positions_stay_in_the_global_frame(self, set_test_backend):
+        """Every vertex but the image shares z = 0: the arm is invisible to z."""
+        optic = entered_along_x()
+        assert_allclose(
+            be.ravel(optic.surfaces.global_z_positions),
+            be.array([0.0, 0.0, 0.0, 0.0, -26.0]),
+        )
+
+    def test_first_order_matches_retro(self, set_test_backend):
+        entered = entered_along_x()
+        reference = retro()
+
+        assert_allclose(entered.paraxial.f2(), reference.paraxial.f2())
+        assert_allclose(entered.paraxial.XPL(), reference.paraxial.XPL())
+        assert_allclose(entered.paraxial.EPD(), reference.paraxial.EPD())
+        assert_allclose(entered.paraxial.FNO(), reference.paraxial.FNO())
+
+        y_entered, u_entered = entered.paraxial.marginal_ray()
+        y_ref, u_ref = reference.paraxial.marginal_ray()
+        assert_allclose(y_entered, y_ref)
+        assert_allclose(u_entered, u_ref)
+
+    def test_object_at_infinity_off_the_z_axis_is_recognised(self, set_test_backend):
+        """The infinity sits in x here, and means what it means in z."""
+        assert entered_along_x().object_surface.is_infinite
+
+    def test_real_ray_agrees_with_the_paraxial_axis(self, set_test_backend):
+        """The real marginal ray lands the same distance off the folded axis."""
+        rays = RealRays(
+            be.array([-10.0]),
+            be.array([3.0]),
+            be.array([0.0]),
+            be.array([1.0]),
+            be.array([0.0]),
+            be.array([0.0]),
+            be.array([1.0]),
+            be.array([0.55]),
+        )
+        entered_along_x().surfaces.trace(rays)
+        # The sagittal offset is authored in y, which survives a fold in x-z.
+        straight_rays = _trace_axial_marginal(straight())
+        assert_allclose(be.ravel(rays.y)[0], be.ravel(straight_rays.y)[0])
+
+
+class TestTiltedObjectIsNotAFold:
+    """A tilted object plane does not steer the beam, so it is not a fold.
+
+    The axis is read off the vertices for exactly this reason: taking it from
+    the object surface's own orientation would send every system with a tilted
+    object down the unfolding path and change positions that must not move.
+    """
+
+    def test_positions_stay_global_z(self, set_test_backend):
+        optic = straight()
+        optic.surfaces.surfaces[0].geometry.cs.rx = be.array(math.pi / 8)
+        assert_array_equal(optic.surfaces.positions, optic.surfaces.global_z_positions)


### PR DESCRIPTION
Fixes #726, proposal A.

`positions` now reports the axial coordinate along the unfolded optical axis: signed cumulative vertex-to-vertex path length, projected on the running beam direction (each mirror turns it through d - 2(d.n)n), sign flipped per reflection. Systems whose legs all run along +/-z take an early exit and get global z back bit-for-bit, so straight and on-axis-mirror systems are unchanged. Real-space consumers (Huygens image plane, wavefront reference sphere, viewer limits) move to the new `global_z_positions` and behave as before.

Two things surfaced while validating against a folded system that is entered along +x rather than z:

- The walk starts along the first leg, object vertex to first surface vertex, rather than assuming +z. A system can be entered off the z axis entirely, and then no leg of it is a z interval. The direction is read off vertices, not the object plane's orientation, so a tilted object plane does not read as a fold.
- `ObjectSurface.is_infinite` accepts the object's infinity in x or y, which is where it lands when the entry axis is not z.

Tests: the issue's 90 deg fold against the retro system it unfolds onto, a two-fold periscope against the straight equivalent, a singlet entered along +x, and the tilted-object guard. The acceptance numbers from the issue reproduce. The regression snapshots pass unchanged, and the set of failing tests on my machine is identical before and after the change.

One limitation stays, tracked in #728: the ray generator still builds pupil points on a plane perpendicular to z, so `optic.trace()` remains z-bound for systems entered off axis. First-order readouts (marginal and chief ray, pupils, f2) work.


DO NOT MERGE YET, THANKS :)