### PR TITLE
fix: preserve autograd during image oversampling

### DIFF
--- a/optiland/analysis/image_simulation/engine.py
+++ b/optiland/analysis/image_simulation/engine.py
@@ -231,9 +231,20 @@ class ImageSimulationEngine:
         # Upsampling
         scale = self.config["oversample"]
         if scale > 1:
-            image_np = be.to_numpy(image)
-            upsampled_np = zoom(image_np, (1, 1, scale, scale), order=1)
-            image = be.array(upsampled_np)
+            if be.get_backend() == "torch":
+                import torch.nn.functional as F
+
+                # Match scipy.ndimage.zoom's endpoint-aligned sampling grid.
+                image = F.interpolate(
+                    image,
+                    scale_factor=scale,
+                    mode="bilinear",
+                    align_corners=True,
+                )
+            else:
+                image_np = be.to_numpy(image)
+                upsampled_np = zoom(image_np, (1, 1, scale, scale), order=1)
+                image = be.array(upsampled_np)
 
         return image, (pad, scale)
 
@@ -243,14 +254,15 @@ class ImageSimulationEngine:
 
         # Downsample
         if scale > 1:
-            if be.get_backend().__class__.__name__ == "TorchBackend":
+            if be.get_backend() == "torch":
                 import torch.nn.functional as F
 
+                # Match scipy.ndimage.zoom's endpoint-aligned sampling grid.
                 image = F.interpolate(
                     image,
                     scale_factor=1 / scale,
                     mode="bilinear",
-                    align_corners=False,
+                    align_corners=True,
                 )
             else:
                 image_np = be.to_numpy(image)

--- a/tests/test_image_simulation.py
+++ b/tests/test_image_simulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from scipy.ndimage import zoom
 
 import optiland.backend as be
 from optiland.analysis.image_simulation import (
@@ -10,6 +11,7 @@ from optiland.analysis.image_simulation import (
     SpatiallyVariableSimulator,
 )
 from optiland.samples.objectives import ReverseTelephoto, Telephoto
+from tests.utils import assert_allclose
 
 
 def create_grid_image(size=128, step=20, thickness=2):
@@ -135,3 +137,63 @@ def test_image_simulation_engine_run_batch(set_test_backend):
 
     assert result.shape == (2, 3, 64, 64)
     assert not be.any(be.isnan(result))
+
+
+def test_image_simulation_engine_resampling_preserves_backend_contract(
+    set_test_backend,
+):
+    """Oversampling preserves values and the active backend contract."""
+    engine = ImageSimulationEngine(
+        optic=None,
+        config={"oversample": 2, "padding": 1},
+    )
+    source_np = np.arange(20, dtype=np.float64).reshape(1, 1, 4, 5)
+
+    if be.get_backend() == "torch":
+        import torch
+
+        image = torch.tensor(
+            source_np,
+            device=be.get_device(),
+            requires_grad=True,
+        )
+    else:
+        image = source_np
+
+    engine.source_image = image
+    upsampled, pad_info = engine._preprocess(image)
+    result = engine._postprocess(upsampled, pad_info)
+
+    assert upsampled.shape == (1, 1, 12, 14)
+    assert result.shape == image.shape
+    assert upsampled.dtype == image.dtype
+    assert result.dtype == image.dtype
+
+    padded = np.pad(
+        source_np,
+        ((0, 0), (0, 0), (1, 1), (1, 1)),
+        mode="reflect",
+    )
+    expected_upsampled = zoom(padded, (1, 1, 2, 2), order=1)
+    assert_allclose(upsampled, expected_upsampled)
+
+    expected = zoom(expected_upsampled, (1, 1, 0.5, 0.5), order=1)
+    expected = expected[:, :, 1:5, 1:6]
+    assert_allclose(result, expected)
+
+    if be.get_backend() == "torch":
+        assert upsampled.device == image.device
+        assert result.device == image.device
+
+        upsample_grad = torch.autograd.grad(
+            upsampled.sum(), image, retain_graph=True, allow_unused=True
+        )[0]
+        result_grad = torch.autograd.grad(
+            result.sum(), image, allow_unused=True
+        )[0]
+
+        assert upsample_grad is not None
+        assert result_grad is not None
+        assert torch.all(torch.isfinite(upsample_grad))
+        assert torch.all(torch.isfinite(result_grad))
+        assert torch.any(result_grad != 0)


### PR DESCRIPTION
## Summary

- keep Torch tensors on their original dtype and device during image oversampling
- use torch.nn.functional.interpolate for Torch preprocessing and postprocessing so gradients remain connected
- fix the unreachable Torch backend branch in postprocessing
- add NumPy/Torch parity, shape, dtype, device, and autograd regression coverage

## Root cause

The preprocessing path always converted data through NumPy and SciPy, which detached Torch tensors from the computation graph. The intended Torch postprocessing branch was also unreachable because get_backend returns a string, while the code inspected its class name.

The Torch interpolation uses align_corners=True to preserve the endpoint-aligned sampling geometry of the existing SciPy path.

## Validation

- pytest tests/test_image_simulation.py tests/analysis/test_image_simulation.py: 19 passed
- pytest tests/regression: 8 passed
- ruff check --no-cache .: passed
- ruff format --check --no-cache .: passed

Fixes #720