### PR TITLE
feat(paraxial): add EFL and ray-transfer matrix for a surface range

### DIFF
--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -198,6 +198,17 @@ New to these concepts? See the :ref:`glossary` first.
    print("XPL:", lens.paraxial.XPL())   # exit pupil location, relative to the image surface
    print("Magnification:", lens.paraxial.magnification())
 
+   # EFL of a lens group, i.e. surfaces 1 through 2 only
+   print("Group EFL:", lens.paraxial.f2_range(1, 2))
+
+.. note::
+
+   ``f2_range(start, end)`` treats the surface range as a lens group **in
+   isolation**, with its own conjugates. It is not a decomposition of the
+   system's power, so the group focal lengths of a design will not add back up
+   to ``f2()``. The underlying 2x2 ray-transfer matrix of a surface range is
+   available as ``lens.paraxial.ray_transfer_matrix(start, end)``.
+
 .. note::
 
    ``EPL()`` is measured **relative to the first physical surface** (surface 1),

--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -86,6 +86,49 @@ class Paraxial:
         f2 = -y[0] / u[-1]
         return f2[0]
 
+    def f2_range(
+        self,
+        start: int,
+        end: int,
+        wavelength: float | None = None,
+    ) -> ScalarOrArray:
+        """Calculate the effective focal length of a range of surfaces.
+
+        The range is treated as a lens group in isolation: the returned value
+        is the paraxial EFL that surfaces ``start`` through ``end`` have with
+        their own conjugates, evaluated in the media that bound the range in
+        the parent system.
+
+        This is deliberately not a decomposition of the full system's power.
+        The focal lengths of a system's groups do not, in general, recombine
+        into :meth:`f2`, since that would additionally require the separations
+        between the groups' principal planes.
+
+        Args:
+            start: Index of the first surface of the range, inclusive.
+            end: Index of the last surface of the range, inclusive.
+            wavelength: Wavelength in micrometers at which the refractive
+                indices are evaluated. Defaults to the system's primary
+                wavelength.
+
+        Returns:
+            Effective focal length of the surface range. A range with no net
+                power (an afocal group) returns infinity.
+
+        Raises:
+            ValueError: If the surface range is invalid.
+
+        """
+        matrix = self.ray_transfer_matrix(start, end, wavelength)
+
+        # A ray entering parallel to the axis (y=1, u=0) leaves the range with
+        # slope u_out = C, so the EFL is -y_in / u_out = -1 / C. This is the
+        # same ratio f2() forms from an explicit paraxial trace.
+        C = matrix[1, 0]
+        if C == 0:
+            return be.array(float("inf"))
+        return -1.0 / C
+
     def F1(self) -> ScalarOrArray:
         """Calculate the front focal point (F1) location.
 
@@ -472,6 +515,131 @@ class Paraxial:
                 - u_ray: Slopes of the traced ray after each surface.
         """
         return self._ray_tracer.trace(Hy, Py, wavelength)
+
+    def ray_transfer_matrix(
+        self,
+        start: int,
+        end: int,
+        wavelength: float | None = None,
+    ) -> BEArray:
+        """Build the paraxial ray-transfer (ABCD) matrix of a surface range.
+
+        The matrix maps a paraxial ray incident on surface ``start`` to the
+        ray leaving surface ``end``::
+
+            [y_out]   [A  B] [y_in]
+            [u_out] = [C  D] [u_in]
+
+        Both indices are inclusive. The input height and slope are those
+        immediately before surface ``start``, and the output height and slope
+        those immediately after surface ``end``. Only surfaces inside the
+        range contribute: no propagation is included before ``start`` or after
+        ``end``.
+
+        The per-surface refraction, reflection and transfer steps follow the
+        same conventions as :meth:`trace_generic`, so the matrix and an
+        explicit paraxial trace of the same range agree.
+
+        Args:
+            start: Index of the first surface of the range, inclusive. Must be
+                at least 1, since surface 0 is the object surface and carries
+                no power.
+            end: Index of the last surface of the range, inclusive.
+            wavelength: Wavelength in micrometers at which the refractive
+                indices are evaluated. Defaults to the system's primary
+                wavelength.
+
+        Returns:
+            The 2x2 ray-transfer matrix of the surface range.
+
+        Raises:
+            ValueError: If the surface range is invalid.
+
+        """
+        num_surfaces = self.surfaces.num_surfaces
+        if start < 1:
+            raise ValueError(
+                f"Invalid start surface, got {start}. The range must begin at "
+                "an optical surface, so its index must be at least 1 (index 0 "
+                "is the object surface)."
+            )
+        if end > num_surfaces - 1:
+            raise ValueError(
+                f"Invalid end surface, got {end}. The system has "
+                f"{num_surfaces} surfaces, so the largest valid index is "
+                f"{num_surfaces - 1}."
+            )
+        if start > end:
+            raise ValueError(
+                f"Invalid surface range, got start={start} and end={end}. The "
+                "range is inclusive and ordered, so start must not exceed end."
+            )
+
+        if wavelength is None:
+            wavelength = self.optic.primary_wavelength
+
+        R = self.surfaces.radii
+        n = self.surfaces.n(wavelength)
+        pos = be.ravel(self.surfaces.positions)
+
+        matrix = self._interaction_matrix(start, R, n)
+        for k in range(start + 1, end + 1):
+            transfer = self._transfer_matrix(pos[k] - pos[k - 1], n)
+            matrix = be.matmul(
+                self._interaction_matrix(k, R, n), be.matmul(transfer, matrix)
+            )
+        return matrix
+
+    def _interaction_matrix(self, k: int, R: BEArray, n: BEArray) -> BEArray:
+        """Build the ray-transfer matrix of a single surface interaction.
+
+        Args:
+            k: Index of the surface.
+            R: Radii of curvature of all surfaces.
+            n: Refractive indices following each surface.
+
+        Returns:
+            The 2x2 ray-transfer matrix of the surface interaction.
+
+        """
+        surface = self.surfaces[k]
+
+        # Derive the constants from n so they carry the backend's dtype and
+        # device. R is unsuitable, as it is infinite for a plane surface.
+        zero = n[k] * 0.0
+        one = zero + 1.0
+
+        if surface.interaction_model.is_reflective:
+            D = -one
+            if surface.surface_type == "paraxial":
+                C = -one / surface.interaction_model.f
+            else:
+                C = -2.0 / R[k]
+        else:
+            D = n[k - 1] / n[k]
+            if surface.surface_type == "paraxial":
+                C = -one / (surface.interaction_model.f * n[k])
+            else:
+                C = -((n[k] - n[k - 1]) / R[k]) / n[k]
+
+        return be.stack([be.stack([one, zero]), be.stack([C, D])])
+
+    @staticmethod
+    def _transfer_matrix(t: BEArray, n: BEArray) -> BEArray:
+        """Build the ray-transfer matrix for propagation over a distance.
+
+        Args:
+            t: The axial distance to propagate.
+            n: Refractive indices following each surface, used only as a
+                template for the backend's dtype and device.
+
+        Returns:
+            The 2x2 ray-transfer matrix of the propagation.
+
+        """
+        zero = n[0] * 0.0
+        one = zero + 1.0
+        return be.stack([be.stack([one, t + zero]), be.stack([zero, one])])
 
     def trace_generic(
         self,

--- a/tests/test_paraxial.py
+++ b/tests/test_paraxial.py
@@ -1297,3 +1297,184 @@ def test_chief_ray_without_field_definition_raises_descriptive_error(set_test_ba
 
     with pytest.raises(ValueError, match="No field definition is set"):
         lens.paraxial.chief_ray()
+
+
+def _air_spaced_singlet(n_lens=1.5, r1=50.0, r2=-50.0, d=5.0):
+    """Build a singlet in air, for comparison against analytic formulas."""
+    lens = Optic()
+    lens.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    lens.surfaces.add(
+        index=1, radius=r1, thickness=d, material=IdealMaterial(n=n_lens), is_stop=True
+    )
+    lens.surfaces.add(index=2, radius=r2, thickness=95.0)
+    lens.surfaces.add(index=3)
+
+    lens.set_aperture(aperture_type="EPD", value=10)
+    lens.fields.set_type(field_type="angle")
+    lens.fields.add(y=0)
+    lens.wavelengths.add(value=0.5876, is_primary=True)
+    return lens
+
+
+@pytest.mark.parametrize("optic_and_values", get_optic_data(), indirect=True)
+def test_f2_range_over_full_system_matches_f2(optic_and_values):
+    """The EFL of the complete surface range equals the system EFL."""
+    optic_instance, values = optic_and_values
+    last = optic_instance.surfaces.num_surfaces - 1
+    assert_allclose(optic_instance.paraxial.f2_range(1, last), values["f2"])
+
+
+def test_f2_range_single_element_matches_thick_lens(set_test_backend):
+    """A lone thick element reproduces the Jenkins & White thick-lens EFL."""
+    n_lens, r1, r2, d = 1.5, 50.0, -50.0, 5.0
+    lens = _air_spaced_singlet(n_lens, r1, r2, d)
+
+    expected = ThickLens(n1=1.0, n2=n_lens, n3=1.0, r1=r1, r2=r2, d=d).f2
+    assert_allclose(lens.paraxial.f2_range(1, 2), expected)
+
+
+def test_f2_range_element_within_system_matches_thick_lens(set_test_backend):
+    """A group embedded in a larger system is evaluated in isolation."""
+    lens = CookeTriplet()
+
+    # First element of the triplet: surfaces 1 and 2, with air on both sides.
+    n_lens = be.to_numpy(lens.surfaces[1].material_post.n(lens.primary_wavelength))
+    radii = be.to_numpy(lens.surfaces.radii)
+    positions = be.to_numpy(be.ravel(lens.surfaces.positions))
+
+    expected = ThickLens(
+        n1=1.0,
+        n2=n_lens.item(),
+        n3=1.0,
+        r1=radii[1].item(),
+        r2=radii[2].item(),
+        d=(positions[2] - positions[1]).item(),
+    ).f2
+    assert_allclose(lens.paraxial.f2_range(1, 2), expected)
+
+
+def test_f2_range_single_surface(set_test_backend):
+    """A single refracting surface has an EFL of n' / power."""
+    n_lens, r1 = 1.5, 50.0
+    lens = _air_spaced_singlet(n_lens=n_lens, r1=r1)
+
+    assert_allclose(lens.paraxial.f2_range(1, 1), n_lens / ((n_lens - 1.0) / r1))
+
+
+def test_f2_range_is_not_a_decomposition_of_system_power(set_test_backend):
+    """Group EFLs are computed in isolation, not by splitting system power."""
+    lens = CookeTriplet()
+    group_powers = sum(
+        1.0 / float(be.to_numpy(lens.paraxial.f2_range(k, k + 1))) for k in (1, 3, 5)
+    )
+    system_power = 1.0 / float(be.to_numpy(lens.paraxial.f2()))
+
+    # The group powers ignore the separations between the groups' principal
+    # planes, so they must not be mistaken for the system power. Assert they
+    # genuinely differ, so the documented caveat stays honest.
+    assert abs(group_powers - system_power) > 1e-3
+
+
+def test_f2_range_afocal_returns_inf(set_test_backend):
+    """A range with no net power has an infinite EFL."""
+    lens = _air_spaced_singlet()
+
+    # Surface 3 is the flat image surface, with air on both sides.
+    assert be.isinf(lens.paraxial.f2_range(3, 3))
+
+
+def test_f2_range_paraxial_surface(set_test_backend):
+    """Ideal (paraxial) surfaces report their own focal length."""
+    lens = Optic()
+    lens.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    lens.surfaces.add(
+        index=1, surface_type="paraxial", f=-50.0, thickness=0.0, is_stop=True
+    )
+    lens.surfaces.add(index=2)
+    lens.set_aperture(aperture_type="EPD", value=10)
+    lens.fields.set_type(field_type="angle")
+    lens.fields.add(y=0)
+    lens.wavelengths.add(value=0.5876, is_primary=True)
+
+    assert_allclose(lens.paraxial.f2_range(1, 1), -50.0)
+
+
+def test_f2_range_respects_wavelength(set_test_backend):
+    """The wavelength argument selects the dispersion used for the group."""
+    lens = CookeTriplet()
+    blue = float(be.to_numpy(lens.paraxial.f2_range(1, 2, wavelength=0.4861)))
+    red = float(be.to_numpy(lens.paraxial.f2_range(1, 2, wavelength=0.6563)))
+
+    # Normal dispersion: the blue focal length is the shorter of the two.
+    assert blue < red
+
+
+def test_ray_transfer_matrix_determinant(set_test_backend):
+    """det(M) equals n_before / n_after for a purely refractive range."""
+    lens = CookeTriplet()
+    matrix = be.to_numpy(lens.paraxial.ray_transfer_matrix(1, 6))
+    n = be.to_numpy(lens.surfaces.n(lens.primary_wavelength))
+
+    determinant = matrix[0, 0] * matrix[1, 1] - matrix[0, 1] * matrix[1, 0]
+    assert_allclose(determinant, n[0] / n[6])
+
+
+def test_ray_transfer_matrix_composes(set_test_backend):
+    """Splitting a range and re-composing it reproduces the whole matrix."""
+    lens = CookeTriplet()
+    positions = be.ravel(lens.surfaces.positions)
+
+    whole = lens.paraxial.ray_transfer_matrix(1, 6)
+    first = lens.paraxial.ray_transfer_matrix(1, 3)
+    second = lens.paraxial.ray_transfer_matrix(4, 6)
+    gap = float(be.to_numpy(positions[4] - positions[3]))
+    transfer = be.array([[1.0, gap], [0.0, 1.0]])
+
+    assert_allclose(be.matmul(second, be.matmul(transfer, first)), whole)
+
+
+def test_ray_transfer_matrix_invalid_range(set_test_backend):
+    """Out-of-bounds and inverted surface ranges are rejected."""
+    lens = CookeTriplet()
+    last = lens.surfaces.num_surfaces - 1
+
+    with pytest.raises(ValueError, match="at least 1"):
+        lens.paraxial.f2_range(0, 2)
+
+    with pytest.raises(ValueError, match="largest valid index"):
+        lens.paraxial.f2_range(1, last + 1)
+
+    with pytest.raises(ValueError, match="must not exceed end"):
+        lens.paraxial.ray_transfer_matrix(4, 2)
+
+
+def test_f2_range_is_differentiable(set_test_backend):
+    """The group EFL carries gradients back to the surface parameters."""
+    if be.get_backend() != "torch":
+        pytest.skip("Autodiff test only runs for torch backend")
+
+    be.grad_mode.enable()
+    radius_tensor = be.array(50.0)
+    radius_tensor.requires_grad = True
+
+    lens = Optic()
+    lens.surfaces.add(index=0, radius=be.inf, thickness=be.inf)
+    lens.surfaces.add(
+        index=1,
+        radius=radius_tensor,
+        thickness=5.0,
+        material=IdealMaterial(n=1.5),
+        is_stop=True,
+    )
+    lens.surfaces.add(index=2, radius=-50.0, thickness=95.0)
+    lens.surfaces.add(index=3)
+    lens.set_aperture(aperture_type="EPD", value=10)
+    lens.fields.set_type(field_type="angle")
+    lens.fields.add(y=0)
+    lens.wavelengths.add(value=0.5876, is_primary=True)
+
+    lens.paraxial.f2_range(1, 2).backward()
+
+    grad = lens.surfaces[1].geometry.radius.grad
+    assert grad is not None
+    assert be.to_numpy(grad) != 0


### PR DESCRIPTION
Closes #732.

Adds a paraxial helper that returns the effective focal length of a contiguous
range of surfaces, so a lens group inside a larger design can be characterised
on its own.

### API

```python
lens = CookeTriplet()
lens.paraxial.f2_range(1, 2)            # EFL of the first element
lens.paraxial.ray_transfer_matrix(1, 2) # the underlying 2x2 ABCD matrix
```

Both indices are inclusive, and both methods take an optional `wavelength`
that defaults to the system's primary wavelength.

### Approach

`ray_transfer_matrix(start, end)` builds the equivalent ABCD matrix for the
range by composing the per-surface interaction and transfer matrices. Those
matrices are transcribed directly from the update rules in
`ParaxialRayTracer.trace_generic`, including the reflective and `paraxial`
(ideal lens) branches, so the matrix and an explicit trace cannot drift apart:

| step | matrix |
| --- | --- |
| refraction | `[[1, 0], [-phi_k / n_k, n_{k-1} / n_k]]` |
| reflection | `[[1, 0], [-2 / R_k, -1]]` |
| transfer   | `[[1, t], [0, 1]]` |

`f2_range()` then reads the EFL off that matrix as `-1 / C`, which is the same
ratio `f2()` forms from a ray launched parallel to the axis.

The matrices are assembled with `be.stack` rather than by index assignment, so
the result stays differentiable under the torch backend.

### On the "in isolation" caveat

Per the issue, the docstring states explicitly that this is the paraxial EFL of
the range **with its own conjugates**, and not a decomposition of the full
system's power. `test_f2_range_is_not_a_decomposition_of_system_power` asserts
that the group powers of a Cooke triplet genuinely do *not* sum to the system
power (0.0032 vs 0.0291), so the caveat cannot quietly stop being true.

### Tests

`tests/test_paraxial.py`, all on both the numpy and torch backends:

- `f2_range(1, last)` reproduces `f2()` across every sample system in
  `get_optic_data()` — this is the main correctness check, and it covers the
  mirror path via `HubbleTelescope`.
- a lone thick element, and an element embedded in a Cooke triplet, both match
  the analytic Jenkins & White thick-lens EFL already used elsewhere in the file.
- a single refracting surface gives `n' / phi`.
- `det(M) == n_before / n_after` for a refractive range.
- splitting a range and re-composing it reproduces the whole matrix.
- ideal (`paraxial`) surfaces, an afocal range returning `inf`, the `wavelength`
  argument, and the `ValueError`s for invalid ranges.

Locally the paraxial suite is 2128 passed / 1 skipped across both backends
(the skip is the autodiff test on numpy), and `ruff check` / `ruff format` are
clean.

### Unrelated pre-existing failures

While running the full suite I hit 5 failures in `tests/test_ray_aiming.py`
(`test_epd_invariant_under_translation` and
`test_float_by_stop_epd_invariant_under_translation`, numpy backend). They
reproduce identically on a clean `master` with my changes stashed, so they are
not from this PR — but flagging them in case they aren't already known.

### Notes for review

- I made `ray_transfer_matrix` public because the matrix is useful beyond EFL
  (group principal planes, for instance), but I'm happy to make it private if
  you'd rather keep the surface area smaller.
- I kept this to the paraxial helper. If an `EFLRange`-style optimization
  operand would be welcome — a couple of people in #471 mentioned wanting to
  constrain group focal lengths — I'm glad to add it in a follow-up.
