### PR TITLE
Reduce complexity in several modules

### DIFF
--- a/optiland/analysis/angle_vs_height.py
+++ b/optiland/analysis/angle_vs_height.py
@@ -10,6 +10,7 @@ Implemented in Optiland by Kramer Harrison, 2025
 from __future__ import annotations
 
 import abc
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
@@ -27,65 +28,66 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
 
 
-def _plot_angle_vs_height(
-    plot_data_list: list,
-    axis: int,
-    optic_name: str,
-    plot_style: str,
-    ax: Axes,
-    title: str,
-    color_label: str,
-    cmap: str | Colormap,
-) -> None:
+@dataclass(frozen=True)
+class _AngleVsHeightPlotSpec:
+    """Everything needed to render one angle-vs-height plot, besides the axes."""
+
+    plot_data_list: list
+    axis: int
+    optic_name: str
+    plot_style: str
+    title: str | None
+    color_label: str
+    cmap: str | Colormap
+
+
+def _compose_title(title: str | None, optic_name: str, legend_labels: list[str]) -> str:
+    base_title = " - ".join(str(part) for part in (title, optic_name) if part)
+    full_title = f"{base_title}\n" if base_title else ""
+    return full_title + ", ".join(legend_labels)
+
+
+def _add_angle_vs_height_line(
+    ax: Axes, spec: _AngleVsHeightPlotSpec, norm, series: tuple
+):
+    """Add one (height, angle) trace as a scan-range-colored LineCollection."""
+    height, angle_deg, scan_range, _ = series
+    points = np.array([height, angle_deg]).T.reshape(-1, 1, 2)
+    segments = np.concatenate([points[:-1], points[1:]], axis=1)
+
+    lc = LineCollection(segments, cmap=spec.cmap, norm=norm, linestyle=spec.plot_style)
+    lc.set_array(scan_range)
+    lc.set_linewidth(3)
+    return ax.add_collection(lc)
+
+
+def _plot_angle_vs_height(plot_spec: _AngleVsHeightPlotSpec, ax: Axes) -> None:
     """Helper function to generate a consistent angle vs. image
     height plot on a given axis.
 
     Args:
-        plot_data_list (list): A list of tuples, where each tuple contains:
-            (height, angle_deg, scan_range, legend_label).
-        axis (int): Specifies the axis for measurement (0 for x, 1 for y).
-        optic_name (str): The name of the optic, used for the plot title.
-        plot_style (str): Matplotlib plot style for the line.
+        plot_spec: The data and styling for the plot.
         ax (matplotlib.axes.Axes): The axes object to plot on.
-        title (str or None): An optional subtitle for the plot.
-        color_label (str): The label for the colorbar.
-        cmap (str): The name of the colormap to use.
     """
     norm = plt.Normalize(-1, 1)
-    linewidth = 3
+    line = None
+    for series in plot_spec.plot_data_list:
+        line = _add_angle_vs_height_line(ax, plot_spec, norm, series)
 
-    base_title = ""
-    if title and optic_name:
-        base_title = f"{title} - {optic_name}"
-    elif title:
-        base_title = str(title)
-    elif optic_name:
-        base_title = str(optic_name)
-
-    # Compose the full title
-    full_title = base_title
-    if full_title:
-        full_title += "\n"
-    full_title += ", ".join([p[3] for p in plot_data_list])
-
-    for height, angle_deg, scan_range, _ in plot_data_list:
-        # Create segments for the LineCollection
-        points = np.array([height, angle_deg]).T.reshape(-1, 1, 2)
-        segments = np.concatenate([points[:-1], points[1:]], axis=1)
-
-        # Create a LineCollection, color it with the scan_range, and add to plot
-        lc = LineCollection(segments, cmap=cmap, norm=norm, linestyle=plot_style)
-        lc.set_array(scan_range)
-        lc.set_linewidth(linewidth)
-        line = ax.add_collection(lc)
+    full_title = _compose_title(
+        plot_spec.title,
+        plot_spec.optic_name,
+        [p[3] for p in plot_spec.plot_data_list],
+    )
 
     fig = ax.get_figure()
-    fig.suptitle("Incident Angle vs Image Height" + (" (x-axis)" if axis == 0 else ""))
+    axis_suffix = " (x-axis)" if plot_spec.axis == 0 else ""
+    fig.suptitle("Incident Angle vs Image Height" + axis_suffix)
     ax.set_title(full_title, fontsize=10)
     ax.set_xlabel("Image Height in Millimeters")
     ax.set_ylabel("Incident Angle in Degrees")
-    cbar = fig.colorbar(line, ax=ax, label=color_label)
-    cbar.set_label(color_label, labelpad=15)
+    cbar = fig.colorbar(line, ax=ax, label=plot_spec.color_label)
+    cbar.set_label(plot_spec.color_label, labelpad=15)
     ax.grid(alpha=0.25)
     ax.autoscale_view()
 
@@ -212,6 +214,76 @@ class BaseAngleVsHeightAnalysis(BaseAnalysis, abc.ABC):
         }
         return data
 
+    @staticmethod
+    def _prepare_axes(
+        fig_to_plot_on: Figure | None, figsize: tuple[float, float]
+    ) -> tuple[Figure, Axes, bool]:
+        is_gui_embedding = fig_to_plot_on is not None
+        if is_gui_embedding:
+            current_fig = fig_to_plot_on
+            current_fig.clear()
+            ax = current_fig.add_subplot(111)
+        else:
+            current_fig, ax = plt.subplots(figsize=figsize)
+        return current_fig, ax, is_gui_embedding
+
+    @staticmethod
+    def _draw_no_data_message(ax: Axes) -> None:
+        ax.text(
+            0.5,
+            0.5,
+            "Error: Data could not be generated.",
+            ha="center",
+            va="center",
+            color="red",
+        )
+
+    def _color_label(self, fixed_coords_type: str) -> str:
+        """The colorbar label for what is being scanned."""
+        if fixed_coords_type == "Pupil":  # Pupil is fixed, Field is scanned
+            kind, coord = "Field", "Hx" if self.axis == 0 else "Hy"
+        else:  # Field is fixed, Pupil is scanned
+            kind, coord = "Pupil", "Px" if self.axis == 0 else "Py"
+        return f"Normalized {kind} Coordinate ({coord})"
+
+    @staticmethod
+    def _legend_label(fixed_coords: str, fixed_p1, fixed_p2, wavelength) -> str:
+        prefix1, prefix2 = ("Px", "Py") if fixed_coords == "Pupil" else ("Hx", "Hy")
+        return (
+            f"{prefix1}={np.round(fixed_p1, 4).item()} "
+            f"{prefix2}={np.round(fixed_p2, 4).item()}, "
+            f"{np.round(wavelength, 4).item()} µm"
+        )
+
+    def _build_plot_data_list(self) -> list[tuple]:
+        """Reshape the generated data into the tuples `_plot_angle_vs_height` needs."""
+        plot_data_list = []
+        for (fixed_p1, fixed_p2, wavelength), plot_data in self.data.items():
+            fixed_p1 = be.to_numpy(fixed_p1)
+            fixed_p2 = be.to_numpy(fixed_p2)
+            wavelength = be.to_numpy(wavelength)
+            legend_label = self._legend_label(
+                plot_data["fixed_coordinates"], fixed_p1, fixed_p2, wavelength
+            )
+            plot_data_list.append(
+                (
+                    plot_data["height"],
+                    np.rad2deg(plot_data["angle"]),
+                    plot_data["scan_range"],
+                    legend_label,
+                )
+            )
+        return plot_data_list
+
+    @staticmethod
+    def _finalize_figure(
+        current_fig: Figure, is_gui_embedding: bool, show: bool
+    ) -> None:
+        if is_gui_embedding and hasattr(current_fig, "canvas"):
+            current_fig.canvas.draw_idle()
+        if show and not is_gui_embedding:
+            plt.show()
+
     def view(
         self,
         fig_to_plot_on: Figure = None,
@@ -240,87 +312,32 @@ class BaseAngleVsHeightAnalysis(BaseAnalysis, abc.ABC):
         Returns:
             tuple: A tuple containing the figure and axes objects used for plotting.
         """
-        is_gui_embedding = fig_to_plot_on is not None
-
-        if is_gui_embedding:
-            current_fig = fig_to_plot_on
-            current_fig.clear()
-            ax = current_fig.add_subplot(111)
-        else:
-            current_fig, ax = plt.subplots(figsize=figsize)
+        current_fig, ax, is_gui_embedding = self._prepare_axes(fig_to_plot_on, figsize)
 
         if not self.data:
-            ax.text(
-                0.5,
-                0.5,
-                "Error: Data could not be generated.",
-                ha="center",
-                va="center",
-                color="red",
-            )
+            self._draw_no_data_message(ax)
             if is_gui_embedding:
                 current_fig.canvas.draw_idle()
             return ax
 
-        plot_data_list = []
-
-        # Determine the colorbar label based on what is being scanned.
         first_item_data = next(iter(self.data.values()))
-        fixed_coords_type = first_item_data["fixed_coordinates"]
-        if fixed_coords_type == "Pupil":  # Pupil is fixed, Field is scanned
-            color_label = (
-                f"Normalized Field Coordinate ({'Hx' if self.axis == 0 else 'Hy'})"
-            )
-        else:  # Field is fixed, Pupil is scanned
-            color_label = (
-                f"Normalized Pupil Coordinate ({'Px' if self.axis == 0 else 'Py'})"
-            )
-
-        # Iterate through the generated data items to prepare for plotting
-        for (fixed_p1, fixed_p2, wavelength), plot_data in self.data.items():
-            fixed_p1 = be.to_numpy(fixed_p1)
-            fixed_p2 = be.to_numpy(fixed_p2)
-            wavelength = be.to_numpy(wavelength)
-
-            fixed_coords = plot_data["fixed_coordinates"]
-            if fixed_coords == "Pupil":
-                legend_label = (
-                    f"Px={np.round(fixed_p1, 4).item()} "
-                    f"Py={np.round(fixed_p2, 4).item()}, "
-                    f"{np.round(wavelength, 4).item()} µm"
-                )
-            else:  # fixed_coords == 'Field'
-                legend_label = (
-                    f"Hx={np.round(fixed_p1, 4).item()} "
-                    f"Hy={np.round(fixed_p2, 4).item()}, "
-                    f"{np.round(wavelength, 4).item()} µm"
-                )
-            plot_data_list.append(
-                (
-                    plot_data["height"],
-                    np.rad2deg(plot_data["angle"]),
-                    plot_data["scan_range"],
-                    legend_label,
-                )
-            )
+        color_label = self._color_label(first_item_data["fixed_coordinates"])
 
         _plot_angle_vs_height(
-            plot_data_list=plot_data_list,
-            axis=self.axis,
-            optic_name=self.optic.name,
-            plot_style=line_style,
+            _AngleVsHeightPlotSpec(
+                plot_data_list=self._build_plot_data_list(),
+                axis=self.axis,
+                optic_name=self.optic.name,
+                plot_style=line_style,
+                title=title,
+                color_label=color_label,
+                cmap=cmap,
+            ),
             ax=ax,
-            title=title,
-            color_label=color_label,
-            cmap=cmap,
         )
 
         current_fig.tight_layout()
-
-        if is_gui_embedding and hasattr(current_fig, "canvas"):
-            current_fig.canvas.draw_idle()
-        if show and not is_gui_embedding:
-            plt.show()
+        self._finalize_figure(current_fig, is_gui_embedding, show)
         return current_fig, ax
 
 

--- a/optiland/analysis/rms_vs_field.py
+++ b/optiland/analysis/rms_vs_field.py
@@ -23,6 +23,48 @@ if TYPE_CHECKING:
     from optiland.optic import Optic
 
 
+def _prepare_axes(
+    fig_to_plot_on: Figure | None, figsize: tuple[float, float]
+) -> tuple[Figure, Axes, bool]:
+    is_gui_embedding = fig_to_plot_on is not None
+    if is_gui_embedding:
+        current_fig = fig_to_plot_on
+        current_fig.clear()
+        ax = current_fig.add_subplot(111)
+    else:
+        current_fig, ax = plt.subplots(figsize=figsize)
+    return current_fig, ax, is_gui_embedding
+
+
+def _finalize_figure(current_fig: Figure, is_gui_embedding: bool, show: bool) -> None:
+    if is_gui_embedding and hasattr(current_fig, "canvas"):
+        current_fig.canvas.draw_idle()
+    if show and not is_gui_embedding:
+        plt.show()
+
+
+def _plot_field_series(
+    ax: Axes, field_y, series_data, wavelengths, y_label: str
+) -> None:
+    """Plot one line per wavelength of `series_data` vs. normalized Y field.
+
+    Shared by RmsSpotSizeVsField.view() and RmsWavefrontErrorVsField.view(),
+    which differ only in which precomputed array and axis label they plot.
+    """
+    field_y_np = be.to_numpy(field_y)
+    data_np = be.to_numpy(series_data)
+
+    for i, wp in enumerate(wavelengths):
+        ax.plot(field_y_np, data_np[:, i], label=f"{wp.value:.4f} µm")
+
+    ax.set_xlabel("Normalized Y Field Coordinate")
+    ax.set_ylabel(y_label)
+    ax.legend(bbox_to_anchor=(1.05, 0.5), loc="center left")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, None)
+    ax.grid()
+
+
 class RmsSpotSizeVsField(SpotDiagram):
     """RMS Spot Size versus Field Coordinate.
 
@@ -89,38 +131,18 @@ class RmsSpotSizeVsField(SpotDiagram):
         - The legend is placed outside the plot area for better readability.
         - The method is suitable for both standalone plotting and GUI embedding.
         """
-        is_gui_embedding = fig_to_plot_on is not None
+        current_fig, ax, is_gui_embedding = _prepare_axes(fig_to_plot_on, figsize)
 
-        if is_gui_embedding:
-            current_fig = fig_to_plot_on
-            current_fig.clear()
-            ax = current_fig.add_subplot(111)
-        else:
-            current_fig, ax = plt.subplots(figsize=figsize)
+        _plot_field_series(
+            ax,
+            self._field[:, 1],
+            self._spot_size,
+            self.wavelengths,
+            "RMS Spot Size (mm)",
+        )
 
-        analysis_wavelengths = self.wavelengths
-        spot_size_data = be.to_numpy(self._spot_size)
-
-        # Plot each wavelength's data as a separate line to handle legends correctly.
-        for i, wp in enumerate(analysis_wavelengths):
-            ax.plot(
-                be.to_numpy(self._field[:, 1]),
-                spot_size_data[:, i],
-                label=f"{wp.value:.4f} µm",
-            )
-
-        ax.set_xlabel("Normalized Y Field Coordinate")
-        ax.set_ylabel("RMS Spot Size (mm)")
-        ax.legend(bbox_to_anchor=(1.05, 0.5), loc="center left")
-        ax.set_xlim(0, 1)
-        ax.set_ylim(0, None)
-        ax.grid()
         current_fig.tight_layout()
-
-        if is_gui_embedding and hasattr(current_fig, "canvas"):
-            current_fig.canvas.draw_idle()
-        if show and not is_gui_embedding:
-            plt.show()
+        _finalize_figure(current_fig, is_gui_embedding, show)
         return current_fig, ax
 
 
@@ -163,37 +185,18 @@ class RmsWavefrontErrorVsField(Wavefront):
         show: bool = True,
     ) -> tuple[Figure, Axes]:
         """View the RMS wavefront error versus field coordinate."""
-        is_gui_embedding = fig_to_plot_on is not None
+        current_fig, ax, is_gui_embedding = _prepare_axes(fig_to_plot_on, figsize)
 
-        if is_gui_embedding:
-            current_fig = fig_to_plot_on
-            current_fig.clear()
-            ax = current_fig.add_subplot(111)
-        else:
-            current_fig, ax = plt.subplots(figsize=figsize)
+        _plot_field_series(
+            ax,
+            self._field[:, 1],
+            self._wavefront_error,
+            self.wavelengths,
+            "RMS Wavefront Error (waves)",
+        )
 
-        analysis_wavelengths = self.wavelengths
-        wavefront_error_data = be.to_numpy(self._wavefront_error)
-
-        # Plot each wavelength's data as a separate line.
-        for i, wp in enumerate(analysis_wavelengths):
-            ax.plot(
-                be.to_numpy(self._field[:, 1]),
-                wavefront_error_data[:, i],
-                label=f"{wp.value:.4f} µm",
-            )
-        ax.set_xlabel("Normalized Y Field Coordinate")
-        ax.set_ylabel("RMS Wavefront Error (waves)")
-        ax.legend(bbox_to_anchor=(1.05, 0.5), loc="center left")
-        ax.set_xlim(0, 1)
-        ax.set_ylim(0, None)
-        ax.grid()
         current_fig.tight_layout()
-
-        if is_gui_embedding and hasattr(current_fig, "canvas"):
-            current_fig.canvas.draw_idle()
-        if show and not is_gui_embedding:
-            plt.show()
+        _finalize_figure(current_fig, is_gui_embedding, show)
         return current_fig, ax
 
     def _rms_wavefront_error(self):

--- a/optiland/diagnostics/checks.py
+++ b/optiland/diagnostics/checks.py
@@ -23,7 +23,9 @@ from optiland.diagnostics.report import Diagnostic, Severity
 from optiland.surfaces.object_surface import ObjectSurface
 
 if TYPE_CHECKING:
+    from optiland._types import ScalarOrArray
     from optiland.optic.optic import Optic
+    from optiland.surfaces.standard_surface import Surface
 
 SystemCheck = Callable[["Optic"], "list[Diagnostic]"]
 
@@ -225,7 +227,9 @@ def check_stop_at_object_or_image(lens: Optic) -> list[Diagnostic]:
 # --------------------------------------------------------------------------
 
 
-def _interior_thickness_diagnostic(index: int, surf, n: int) -> Diagnostic | None:
+def _interior_thickness_diagnostic(
+    index: int, surf: Surface, n: int
+) -> Diagnostic | None:
     # The object surface (index 0) may legitimately sit at infinity, and
     # the image surface's thickness is not meaningful, so only interior
     # surfaces are checked for non-finite thickness.
@@ -243,7 +247,7 @@ def _interior_thickness_diagnostic(index: int, surf, n: int) -> Diagnostic | Non
     )
 
 
-def _nan_radius_diagnostic(index: int, surf) -> Diagnostic | None:
+def _nan_radius_diagnostic(index: int, surf: Surface) -> Diagnostic | None:
     radius = getattr(surf.geometry, "radius", None)
     # An infinite radius is a normal, flat surface; only NaN is a bug.
     if radius is None or not be.isnan(be.array(radius)).any():
@@ -274,7 +278,7 @@ def check_non_finite_interior_thickness(lens: Optic) -> list[Diagnostic]:
 # --------------------------------------------------------------------------
 
 
-def _material_dispersion_range(surf) -> tuple[float, float, str] | None:
+def _material_dispersion_range(surf: Surface) -> tuple[float, float, str] | None:
     material = getattr(surf, "material_post", None)
     material_data = getattr(material, "material_data", None)
     if not material_data:
@@ -330,7 +334,7 @@ def check_wavelength_outside_material_range(lens: Optic) -> list[Diagnostic]:
 
 
 def _thickness_sign_diagnostic(
-    index: int, thickness, expect_negative: bool, reflections: int
+    index: int, thickness: ScalarOrArray, expect_negative: bool, reflections: int
 ) -> Diagnostic | None:
     is_bad = thickness >= 0 if expect_negative else thickness <= 0
     if not is_bad:

--- a/optiland/diagnostics/checks.py
+++ b/optiland/diagnostics/checks.py
@@ -15,6 +15,7 @@ Kramer Harrison, 2026
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
@@ -33,204 +34,320 @@ def _doc_url(code: str) -> str:
     return f"{_DOC_BASE}#{code.lower()}"
 
 
-def check_no_wavelengths(lens: Optic) -> list[Diagnostic]:
-    """OPT001: no wavelengths are defined."""
-    if lens.wavelengths.num_wavelengths > 0:
+# --------------------------------------------------------------------------
+# OPT001-OPT006: simple, single-condition presence checks.
+#
+# Each of these fires at most one diagnostic, based on one boolean fact
+# about the system. Rather than repeat the same "if broken: build and
+# return a Diagnostic" shape six times, each is declared as data and run
+# through a single, shared executor.
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _PresenceRule:
+    """A diagnostic that fires when `is_broken(lens)` is true."""
+
+    code: str
+    severity: Severity
+    is_broken: Callable[[Optic], bool]
+    message: Callable[[Optic], str]
+    fix: str
+
+
+def _run_presence_rule(lens: Optic, rule: _PresenceRule) -> list[Diagnostic]:
+    if not rule.is_broken(lens):
         return []
     return [
         Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT001",
-            message="No wavelengths are defined on the optical system.",
-            fix="lens.wavelengths.add(value=0.55, is_primary=True)",
-            doc_url=_doc_url("OPT001"),
+            severity=rule.severity,
+            code=rule.code,
+            message=rule.message(lens),
+            fix=rule.fix,
+            doc_url=_doc_url(rule.code),
         )
     ]
+
+
+_OPT001_NO_WAVELENGTHS = _PresenceRule(
+    code="OPT001",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: lens.wavelengths.num_wavelengths == 0,
+    message=lambda lens: "No wavelengths are defined on the optical system.",
+    fix="lens.wavelengths.add(value=0.55, is_primary=True)",
+)
+
+_OPT002_NO_PRIMARY_WAVELENGTH = _PresenceRule(
+    code="OPT002",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: (
+        lens.wavelengths.num_wavelengths > 0
+        and not any(w.is_primary for w in lens.wavelengths)
+    ),
+    message=lambda lens: "Wavelengths are defined, but none is marked primary.",
+    fix="lens.wavelengths.add(value=0.55, is_primary=True)",
+)
+
+_OPT003_NO_APERTURE = _PresenceRule(
+    code="OPT003",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: lens.aperture is None,
+    message=lambda lens: "No aperture is defined on the optical system.",
+    fix='lens.set_aperture(aperture_type="EPD", value=25)',
+)
+
+_OPT004_NO_STOP_SURFACE = _PresenceRule(
+    code="OPT004",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: (
+        len(lens.surfaces.surfaces) > 0
+        and not any(surf.is_stop for surf in lens.surfaces.surfaces)
+    ),
+    message=lambda lens: "No stop surface is defined.",
+    fix="lens.surfaces.add(..., is_stop=True) on the aperture surface",
+)
+
+_OPT005_TOO_FEW_SURFACES = _PresenceRule(
+    code="OPT005",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: lens.surfaces.num_surfaces < 2,
+    message=lambda lens: (
+        f"The system has only {lens.surfaces.num_surfaces} surface(s); "
+        "at least an object and an image surface are required."
+    ),
+    fix=(
+        "lens.surfaces.add(index=0, thickness=be.inf) for the object "
+        "surface, then add an image surface last"
+    ),
+)
+
+_OPT006_NO_FIELDS = _PresenceRule(
+    code="OPT006",
+    severity=Severity.ERROR,
+    is_broken=lambda lens: len(lens.fields.fields) == 0,
+    message=lambda lens: "No fields are defined on the optical system.",
+    fix="lens.fields.add(y=0)",
+)
+
+
+def check_no_wavelengths(lens: Optic) -> list[Diagnostic]:
+    """OPT001: no wavelengths are defined."""
+    return _run_presence_rule(lens, _OPT001_NO_WAVELENGTHS)
 
 
 def check_no_primary_wavelength(lens: Optic) -> list[Diagnostic]:
     """OPT002: wavelengths exist, but none is marked primary."""
-    if lens.wavelengths.num_wavelengths == 0:
-        return []
-    if any(w.is_primary for w in lens.wavelengths):
-        return []
-    return [
-        Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT002",
-            message="Wavelengths are defined, but none is marked primary.",
-            fix="lens.wavelengths.add(value=0.55, is_primary=True)",
-            doc_url=_doc_url("OPT002"),
-        )
-    ]
+    return _run_presence_rule(lens, _OPT002_NO_PRIMARY_WAVELENGTH)
 
 
 def check_no_aperture(lens: Optic) -> list[Diagnostic]:
     """OPT003: no aperture is defined."""
-    if lens.aperture is not None:
-        return []
-    return [
-        Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT003",
-            message="No aperture is defined on the optical system.",
-            fix='lens.set_aperture(aperture_type="EPD", value=25)',
-            doc_url=_doc_url("OPT003"),
-        )
-    ]
+    return _run_presence_rule(lens, _OPT003_NO_APERTURE)
 
 
 def check_no_stop_surface(lens: Optic) -> list[Diagnostic]:
     """OPT004: no surface is marked as the aperture stop."""
-    surfaces = lens.surfaces.surfaces
-    if len(surfaces) == 0:
-        return []
-    if any(surf.is_stop for surf in surfaces):
-        return []
-    return [
-        Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT004",
-            message="No stop surface is defined.",
-            fix="lens.surfaces.add(..., is_stop=True) on the aperture surface",
-            doc_url=_doc_url("OPT004"),
-        )
-    ]
+    return _run_presence_rule(lens, _OPT004_NO_STOP_SURFACE)
 
 
 def check_too_few_surfaces(lens: Optic) -> list[Diagnostic]:
     """OPT005: fewer than 2 surfaces, so there is no object/image pair."""
-    if lens.surfaces.num_surfaces >= 2:
-        return []
-    return [
-        Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT005",
-            message=(
-                f"The system has only {lens.surfaces.num_surfaces} surface(s); "
-                "at least an object and an image surface are required."
-            ),
-            fix=(
-                "lens.surfaces.add(index=0, thickness=be.inf) for the object "
-                "surface, then add an image surface last"
-            ),
-            doc_url=_doc_url("OPT005"),
-        )
-    ]
+    return _run_presence_rule(lens, _OPT005_TOO_FEW_SURFACES)
 
 
 def check_no_fields(lens: Optic) -> list[Diagnostic]:
     """OPT006: no fields are defined."""
-    if len(lens.fields.fields) > 0:
-        return []
-    return [
-        Diagnostic(
-            severity=Severity.ERROR,
-            code="OPT006",
-            message="No fields are defined on the optical system.",
-            fix="lens.fields.add(y=0)",
-            doc_url=_doc_url("OPT006"),
-        )
-    ]
+    return _run_presence_rule(lens, _OPT006_NO_FIELDS)
+
+
+# --------------------------------------------------------------------------
+# OPT007, OPT011: "find the one offending surface" checks.
+# --------------------------------------------------------------------------
 
 
 def check_object_surface_not_first(lens: Optic) -> list[Diagnostic]:
     """OPT007: the object surface is not at index 0."""
     surfaces = lens.surfaces.surfaces
-    if len(surfaces) == 0:
+    misplaced = next(
+        (
+            index
+            for index, surf in enumerate(surfaces)
+            if isinstance(surf, ObjectSurface) and index != 0
+        ),
+        None,
+    )
+    if misplaced is None:
         return []
-    for index, surf in enumerate(surfaces):
-        if isinstance(surf, ObjectSurface) and index != 0:
-            return [
-                Diagnostic(
-                    severity=Severity.WARNING,
-                    code="OPT007",
-                    message=f"The object surface is at index {index}, not 0.",
-                    fix="Reorder surfaces; the object surface must be index 0.",
-                    where=index,
-                    doc_url=_doc_url("OPT007"),
-                )
-            ]
-    return []
+    return [
+        Diagnostic(
+            severity=Severity.WARNING,
+            code="OPT007",
+            message=f"The object surface is at index {misplaced}, not 0.",
+            fix="Reorder surfaces; the object surface must be index 0.",
+            where=misplaced,
+            doc_url=_doc_url("OPT007"),
+        )
+    ]
+
+
+def check_stop_at_object_or_image(lens: Optic) -> list[Diagnostic]:
+    """OPT011: the stop surface is the object or image surface."""
+    surfaces = lens.surfaces.surfaces
+    last = len(surfaces) - 1
+    found = next(
+        (
+            index
+            for index, surf in enumerate(surfaces)
+            if surf.is_stop and index in (0, last)
+        ),
+        None,
+    )
+    if found is None:
+        return []
+    role = "object" if found == 0 else "image"
+    return [
+        Diagnostic(
+            severity=Severity.WARNING,
+            code="OPT011",
+            message=(
+                f"The stop surface is the {role} surface (index {found}); "
+                "this is usually a mistake."
+            ),
+            fix="Move is_stop=True to the intended aperture surface.",
+            where=found,
+            doc_url=_doc_url("OPT011"),
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# OPT008: non-finite interior thickness or NaN radius.
+# --------------------------------------------------------------------------
+
+
+def _interior_thickness_diagnostic(index: int, surf, n: int) -> Diagnostic | None:
+    # The object surface (index 0) may legitimately sit at infinity, and
+    # the image surface's thickness is not meaningful, so only interior
+    # surfaces are checked for non-finite thickness.
+    if not (0 < index < n - 1):
+        return None
+    if be.isfinite(be.array(surf.thickness)).all():
+        return None
+    return Diagnostic(
+        severity=Severity.WARNING,
+        code="OPT008",
+        message=f"Surface {index} has a non-finite thickness ({surf.thickness}).",
+        fix=f"Set a finite thickness on surface {index}.",
+        where=index,
+        doc_url=_doc_url("OPT008"),
+    )
+
+
+def _nan_radius_diagnostic(index: int, surf) -> Diagnostic | None:
+    radius = getattr(surf.geometry, "radius", None)
+    # An infinite radius is a normal, flat surface; only NaN is a bug.
+    if radius is None or not be.isnan(be.array(radius)).any():
+        return None
+    return Diagnostic(
+        severity=Severity.WARNING,
+        code="OPT008",
+        message=f"Surface {index} has a NaN radius of curvature.",
+        fix=f"Set a valid radius on surface {index}.",
+        where=index,
+        doc_url=_doc_url("OPT008"),
+    )
 
 
 def check_non_finite_interior_thickness(lens: Optic) -> list[Diagnostic]:
     """OPT008: an interior surface has a non-finite thickness or NaN radius."""
     surfaces = lens.surfaces.surfaces
     n = len(surfaces)
-    findings: list[Diagnostic] = []
+    candidates = [
+        _interior_thickness_diagnostic(index, surf, n)
+        for index, surf in enumerate(surfaces)
+    ] + [_nan_radius_diagnostic(index, surf) for index, surf in enumerate(surfaces)]
+    return [d for d in candidates if d is not None]
 
-    for index, surf in enumerate(surfaces):
-        # The object surface (index 0) may legitimately sit at infinity, and
-        # the image surface's thickness is not meaningful, so only interior
-        # surfaces are checked for non-finite thickness.
-        if 0 < index < n - 1 and not be.isfinite(be.array(surf.thickness)).all():
-            findings.append(
-                Diagnostic(
-                    severity=Severity.WARNING,
-                    code="OPT008",
-                    message=(
-                        f"Surface {index} has a non-finite thickness "
-                        f"({surf.thickness})."
-                    ),
-                    fix=f"Set a finite thickness on surface {index}.",
-                    where=index,
-                    doc_url=_doc_url("OPT008"),
-                )
-            )
 
-        radius = getattr(surf.geometry, "radius", None)
-        # An infinite radius is a normal, flat surface; only NaN is a bug.
-        if radius is not None and be.isnan(be.array(radius)).any():
-            findings.append(
-                Diagnostic(
-                    severity=Severity.WARNING,
-                    code="OPT008",
-                    message=f"Surface {index} has a NaN radius of curvature.",
-                    fix=f"Set a valid radius on surface {index}.",
-                    where=index,
-                    doc_url=_doc_url("OPT008"),
-                )
-            )
+# --------------------------------------------------------------------------
+# OPT009: a wavelength falls outside a material's dispersion data range.
+# --------------------------------------------------------------------------
 
-    return findings
+
+def _material_dispersion_range(surf) -> tuple[float, float, str] | None:
+    material = getattr(surf, "material_post", None)
+    material_data = getattr(material, "material_data", None)
+    if not material_data:
+        return None
+
+    min_wl = material_data.get("min_wavelength")
+    max_wl = material_data.get("max_wavelength")
+    if min_wl is None or max_wl is None:
+        return None
+
+    name = getattr(material, "name", None) or repr(material)
+    return min_wl, max_wl, name
+
+
+def _wavelength_range_diagnostic(
+    index: int, name: str, min_wl: float, max_wl: float, value: float
+) -> Diagnostic:
+    return Diagnostic(
+        severity=Severity.WARNING,
+        code="OPT009",
+        message=(
+            f"Wavelength {value} um is outside the valid dispersion range "
+            f"[{min_wl}, {max_wl}] um of material '{name}' on surface {index}."
+        ),
+        fix=(
+            "Use a wavelength within the material's data range, "
+            "or choose a different material."
+        ),
+        where=index,
+        doc_url=_doc_url("OPT009"),
+    )
 
 
 def check_wavelength_outside_material_range(lens: Optic) -> list[Diagnostic]:
     """OPT009: a wavelength falls outside a material's dispersion data range."""
     findings: list[Diagnostic] = []
     for index, surf in enumerate(lens.surfaces.surfaces):
-        material = getattr(surf, "material_post", None)
-        material_data = getattr(material, "material_data", None)
-        if not material_data:
+        dispersion_range = _material_dispersion_range(surf)
+        if dispersion_range is None:
             continue
-
-        min_wl = material_data.get("min_wavelength")
-        max_wl = material_data.get("max_wavelength")
-        if min_wl is None or max_wl is None:
-            continue
-
-        material_name = getattr(material, "name", None) or repr(material)
-        for wavelength in lens.wavelengths:
-            if wavelength.value < min_wl or wavelength.value > max_wl:
-                findings.append(
-                    Diagnostic(
-                        severity=Severity.WARNING,
-                        code="OPT009",
-                        message=(
-                            f"Wavelength {wavelength.value} um is outside the "
-                            f"valid dispersion range [{min_wl}, {max_wl}] um of "
-                            f"material '{material_name}' on surface {index}."
-                        ),
-                        fix=(
-                            "Use a wavelength within the material's data range, "
-                            "or choose a different material."
-                        ),
-                        where=index,
-                        doc_url=_doc_url("OPT009"),
-                    )
-                )
+        min_wl, max_wl, name = dispersion_range
+        findings.extend(
+            _wavelength_range_diagnostic(index, name, min_wl, max_wl, w.value)
+            for w in lens.wavelengths
+            if w.value < min_wl or w.value > max_wl
+        )
     return findings
+
+
+# --------------------------------------------------------------------------
+# OPT010: a thickness has an unexpected sign, or is exactly zero.
+# --------------------------------------------------------------------------
+
+
+def _thickness_sign_diagnostic(
+    index: int, thickness, expect_negative: bool, reflections: int
+) -> Diagnostic | None:
+    is_bad = thickness >= 0 if expect_negative else thickness <= 0
+    if not is_bad:
+        return None
+    expected = "negative" if expect_negative else "positive"
+    return Diagnostic(
+        severity=Severity.WARNING,
+        code="OPT010",
+        message=(
+            f"Surface {index} has thickness {thickness}, but "
+            f"{reflections} reflection(s) precede it (inclusive), "
+            f"so a {expected} value was expected."
+        ),
+        fix=f"Set a {expected} thickness on surface {index}.",
+        where=index,
+        doc_url=_doc_url("OPT010"),
+    )
 
 
 def check_non_positive_thickness(lens: Optic) -> list[Diagnostic]:
@@ -258,50 +375,44 @@ def check_non_positive_thickness(lens: Optic) -> list[Diagnostic]:
         if not be.isfinite(be.array(thickness)).all():
             continue
 
-        expect_negative = reflections % 2 == 1
-        is_bad = thickness >= 0 if expect_negative else thickness <= 0
-        if is_bad:
-            expected = "negative" if expect_negative else "positive"
-            findings.append(
-                Diagnostic(
-                    severity=Severity.WARNING,
-                    code="OPT010",
-                    message=(
-                        f"Surface {index} has thickness {thickness}, but "
-                        f"{reflections} reflection(s) precede it (inclusive), "
-                        f"so a {expected} value was expected."
-                    ),
-                    fix=f"Set a {expected} thickness on surface {index}.",
-                    where=index,
-                    doc_url=_doc_url("OPT010"),
-                )
-            )
+        diagnostic = _thickness_sign_diagnostic(
+            index, thickness, reflections % 2 == 1, reflections
+        )
+        if diagnostic is not None:
+            findings.append(diagnostic)
+
     return findings
 
 
-def check_stop_at_object_or_image(lens: Optic) -> list[Diagnostic]:
-    """OPT011: the stop surface is the object or image surface."""
-    surfaces = lens.surfaces.surfaces
-    n = len(surfaces)
-    if n == 0:
-        return []
-    for index, surf in enumerate(surfaces):
-        if surf.is_stop and index in (0, n - 1):
-            role = "object" if index == 0 else "image"
-            return [
-                Diagnostic(
-                    severity=Severity.WARNING,
-                    code="OPT011",
-                    message=(
-                        f"The stop surface is the {role} surface (index {index}); "
-                        "this is usually a mistake."
-                    ),
-                    fix="Move is_stop=True to the intended aperture surface.",
-                    where=index,
-                    doc_url=_doc_url("OPT011"),
-                )
-            ]
-    return []
+# --------------------------------------------------------------------------
+# OPT012: a probe trace shows no rays reaching the image surface.
+# --------------------------------------------------------------------------
+
+
+def _system_ready_for_probe_trace(lens: Optic) -> bool:
+    preconditions = (
+        lens.surfaces.num_surfaces >= 2,
+        lens.wavelengths.num_wavelengths > 0,
+        any(w.is_primary for w in lens.wavelengths),
+        lens.aperture is not None,
+        any(surf.is_stop for surf in lens.surfaces.surfaces),
+        len(lens.fields.fields) > 0,
+    )
+    return all(preconditions)
+
+
+def _probe_trace_reaches_image(lens: Optic) -> bool:
+    """True if a probe trace reaches the image, or can't be judged."""
+    hx, hy = lens.fields.get_field_coords()[0]
+    try:
+        lens.trace(hx, hy, lens.primary_wavelength, num_rays=8)
+    except Exception:
+        # Ray tracing failures surface through their own exceptions; a probe
+        # trace that raises is not this check's concern to report.
+        return True
+
+    intensity = lens.surfaces.intensity[-1, :]
+    return bool(be.any(intensity != 0))
 
 
 def check_no_rays_reach_image(lens: Optic) -> list[Diagnostic]:
@@ -312,31 +423,10 @@ def check_no_rays_reach_image(lens: Optic) -> list[Diagnostic]:
     surfaces, and at least one field. Any check failure above already
     reports the root cause, so this is skipped rather than duplicated.
     """
-    if lens.surfaces.num_surfaces < 2:
+    if not _system_ready_for_probe_trace(lens):
         return []
-    if lens.wavelengths.num_wavelengths == 0:
+    if _probe_trace_reaches_image(lens):
         return []
-    if not any(w.is_primary for w in lens.wavelengths):
-        return []
-    if lens.aperture is None:
-        return []
-    if not any(surf.is_stop for surf in lens.surfaces.surfaces):
-        return []
-    if len(lens.fields.fields) == 0:
-        return []
-
-    hx, hy = lens.fields.get_field_coords()[0]
-    try:
-        lens.trace(hx, hy, lens.primary_wavelength, num_rays=8)
-    except Exception:
-        # Ray tracing failures surface through their own exceptions; a probe
-        # trace that raises is not this check's concern to report.
-        return []
-
-    intensity = lens.surfaces.intensity[-1, :]
-    if be.any(intensity != 0):
-        return []
-
     return [
         Diagnostic(
             severity=Severity.WARNING,

--- a/optiland/materials/_catalog_parsing.py
+++ b/optiland/materials/_catalog_parsing.py
@@ -1,0 +1,89 @@
+"""Parsing helpers for catalog metadata and refractiveindex.info YAML payloads.
+
+Split out of ``optiland.materials.registry`` — these are pure string/dict
+parsing functions with no dependency on `MaterialRegistry` state.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+
+def _levenshtein(s1: str, s2: str) -> int:
+    """Compute the Levenshtein edit distance between two strings."""
+    rows, cols = len(s1) + 1, len(s2) + 1
+    dist = [[0] * cols for _ in range(rows)]
+    for i in range(1, rows):
+        dist[i][0] = i
+    for j in range(1, cols):
+        dist[0][j] = j
+    for i in range(1, rows):
+        for j in range(1, cols):
+            cost = 0 if s1[i - 1] == s2[j - 1] else 1
+            dist[i][j] = min(
+                dist[i - 1][j] + 1,
+                dist[i][j - 1] + 1,
+                dist[i - 1][j - 1] + cost,
+            )
+    return dist[-1][-1]
+
+
+def _catalog_dir_from_filename(filename: str, group: str = "") -> str:
+    """Extract the manufacturer catalog name from a filename path.
+
+    For glass entries whose path starts with ``glass/``, the manufacturer is
+    always the second path segment (``glass/{manufacturer}/...``), regardless
+    of nesting depth.  For all other entries the species name is the
+    second-to-last segment.
+    """
+    parts = filename.replace("\\", "/").split("/")
+    if group.lower() == "glass" and parts[0].lower() == "glass" and len(parts) >= 3:
+        return parts[1]
+    return parts[-2] if len(parts) >= 3 else ""
+
+
+def _wavelength_range_from_data_points(raw: str) -> tuple[float, float] | None:
+    """Min/max wavelength (µm) from a DATA entry's whitespace-table payload."""
+    wls: list[float] = []
+    for line in raw.strip().splitlines():
+        parts = line.split()
+        if parts:
+            with contextlib.suppress(ValueError):
+                wls.append(float(parts[0]))
+    if not wls:
+        return None
+    return min(wls), max(wls)
+
+
+def _wavelength_range_from_formula_field(wl_range: str) -> tuple[float, float] | None:
+    """Min/max wavelength (µm) from a DATA entry's ``wavelength_range`` field."""
+    parts = str(wl_range).split()
+    if len(parts) < 2:
+        return None
+    try:
+        return float(parts[0]), float(parts[1])
+    except ValueError:
+        return None
+
+
+def _extract_wavelength_range(data: dict) -> tuple[float, float]:
+    """Extract min/max wavelength (µm) from a refractiveindex.info YAML payload."""
+    for item in data.get("DATA", []):
+        raw = item.get("data", "")
+        if not raw:
+            continue
+
+        found = _wavelength_range_from_data_points(raw)
+        if found is not None:
+            return found
+
+        # Formula entries may have a wavelength_range field
+        wl_range = item.get("wavelength_range", "")
+        if wl_range:
+            found = _wavelength_range_from_formula_field(wl_range)
+            if found is not None:
+                return found
+
+    return 0.0, 100.0

--- a/optiland/materials/_material_matching.py
+++ b/optiland/materials/_material_matching.py
@@ -1,0 +1,253 @@
+"""Material name resolution engine: filtering, scoring, and match_policy.
+
+Split out of ``optiland.materials.registry`` — everything here is a pure
+function of a candidate DataFrame and the caller's search parameters, with
+no dependency on `MaterialRegistry` instance state.
+
+Kramer Harrison, 2025
+"""
+
+from __future__ import annotations
+
+import pathlib
+import warnings
+from importlib import resources
+
+import pandas as pd
+
+from optiland._suggest import did_you_mean
+from optiland.materials._catalog_parsing import _levenshtein
+from optiland.materials.material_spec import MatchPolicy
+from optiland.materials.warnings import OptilandMaterialWarning
+
+_DATA_NK_DIR = str(resources.files("optiland.database").joinpath("data-nk"))
+
+
+def resolve_with_row(
+    df: pd.DataFrame,
+    name: str,
+    catalog: str | None,
+    reference: str | None,
+    match_policy: MatchPolicy,
+    min_wavelength: float | None,
+    max_wavelength: float | None,
+) -> tuple[str, dict]:
+    """Resolve a material against ``df`` and return ``(path, metadata_row_dict)``."""
+    df = _prefilter_by_catalog(df, catalog)
+
+    filtered_df = _find_matches(df, name, reference, min_wavelength, max_wavelength)
+    _raise_if_no_matches(filtered_df, name, catalog, reference, df)
+
+    _apply_match_policy(filtered_df, name, catalog, match_policy)
+
+    row = filtered_df.iloc[0].to_dict()
+    return _row_to_path(row), row
+
+
+def _prefilter_by_catalog(df: pd.DataFrame, catalog: str | None) -> pd.DataFrame:
+    """Restrict ``df`` to a single manufacturer catalog, if given."""
+    if catalog is None:
+        return df
+    catalog_lower = catalog.lower()
+    filtered = df[df["catalog_dir"].str.lower() == catalog_lower].copy()
+    if filtered.empty:
+        known = sorted(df["catalog_dir"].dropna().unique())
+        raise ValueError(
+            f"No catalog '{catalog}' found in the material database."
+            f"{did_you_mean(catalog, known)} "
+            "List the available catalogs with "
+            "MaterialRegistry.instance().list_catalogs()."
+        )
+    return filtered
+
+
+def _raise_if_no_matches(
+    filtered_df: pd.DataFrame,
+    name: str,
+    catalog: str | None,
+    reference: str | None,
+    candidates: pd.DataFrame | None = None,
+) -> None:
+    """Raise ``ValueError`` if no candidate rows survived filtering.
+
+    Args:
+        filtered_df: The rows that survived name/reference filtering.
+        name: The requested material name.
+        catalog: The catalog the search was scoped to, if any.
+        reference: The reference the search was scoped to, if any.
+        candidates: The rows searched, used to build a "did you mean"
+            suggestion from their ``name`` column.
+    """
+    if not filtered_df.empty:
+        return
+    msg = f"No matches found for material '{name}'"
+    if catalog:
+        msg += f" in catalog '{catalog}'"
+    if reference:
+        msg += f" with reference '{reference}'"
+    msg += "."
+    if candidates is not None and "name" in candidates:
+        msg += did_you_mean(name, candidates["name"].dropna().unique())
+    raise ValueError(msg)
+
+
+def _apply_match_policy(
+    filtered_df: pd.DataFrame,
+    name: str,
+    catalog: str | None,
+    match_policy: MatchPolicy,
+) -> None:
+    """Enforce ``match_policy`` for a non-exact or ambiguous top match."""
+    best_score = filtered_df["similarity_score"].iloc[0]
+    exact_mask = filtered_df["similarity_score"] == 0
+    n_exact_files = (
+        int(filtered_df.loc[exact_mask, "filename"].nunique())
+        if exact_mask.any()
+        else 0
+    )
+    ambiguous_exact = best_score == 0 and n_exact_files > 1
+
+    if best_score <= 0 and not ambiguous_exact:
+        return
+
+    if catalog is not None:
+        _apply_match_policy_with_catalog(
+            filtered_df, name, catalog, match_policy, best_score
+        )
+    else:
+        _apply_match_policy_without_catalog(
+            filtered_df, name, match_policy, best_score, ambiguous_exact
+        )
+
+
+def _apply_match_policy_with_catalog(
+    filtered_df: pd.DataFrame,
+    name: str,
+    catalog: str,
+    match_policy: MatchPolicy,
+    best_score: float,
+) -> None:
+    """Apply ``match_policy`` when resolution was scoped to one catalog."""
+    if match_policy == MatchPolicy.STRICT:
+        raise ValueError(
+            f"No exact match for '{name}' in catalog '{catalog}'. "
+            "Use the exact name or a less strict match_policy."
+        )
+    if best_score > 0:
+        resolved = filtered_df.iloc[0]["name"]
+        warnings.warn(
+            f"No exact match for '{name}' in catalog '{catalog}'; "
+            f"resolved to '{resolved}'. Use exact name to silence.",
+            OptilandMaterialWarning,
+            stacklevel=6,
+        )
+
+
+def _apply_match_policy_without_catalog(
+    filtered_df: pd.DataFrame,
+    name: str,
+    match_policy: MatchPolicy,
+    best_score: float,
+    ambiguous_exact: bool = False,
+) -> None:
+    """Apply ``match_policy`` when resolution spans all catalogs."""
+    if match_policy == MatchPolicy.STRICT:
+        if ambiguous_exact:
+            catalogs = sorted(
+                filtered_df.loc[
+                    filtered_df["similarity_score"] == 0, "catalog_dir"
+                ].unique()
+            )
+            raise ValueError(
+                f"Material '{name}' matches exactly in multiple catalogs: "
+                f"{catalogs}. Pass catalog=<name> to disambiguate."
+            )
+        top = filtered_df.head(5)["name"].tolist()
+        raise ValueError(
+            f"No exact match for material '{name}'. "
+            f"Top candidates: {top}. "
+            "Use match_policy='warn' or 'best' for fuzzy matching."
+        )
+    if match_policy == MatchPolicy.WARN:
+        if best_score > 0:
+            resolved = filtered_df.iloc[0]["name"]
+            warnings.warn(
+                f"Material '{name}' resolved to '{resolved}' via fuzzy match.",
+                OptilandMaterialWarning,
+                stacklevel=6,
+            )
+        elif ambiguous_exact:
+            catalogs = sorted(
+                filtered_df.loc[
+                    filtered_df["similarity_score"] == 0, "catalog_dir"
+                ].unique()
+            )
+            resolved_catalog = filtered_df.iloc[0]["catalog_dir"]
+            warnings.warn(
+                f"Material '{name}' matches exactly in multiple catalogs "
+                f"{catalogs}; resolved to catalog '{resolved_catalog}'. "
+                "Pass catalog=<name> to disambiguate and silence this "
+                "warning.",
+                OptilandMaterialWarning,
+                stacklevel=6,
+            )
+
+
+def _row_to_path(row: dict) -> str:
+    """Resolve a matched row's ``filename`` to an absolute path."""
+    filename = row["filename"]
+    if not pathlib.Path(filename).is_absolute():
+        return str(pathlib.Path(_DATA_NK_DIR) / filename)
+    return filename
+
+
+def _find_matches(
+    df: pd.DataFrame,
+    name: str,
+    reference: str | None,
+    min_wavelength: float | None,
+    max_wavelength: float | None,
+) -> pd.DataFrame:
+    """Find and score candidate rows for the given name."""
+    name_lower = name.lower()
+
+    dfi = df[
+        df["category_name"].str.lower().str.contains(name_lower, na=False)
+        | df["name"].str.lower().str.contains(name_lower, na=False)
+        | df["filename_no_ext"].str.lower().str.contains(name_lower, na=False)
+    ].copy()
+
+    if reference:
+        ref_lower = reference.lower()
+        dfi = dfi[
+            dfi["category_name"].str.lower().str.contains(ref_lower, na=False)
+            | dfi["category_name_full"].str.lower().str.contains(ref_lower, na=False)
+            | dfi["reference"].str.lower().str.contains(ref_lower, na=False)
+            | dfi["name"].str.lower().str.contains(ref_lower, na=False)
+            | dfi["filename"].str.lower().str.contains(ref_lower, na=False)
+        ]
+
+    if min_wavelength is not None:
+        dfi = dfi[
+            (dfi["min_wavelength"] <= min_wavelength)
+            & (dfi["max_wavelength"] >= min_wavelength)
+        ]
+    if max_wavelength is not None:
+        dfi = dfi[
+            (dfi["min_wavelength"] <= max_wavelength)
+            & (dfi["max_wavelength"] >= max_wavelength)
+        ]
+
+    if dfi.empty:
+        return pd.DataFrame()
+
+    dfi["similarity_score"] = dfi.apply(
+        lambda row: min(
+            _levenshtein(name_lower, row["category_name"].lower()),
+            _levenshtein(name_lower, row["name"].lower()),
+            _levenshtein(name_lower, row["filename_no_ext"].lower()),
+        ),
+        axis=1,
+    )
+
+    return dfi.sort_values("similarity_score").reset_index(drop=True)

--- a/optiland/materials/registry.py
+++ b/optiland/materials/registry.py
@@ -11,7 +11,6 @@ Kramer Harrison, 2025
 
 from __future__ import annotations
 
-import contextlib
 import pathlib
 import tempfile
 import warnings
@@ -21,71 +20,15 @@ import pandas as pd
 import yaml
 
 import optiland.plugins as plugins
-from optiland._suggest import did_you_mean
+from optiland.materials._catalog_parsing import (
+    _catalog_dir_from_filename,
+    _extract_wavelength_range,
+)
+from optiland.materials._material_matching import resolve_with_row
 from optiland.materials.material_spec import MatchPolicy
 from optiland.materials.warnings import OptilandMaterialWarning
 
 _CATALOG_CSV = str(resources.files("optiland.database").joinpath("catalog_nk.csv"))
-_DATA_NK_DIR = str(resources.files("optiland.database").joinpath("data-nk"))
-
-
-def _levenshtein(s1: str, s2: str) -> int:
-    """Compute the Levenshtein edit distance between two strings."""
-    rows, cols = len(s1) + 1, len(s2) + 1
-    dist = [[0] * cols for _ in range(rows)]
-    for i in range(1, rows):
-        dist[i][0] = i
-    for j in range(1, cols):
-        dist[0][j] = j
-    for i in range(1, rows):
-        for j in range(1, cols):
-            cost = 0 if s1[i - 1] == s2[j - 1] else 1
-            dist[i][j] = min(
-                dist[i - 1][j] + 1,
-                dist[i][j - 1] + 1,
-                dist[i - 1][j - 1] + cost,
-            )
-    return dist[-1][-1]
-
-
-def _catalog_dir_from_filename(filename: str, group: str = "") -> str:
-    """Extract the manufacturer catalog name from a filename path.
-
-    For glass entries whose path starts with ``glass/``, the manufacturer is
-    always the second path segment (``glass/{manufacturer}/...``), regardless
-    of nesting depth.  For all other entries the species name is the
-    second-to-last segment.
-    """
-    parts = filename.replace("\\", "/").split("/")
-    if group.lower() == "glass" and parts[0].lower() == "glass" and len(parts) >= 3:
-        return parts[1]
-    return parts[-2] if len(parts) >= 3 else ""
-
-
-def _extract_wavelength_range(data: dict) -> tuple[float, float]:
-    """Extract min/max wavelength (µm) from a refractiveindex.info YAML payload."""
-    for item in data.get("DATA", []):
-        raw = item.get("data", "")
-        if not raw:
-            continue
-        wls: list[float] = []
-        for line in raw.strip().splitlines():
-            parts = line.split()
-            if parts:
-                with contextlib.suppress(ValueError):
-                    wls.append(float(parts[0]))
-        if wls:
-            return min(wls), max(wls)
-        # Formula entries may have a wavelength_range field
-        wl_range = item.get("wavelength_range", "")
-        if wl_range:
-            parts = str(wl_range).split()
-            if len(parts) >= 2:
-                try:
-                    return float(parts[0]), float(parts[1])
-                except ValueError:
-                    pass
-    return 0.0, 100.0
 
 
 class MaterialRegistry:
@@ -310,174 +253,15 @@ class MaterialRegistry:
         max_wavelength: float | None,
     ) -> tuple[str, dict]:
         """Resolve a material and return ``(path, metadata_row_dict)``."""
-        df = self._prefilter_by_catalog(self._get_combined_df(), catalog)
-
-        filtered_df = self._find_matches(
-            df, name, reference, min_wavelength, max_wavelength
+        return resolve_with_row(
+            self._get_combined_df(),
+            name,
+            catalog,
+            reference,
+            match_policy,
+            min_wavelength,
+            max_wavelength,
         )
-        self._raise_if_no_matches(filtered_df, name, catalog, reference, df)
-
-        self._apply_match_policy(filtered_df, name, catalog, match_policy)
-
-        row = filtered_df.iloc[0].to_dict()
-        return self._row_to_path(row), row
-
-    def _prefilter_by_catalog(
-        self, df: pd.DataFrame, catalog: str | None
-    ) -> pd.DataFrame:
-        """Restrict ``df`` to a single manufacturer catalog, if given."""
-        if catalog is None:
-            return df
-        catalog_lower = catalog.lower()
-        filtered = df[df["catalog_dir"].str.lower() == catalog_lower].copy()
-        if filtered.empty:
-            known = sorted(df["catalog_dir"].dropna().unique())
-            raise ValueError(
-                f"No catalog '{catalog}' found in the material database."
-                f"{did_you_mean(catalog, known)} "
-                "List the available catalogs with "
-                "MaterialRegistry.instance().list_catalogs()."
-            )
-        return filtered
-
-    def _raise_if_no_matches(
-        self,
-        filtered_df: pd.DataFrame,
-        name: str,
-        catalog: str | None,
-        reference: str | None,
-        candidates: pd.DataFrame | None = None,
-    ) -> None:
-        """Raise ``ValueError`` if no candidate rows survived filtering.
-
-        Args:
-            filtered_df: The rows that survived name/reference filtering.
-            name: The requested material name.
-            catalog: The catalog the search was scoped to, if any.
-            reference: The reference the search was scoped to, if any.
-            candidates: The rows searched, used to build a "did you mean"
-                suggestion from their ``name`` column.
-        """
-        if not filtered_df.empty:
-            return
-        msg = f"No matches found for material '{name}'"
-        if catalog:
-            msg += f" in catalog '{catalog}'"
-        if reference:
-            msg += f" with reference '{reference}'"
-        msg += "."
-        if candidates is not None and "name" in candidates:
-            msg += did_you_mean(name, candidates["name"].dropna().unique())
-        raise ValueError(msg)
-
-    def _apply_match_policy(
-        self,
-        filtered_df: pd.DataFrame,
-        name: str,
-        catalog: str | None,
-        match_policy: MatchPolicy,
-    ) -> None:
-        """Enforce ``match_policy`` for a non-exact or ambiguous top match."""
-        best_score = filtered_df["similarity_score"].iloc[0]
-        exact_mask = filtered_df["similarity_score"] == 0
-        n_exact_files = (
-            int(filtered_df.loc[exact_mask, "filename"].nunique())
-            if exact_mask.any()
-            else 0
-        )
-        ambiguous_exact = best_score == 0 and n_exact_files > 1
-
-        if best_score <= 0 and not ambiguous_exact:
-            return
-
-        if catalog is not None:
-            self._apply_match_policy_with_catalog(
-                filtered_df, name, catalog, match_policy, best_score
-            )
-        else:
-            self._apply_match_policy_without_catalog(
-                filtered_df, name, match_policy, best_score, ambiguous_exact
-            )
-
-    def _apply_match_policy_with_catalog(
-        self,
-        filtered_df: pd.DataFrame,
-        name: str,
-        catalog: str,
-        match_policy: MatchPolicy,
-        best_score: float,
-    ) -> None:
-        """Apply ``match_policy`` when resolution was scoped to one catalog."""
-        if match_policy == MatchPolicy.STRICT:
-            raise ValueError(
-                f"No exact match for '{name}' in catalog '{catalog}'. "
-                "Use the exact name or a less strict match_policy."
-            )
-        if best_score > 0:
-            resolved = filtered_df.iloc[0]["name"]
-            warnings.warn(
-                f"No exact match for '{name}' in catalog '{catalog}'; "
-                f"resolved to '{resolved}'. Use exact name to silence.",
-                OptilandMaterialWarning,
-                stacklevel=6,
-            )
-
-    def _apply_match_policy_without_catalog(
-        self,
-        filtered_df: pd.DataFrame,
-        name: str,
-        match_policy: MatchPolicy,
-        best_score: float,
-        ambiguous_exact: bool = False,
-    ) -> None:
-        """Apply ``match_policy`` when resolution spans all catalogs."""
-        if match_policy == MatchPolicy.STRICT:
-            if ambiguous_exact:
-                catalogs = sorted(
-                    filtered_df.loc[
-                        filtered_df["similarity_score"] == 0, "catalog_dir"
-                    ].unique()
-                )
-                raise ValueError(
-                    f"Material '{name}' matches exactly in multiple catalogs: "
-                    f"{catalogs}. Pass catalog=<name> to disambiguate."
-                )
-            top = filtered_df.head(5)["name"].tolist()
-            raise ValueError(
-                f"No exact match for material '{name}'. "
-                f"Top candidates: {top}. "
-                "Use match_policy='warn' or 'best' for fuzzy matching."
-            )
-        if match_policy == MatchPolicy.WARN:
-            if best_score > 0:
-                resolved = filtered_df.iloc[0]["name"]
-                warnings.warn(
-                    f"Material '{name}' resolved to '{resolved}' via fuzzy match.",
-                    OptilandMaterialWarning,
-                    stacklevel=6,
-                )
-            elif ambiguous_exact:
-                catalogs = sorted(
-                    filtered_df.loc[
-                        filtered_df["similarity_score"] == 0, "catalog_dir"
-                    ].unique()
-                )
-                resolved_catalog = filtered_df.iloc[0]["catalog_dir"]
-                warnings.warn(
-                    f"Material '{name}' matches exactly in multiple catalogs "
-                    f"{catalogs}; resolved to catalog '{resolved_catalog}'. "
-                    "Pass catalog=<name> to disambiguate and silence this "
-                    "warning.",
-                    OptilandMaterialWarning,
-                    stacklevel=6,
-                )
-
-    def _row_to_path(self, row: dict) -> str:
-        """Resolve a matched row's ``filename`` to an absolute path."""
-        filename = row["filename"]
-        if not pathlib.Path(filename).is_absolute():
-            return str(pathlib.Path(_DATA_NK_DIR) / filename)
-        return filename
 
     # ------------------------------------------------------------------
     # Discovery
@@ -555,62 +339,6 @@ class MaterialRegistry:
         )
         self._combined_cache = pd.concat([built_in[mask], user_df], ignore_index=True)
         return self._combined_cache
-
-    def _find_matches(
-        self,
-        df: pd.DataFrame,
-        name: str,
-        reference: str | None,
-        min_wavelength: float | None,
-        max_wavelength: float | None,
-    ) -> pd.DataFrame:
-        """Find and score candidate rows for the given name."""
-        name_lower = name.lower()
-
-        dfi = df[
-            df["category_name"].str.lower().str.contains(name_lower, na=False)
-            | df["name"].str.lower().str.contains(name_lower, na=False)
-            | df["filename_no_ext"].str.lower().str.contains(name_lower, na=False)
-        ].copy()
-
-        if reference:
-            ref_lower = reference.lower()
-            dfi = dfi[
-                dfi["category_name"].str.lower().str.contains(ref_lower, na=False)
-                | dfi["category_name_full"]
-                .str.lower()
-                .str.contains(  # noqa: E501
-                    ref_lower, na=False
-                )
-                | dfi["reference"].str.lower().str.contains(ref_lower, na=False)
-                | dfi["name"].str.lower().str.contains(ref_lower, na=False)
-                | dfi["filename"].str.lower().str.contains(ref_lower, na=False)
-            ]
-
-        if min_wavelength is not None:
-            dfi = dfi[
-                (dfi["min_wavelength"] <= min_wavelength)
-                & (dfi["max_wavelength"] >= min_wavelength)
-            ]
-        if max_wavelength is not None:
-            dfi = dfi[
-                (dfi["min_wavelength"] <= max_wavelength)
-                & (dfi["max_wavelength"] >= max_wavelength)
-            ]
-
-        if dfi.empty:
-            return pd.DataFrame()
-
-        dfi["similarity_score"] = dfi.apply(
-            lambda row: min(
-                _levenshtein(name_lower, row["category_name"].lower()),
-                _levenshtein(name_lower, row["name"].lower()),
-                _levenshtein(name_lower, row["filename_no_ext"].lower()),
-            ),
-            axis=1,
-        )
-
-        return dfi.sort_values("similarity_score").reset_index(drop=True)
 
     def _warn_if_shadow(self, name: str, catalog: str) -> None:
         """Emit a warning if (name, catalog) shadows an existing entry."""

--- a/optiland/multiconfig/multi_configuration.py
+++ b/optiland/multiconfig/multi_configuration.py
@@ -18,8 +18,11 @@ from optiland.visualization import OpticViewer
 from optiland.visualization.themes import get_active_theme
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from optiland.materials.base import BaseMaterial
     from optiland.optic import Optic
+    from optiland.pickup import Pickup
 
 
 class MultiConfiguration:
@@ -35,6 +38,30 @@ class MultiConfiguration:
     Attributes:
         configurations (list[Optic]): The list of Optic instances.
     """
+
+    # Aliases resolve straight to a dedicated setter; anything else is
+    # treated as a generic dotted attribute path.
+    _PROPERTY_ALIASES = {
+        "radius": "set_radius",
+        "thickness": "set_thickness",
+        "conic": "set_conic",
+        "material": "set_material",
+    }
+
+    # attr_type -> Optic.updater method name, for the standard properties.
+    _STANDARD_UPDATERS = {
+        "radius": "set_radius",
+        "conic": "set_conic",
+        "thickness": "set_thickness",
+        "material": "set_material",
+    }
+
+    # Geometry attributes linked automatically when a configuration is
+    # derived from a source: (attribute on the geometry, pickup attr_type).
+    _LINKED_GEOMETRY_ATTRS = (
+        ("radius", "radius"),
+        ("k", "conic"),
+    )
 
     def __init__(self, base_optic: Optic):
         self.configurations: list[Optic] = [base_optic]
@@ -64,42 +91,57 @@ class MultiConfiguration:
 
         return new_optic
 
-    def _link_configurations(self, source: Optic, target: Optic):
+    def _link_configurations(self, source: Optic, target: Optic) -> None:
         """Internal method to link generic surface properties."""
-        # Link Radii and Conics
-        for i, (surf_s, _surf_t) in enumerate(
-            zip(
-                source.surfaces,
-                target.surfaces,
-                strict=False,
-            )
-        ):
-            # Radius
-            if hasattr(surf_s.geometry, "radius"):
-                target.pickups.add(
-                    source_surface_idx=i,
-                    attr_type="radius",
-                    target_surface_idx=i,
-                    source_optic=source,
-                )
+        num_surfaces = len(source.surfaces)
+        for i, surf_s in enumerate(source.surfaces):
+            for geometry_attr, attr_type in self._LINKED_GEOMETRY_ATTRS:
+                if hasattr(surf_s.geometry, geometry_attr):
+                    target.pickups.add(
+                        source_surface_idx=i,
+                        attr_type=attr_type,
+                        target_surface_idx=i,
+                        source_optic=source,
+                    )
 
-            # Conic
-            if hasattr(surf_s.geometry, "k"):
-                target.pickups.add(
-                    source_surface_idx=i,
-                    attr_type="conic",
-                    target_surface_idx=i,
-                    source_optic=source,
-                )
-
-            # Thickness (except last surface)
-            if i < len(source.surfaces) - 1:
+            # Thickness is linked for every surface except the last.
+            if i < num_surfaces - 1:
                 target.pickups.add(
                     source_surface_idx=i,
                     attr_type="thickness",
                     target_surface_idx=i,
                     source_optic=source,
                 )
+
+    def _resolve_configs(self, configurations) -> tuple[list[int], bool]:
+        """Expand "all" to explicit indices; report whether it was "all"."""
+        if configurations == "all":
+            return list(range(len(self.configurations))), True
+        return configurations, False
+
+    def _apply_across_configs(
+        self,
+        configs_to_update: list[int],
+        all_selected: bool,
+        set_value: Callable[[int], None],
+        ensure_pickup: Callable[[int], None],
+        remove_pickup: Callable[[int], None],
+    ) -> None:
+        """Shared update algorithm for both standard and generic properties.
+
+        Configuration 0 always receives the value directly. Other
+        configurations either stay linked to configuration 0 (when
+        updating "all") or get an independent value with any existing
+        link removed (when updating specific configurations).
+        """
+        for config_idx in configs_to_update:
+            if config_idx == 0:
+                set_value(0)
+            elif all_selected:
+                ensure_pickup(config_idx)
+            else:
+                remove_pickup(config_idx)
+                set_value(config_idx)
 
     def set_property(
         self,
@@ -120,44 +162,25 @@ class MultiConfiguration:
             attribute_path: The dot-separated path to the attribute, or a
                 known alias ('radius', 'thickness', 'conic', 'material').
         """
-        if configurations == "all":
-            configs_to_update = list(range(len(self.configurations)))
-        else:
-            configs_to_update = configurations
-
-        # Standardize aliases
-        if attribute_path == "radius":
-            self.set_radius(surface_index, value, configurations)
-            return
-        elif attribute_path == "thickness":
-            self.set_thickness(surface_index, value, configurations)
-            return
-        elif attribute_path == "conic":
-            self.set_conic(surface_index, value, configurations)
-            return
-        elif attribute_path == "material":
-            self.set_material(surface_index, value, configurations)
+        alias_method = self._PROPERTY_ALIASES.get(attribute_path)
+        if alias_method is not None:
+            getattr(self, alias_method)(surface_index, value, configurations)
             return
 
-        # Generic handling
-        for config_idx in configs_to_update:
-            if config_idx == 0:
-                # Set on base optic
-                self._set_generic_value(0, surface_index, attribute_path, value)
-            else:
-                if configurations == "all":
-                    # If setting "all", we want to ensure it is linked to base
-                    self._ensure_generic_pickup(
-                        config_idx, 0, surface_index, attribute_path
-                    )
-                else:
-                    # If setting specific config (not 0), assume unique val & break link
-                    self._remove_generic_pickup(
-                        config_idx, surface_index, attribute_path
-                    )
-                    self._set_generic_value(
-                        config_idx, surface_index, attribute_path, value
-                    )
+        configs_to_update, all_selected = self._resolve_configs(configurations)
+        self._apply_across_configs(
+            configs_to_update,
+            all_selected,
+            set_value=lambda idx: self._set_generic_value(
+                idx, surface_index, attribute_path, value
+            ),
+            ensure_pickup=lambda idx: self._ensure_generic_pickup(
+                idx, 0, surface_index, attribute_path
+            ),
+            remove_pickup=lambda idx: self._remove_generic_pickup(
+                idx, surface_index, attribute_path
+            ),
+        )
 
     def set_radius(
         self,
@@ -214,138 +237,157 @@ class MultiConfiguration:
         """Convenience wrapper for set_property on the optic."""
         self.set_property(value, configurations, None, attribute_path)
 
-    def _set_standard_property(self, attr_type, surface_index, value, configurations):
+    def _set_standard_property(
+        self,
+        attr_type: str,
+        surface_index: int | None,
+        value: Any,
+        configurations: list[int] | Literal["all"],
+    ) -> None:
         """Internal helper for standard properties (radius, conic, etc)."""
-        if configurations == "all":
-            configs_to_update = list(range(len(self.configurations)))
+        configs_to_update, all_selected = self._resolve_configs(configurations)
+
+        if attr_type == "material":
+            # Materials are pointer-like objects, so they're linked via a
+            # generic pickup on 'material_post' rather than a standard one.
+            def ensure_pickup(idx: int) -> None:
+                self._ensure_generic_pickup(idx, 0, surface_index, "material_post")
+
+            def remove_pickup(idx: int) -> None:
+                self._remove_generic_pickup(idx, surface_index, "material_post")
         else:
-            configs_to_update = configurations
 
-        for config_idx in configs_to_update:
-            if config_idx == 0:
-                # Update base
-                self._apply_standard_value(0, surface_index, attr_type, value)
-            else:
-                if configurations == "all":
-                    # Ensure pickup
-                    if attr_type == "material":
-                        self._ensure_generic_pickup(
-                            config_idx, 0, surface_index, "material_post"
-                        )
-                    else:
-                        self._ensure_pickup(config_idx, surface_index, attr_type)
-                else:
-                    # Remove pickup and set value
-                    if attr_type == "material":
-                        self._remove_generic_pickup(
-                            config_idx, surface_index, "material_post"
-                        )
-                    else:
-                        self._remove_pickup(config_idx, surface_index, attr_type)
+            def ensure_pickup(idx: int) -> None:
+                self._ensure_pickup(idx, surface_index, attr_type)
 
-                    self._apply_standard_value(
-                        config_idx, surface_index, attr_type, value
-                    )
+            def remove_pickup(idx: int) -> None:
+                self._remove_pickup(idx, surface_index, attr_type)
 
-    def _apply_standard_value(self, config_idx, surface_index, attr_type, value):
+        self._apply_across_configs(
+            configs_to_update,
+            all_selected,
+            set_value=lambda idx: self._apply_standard_value(
+                idx, surface_index, attr_type, value
+            ),
+            ensure_pickup=ensure_pickup,
+            remove_pickup=remove_pickup,
+        )
+
+    def _apply_standard_value(
+        self, config_idx: int, surface_index: int, attr_type: str, value: Any
+    ) -> None:
         optic = self.configurations[config_idx]
-        if attr_type == "radius":
-            optic.updater.set_radius(value, surface_index)
-        elif attr_type == "conic":
-            optic.updater.set_conic(value, surface_index)
-        elif attr_type == "thickness":
-            optic.updater.set_thickness(value, surface_index)
-        elif attr_type == "material":
-            optic.updater.set_material(value, surface_index)
+        method = getattr(optic.updater, self._STANDARD_UPDATERS[attr_type])
+        method(value, surface_index)
 
-    def _set_generic_value(self, config_idx, surface_index, path, value):
+    @staticmethod
+    def _full_attribute_path(surface_index: int | None, path: str) -> str:
+        if surface_index is None:
+            return path
+        return f"surfaces.surfaces[{surface_index}].{path}"
+
+    def _set_generic_value(
+        self, config_idx: int, surface_index: int | None, path: str, value: Any
+    ) -> None:
         optic = self.configurations[config_idx]
-        if surface_index is not None:
-            # Relative to surface
-            full_path = f"surfaces.surfaces[{surface_index}].{path}"
-        else:
-            # Relative to optic
-            full_path = path
-
+        full_path = self._full_attribute_path(surface_index, path)
         set_attr_by_path(optic, full_path, value)
 
-    def _ensure_pickup(self, config_idx, surface_index, attr_type):
+    def _find_pickup(
+        self, config_idx: int, matches: Callable[[Pickup], bool]
+    ) -> Pickup | None:
+        return next(
+            (p for p in self.configurations[config_idx].pickups.pickups if matches(p)),
+            None,
+        )
+
+    def _remove_pickups(
+        self, config_idx: int, matches: Callable[[Pickup], bool]
+    ) -> None:
+        pickups = self.configurations[config_idx].pickups.pickups
+        pickups[:] = [p for p in pickups if not matches(p)]
+
+    def _ensure_pickup(
+        self, config_idx: int, surface_index: int, attr_type: str
+    ) -> None:
         """Ensure a standard pickup exists linking to config 0."""
-        optic = self.configurations[config_idx]
-        # Check if pickup exists
-        for p in optic.pickups.pickups:
-            if (
+        source = self.configurations[0]
+
+        def matches(p: Pickup) -> bool:
+            return (
                 p.target_surface_idx == surface_index
                 and p.attr_type == attr_type
-                and p.source_optic == self.configurations[0]
-            ):
-                return  # Exists
+                and p.source_optic == source
+            )
 
-        # Create pickup
-        optic.pickups.add(
+        if self._find_pickup(config_idx, matches) is not None:
+            return
+
+        self.configurations[config_idx].pickups.add(
             source_surface_idx=surface_index,
             attr_type=attr_type,
             target_surface_idx=surface_index,
-            source_optic=self.configurations[0],
+            source_optic=source,
         )
 
-    def _remove_pickup(self, config_idx, surface_index, attr_type):
+    def _remove_pickup(
+        self, config_idx: int, surface_index: int, attr_type: str
+    ) -> None:
         """Remove a standard pickup."""
-        optic = self.configurations[config_idx]
-        to_remove = []
-        for p in optic.pickups.pickups:
-            if p.target_surface_idx == surface_index and p.attr_type == attr_type:
-                to_remove.append(p)
+        self._remove_pickups(
+            config_idx,
+            lambda p: p.target_surface_idx == surface_index
+            and p.attr_type == attr_type,
+        )
 
-        for p in to_remove:
-            optic.pickups.pickups.remove(p)
-
-    def _ensure_generic_pickup(self, config_idx, source_idx, surface_index, path):
+    def _ensure_generic_pickup(
+        self, config_idx: int, source_idx: int, surface_index: int | None, path: str
+    ) -> None:
         """Ensure a generic pickup exists.
 
         For Generic Pickups:
         - target_surface_idx: surface_index
         - attr_type: path (e.g. 'geometry.coefficients[0]')
         """
-        optic = self.configurations[config_idx]
         source_optic = self.configurations[source_idx]
+        full_path = self._full_attribute_path(surface_index, path)
 
-        if surface_index is not None:
-            full_path = f"surfaces.surfaces[{surface_index}].{path}"
-        else:
-            full_path = path
+        def matches(p: Pickup) -> bool:
+            return p.attr_type == full_path and p.source_optic == source_optic
 
-        # Check existence
-        for p in optic.pickups.pickups:
-            if p.attr_type == full_path and p.source_optic == source_optic:
-                return
+        if self._find_pickup(config_idx, matches) is not None:
+            return
 
-        # Add generic pickup
-        optic.pickups.add(
+        self.configurations[config_idx].pickups.add(
             source_surface_idx=0,  # Ignored for generic
             attr_type=full_path,
             target_surface_idx=0,  # Ignored for generic
             source_optic=source_optic,
         )
 
-    def _remove_generic_pickup(self, config_idx, surface_index, path):
-        optic = self.configurations[config_idx]
-        if surface_index is not None:
-            full_path = f"surfaces.surfaces[{surface_index}].{path}"
-        else:
-            full_path = path
-
-        to_remove = []
-        for p in optic.pickups.pickups:
-            if p.attr_type == full_path:
-                to_remove.append(p)
-
-        for p in to_remove:
-            optic.pickups.pickups.remove(p)
+    def _remove_generic_pickup(
+        self, config_idx: int, surface_index: int | None, path: str
+    ) -> None:
+        full_path = self._full_attribute_path(surface_index, path)
+        self._remove_pickups(config_idx, lambda p: p.attr_type == full_path)
 
     def current_config(self, index: int) -> Optic:
         """Returns the configuration at the given index."""
         return self.configurations[index]
+
+    @staticmethod
+    def _config_title(base_title: str | None, index: int) -> str:
+        if base_title:
+            return f"{base_title} (Config {index})"
+        return f"Configuration {index}"
+
+    @staticmethod
+    def _as_axes_list(axes: Any, num_configs: int) -> list:
+        if num_configs == 1:
+            return [axes]
+        if hasattr(axes, "flat"):
+            return axes.flatten()
+        return axes
 
     def draw(
         self,
@@ -379,28 +421,16 @@ class MultiConfiguration:
             sharey=sharey,
         )
         fig.set_facecolor(params["figure.facecolor"])
+        axes = self._as_axes_list(axes, num_configs)
 
-        # Ensure axes is iterable
-        if num_configs == 1:
-            axes = [axes]
-        elif hasattr(axes, "flat"):
-            axes = axes.flatten()
-
+        base_title = kwargs.get("title")
         for i, (optic, ax) in enumerate(zip(self.configurations, axes, strict=False)):
             ax.set_facecolor(params["axes.facecolor"])
 
-            viewer = OpticViewer(optic)
-
-            # Handle title (append config name if title exists)
             plot_kwargs = kwargs.copy()
-            base_title = plot_kwargs.get("title")
+            plot_kwargs["title"] = self._config_title(base_title, i)
 
-            if base_title:
-                plot_kwargs["title"] = f"{base_title} (Config {i})"
-            else:
-                plot_kwargs["title"] = f"Configuration {i}"
-
-            viewer.view(ax=ax, **plot_kwargs)
+            OpticViewer(optic).view(ax=ax, **plot_kwargs)
 
         plt.tight_layout()
         return fig, axes

--- a/optiland/multiconfig/multi_configuration.py
+++ b/optiland/multiconfig/multi_configuration.py
@@ -336,8 +336,9 @@ class MultiConfiguration:
         """Remove a standard pickup."""
         self._remove_pickups(
             config_idx,
-            lambda p: p.target_surface_idx == surface_index
-            and p.attr_type == attr_type,
+            lambda p: (
+                p.target_surface_idx == surface_index and p.attr_type == attr_type
+            ),
         )
 
     def _ensure_generic_pickup(

--- a/optiland/visualization/system/interaction.py
+++ b/optiland/visualization/system/interaction.py
@@ -71,14 +71,8 @@ class InteractionManager:
             self.fig.canvas.mpl_disconnect(cid)
         self.cids = []
 
-    def on_hover(self, event):
-        """Handles hover events to show tooltips and highlight artists."""
-        if event.inaxes != self.ax:
-            if self.active_artist:
-                self.clear_hover_effects()
-            return
-
-        found_artist = None
+    def _find_hovered_artist(self, event):
+        """The topmost artist under the cursor, or None."""
         # Prioritize surfaces over other artists
         artists = sorted(
             self.artist_registry.keys(),
@@ -88,21 +82,31 @@ class InteractionManager:
         for artist in artists:
             contains, _ = artist.contains(event)
             if contains:
-                found_artist = artist
-                break
+                return artist
+        return None
 
-        if self.active_artist != found_artist:
+    def on_hover(self, event):
+        """Handles hover events to show tooltips and highlight artists."""
+        if event.inaxes != self.ax:
             if self.active_artist:
                 self.clear_hover_effects()
-            if self.hover_timer:
-                self.hover_timer.cancel()
+            return
 
-            if found_artist:
-                self.active_artist = found_artist
-                self.hover_timer = Timer(
-                    self.hover_delay, self.show_tooltip, args=[found_artist, event]
-                )
-                self.hover_timer.start()
+        found_artist = self._find_hovered_artist(event)
+        if self.active_artist == found_artist:
+            return
+
+        if self.active_artist:
+            self.clear_hover_effects()
+        if self.hover_timer:
+            self.hover_timer.cancel()
+
+        if found_artist:
+            self.active_artist = found_artist
+            self.hover_timer = Timer(
+                self.hover_delay, self.show_tooltip, args=[found_artist, event]
+            )
+            self.hover_timer.start()
 
     # TODO: Re-enable pop-up box functionality in a future update.
     # The following methods are temporarily disabled.
@@ -111,17 +115,29 @@ class InteractionManager:
     # def on_info_panel_click(self, event):
     # def close_info_panel(self, event=None):
 
-    def highlight_artist(self, artist):
-        """Highlights the given artist."""
+    def _hover_group(self, artist):
+        """Artists that highlight/clear together with `artist`.
+
+        A bundled artist (e.g. one ray among a RayBundle) drags every artist
+        sharing its bundle_id along with it; an unbundled artist acts alone,
+        as long as it actually supports `get_linewidth`.
+        """
         obj = self.artist_registry[artist]
         if hasattr(obj, "bundle_id"):
-            for art, o in self.artist_registry.items():
-                if hasattr(o, "bundle_id") and o.bundle_id == obj.bundle_id:
-                    self.original_props[art] = {"linewidth": art.get_linewidth()}
-                    art.set_linewidth(art.get_linewidth() * 2)
-        elif hasattr(artist, "get_linewidth"):
-            self.original_props[artist] = {"linewidth": artist.get_linewidth()}
-            artist.set_linewidth(artist.get_linewidth() * 2)
+            return [
+                art
+                for art, o in self.artist_registry.items()
+                if hasattr(o, "bundle_id") and o.bundle_id == obj.bundle_id
+            ]
+        if hasattr(artist, "get_linewidth"):
+            return [artist]
+        return []
+
+    def highlight_artist(self, artist):
+        """Highlights the given artist."""
+        for art in self._hover_group(artist):
+            self.original_props[art] = {"linewidth": art.get_linewidth()}
+            art.set_linewidth(art.get_linewidth() * 2)
         self.fig.canvas.draw_idle()
 
     def show_tooltip(self, artist, event):
@@ -139,34 +155,29 @@ class InteractionManager:
         """Clears any active hover effects."""
         if self.hover_timer:
             self.hover_timer.cancel()
-        if self.active_artist:
-            obj = self.artist_registry[self.active_artist]
-            if hasattr(obj, "bundle_id"):
-                for art, o in self.artist_registry.items():
-                    if (
-                        hasattr(o, "bundle_id")
-                        and o.bundle_id == obj.bundle_id
-                        and art in self.original_props
-                    ):
-                        art.set_linewidth(self.original_props[art]["linewidth"])
-                        del self.original_props[art]
-            elif (
-                hasattr(self.active_artist, "get_linewidth")
-                and self.active_artist in self.original_props
-            ):
-                self.active_artist.set_linewidth(
-                    self.original_props[self.active_artist]["linewidth"]
-                )
-                del self.original_props[self.active_artist]
-            self.active_artist = None
-            self.tooltip.set_visible(False)
-            self.fig.canvas.draw_idle()
+        if not self.active_artist:
+            return
+
+        for art in self._hover_group(self.active_artist):
+            if art in self.original_props:
+                art.set_linewidth(self.original_props[art]["linewidth"])
+                del self.original_props[art]
+
+        self.active_artist = None
+        self.tooltip.set_visible(False)
+        self.fig.canvas.draw_idle()
+
+    def _registry_info(self, optiland_object) -> str:
+        """Fallback lookup of an info provider by the object's class name."""
+        provider = INFO_PROVIDER_REGISTRY.get(type(optiland_object).__name__)
+        if provider is None:
+            return "No information available."
+        return provider.get_info(optiland_object)
 
     def default_tooltip_format(self, optiland_object):
         """Default formatter for the tooltip text."""
         # Import here to avoid circular dependencies
         from optiland.visualization.info.providers import (
-            INFO_PROVIDER_REGISTRY,
             LensInfoProvider,
             SurfaceInfoProvider,
         )
@@ -174,25 +185,12 @@ class InteractionManager:
         from optiland.visualization.system.surface import Surface2D
 
         if isinstance(optiland_object, Surface2D):
-            provider = SurfaceInfoProvider(self.optic.surfaces)
-            return provider.get_info(optiland_object)
-
-        elif isinstance(optiland_object, RayBundle):
-            provider = INFO_PROVIDER_REGISTRY["RayBundle"]
-            return provider.get_info(optiland_object)
-
-        elif isinstance(optiland_object, Lens2D):
-            provider = LensInfoProvider(self.optic.surfaces)
-            return provider.get_info(optiland_object)
-
-        else:
-            # Fallback for any other types
-            obj_type = type(optiland_object).__name__
-            if obj_type in INFO_PROVIDER_REGISTRY:
-                provider = INFO_PROVIDER_REGISTRY[obj_type]
-                return provider.get_info(optiland_object)
-            else:
-                return "No information available."
+            return SurfaceInfoProvider(self.optic.surfaces).get_info(optiland_object)
+        if isinstance(optiland_object, RayBundle):
+            return INFO_PROVIDER_REGISTRY["RayBundle"].get_info(optiland_object)
+        if isinstance(optiland_object, Lens2D):
+            return LensInfoProvider(self.optic.surfaces).get_info(optiland_object)
+        return self._registry_info(optiland_object)
 
     def show_info_panel(self, optiland_object):
         """Shows an information panel for the given object."""
@@ -256,12 +254,5 @@ class InteractionManager:
         from optiland.visualization.system.ray_bundle import RayBundle
 
         if isinstance(optiland_object, RayBundle):
-            provider = INFO_PROVIDER_REGISTRY["RayBundle"]
-            return provider.get_info(optiland_object)
-
-        obj_type = type(optiland_object).__name__
-        if obj_type in INFO_PROVIDER_REGISTRY:
-            provider = INFO_PROVIDER_REGISTRY[obj_type]
-            return provider.get_info(optiland_object)
-        else:
-            return "No information available."
+            return INFO_PROVIDER_REGISTRY["RayBundle"].get_info(optiland_object)
+        return self._registry_info(optiland_object)

--- a/optiland/visualization/system/system.py
+++ b/optiland/visualization/system/system.py
@@ -145,40 +145,25 @@ class OpticalSystem:
         lens_surfaces = []
 
         for k, surf in enumerate(self.optic.surfaces):
-            # Get the surface extent
             extent = self.rays.r_extent[k]
 
-            # Object surface
-            if k == 0:
-                if not surf.is_infinite:
-                    self._add_component("surface", surf, extent)
+            # Object surface at infinity: nothing to draw
+            if k == 0 and surf.is_infinite:
+                continue
 
-            # Image surface or paraxial surface
-            elif k == num_surf - 1 or surf.surface_type == "paraxial":
+            # Object, image, or paraxial surface
+            if k == 0 or k == num_surf - 1 or surf.surface_type == "paraxial":
                 self._add_component("surface", surf, extent)
 
             # Surface is a mirror
             elif surf.interaction_model.is_reflective:
-                if lens_surfaces:  # Second surface mirror (lens + mirror)
-                    surface = self._get_lens_surface(surf, extent)
-                    lens_surfaces.append(surface)
-                    self._add_component("lens", lens_surfaces)
-                    lens_surfaces = []
-                else:
-                    self._add_component("mirror", surf, extent)
+                lens_surfaces = self._add_mirror_component(surf, extent, lens_surfaces)
 
-            # Front surface of a lens
-            elif n[k] > 1:
-                surface = self._get_lens_surface(surf, extent)
-                lens_surfaces.append(surface)
-
-            # Back surface of a lens
-            elif n[k] == 1 and n[k - 1] > 1 and lens_surfaces:
-                surface = self._get_lens_surface(surf, extent)
-                lens_surfaces.append(surface)
-                self._add_component("lens", lens_surfaces)
-
-                lens_surfaces = []
+            # Front or back surface of a lens
+            elif n[k] > 1 or (n[k] == 1 and n[k - 1] > 1 and lens_surfaces):
+                lens_surfaces = self._add_lens_edge_component(
+                    surf, extent, n[k], lens_surfaces
+                )
 
             # Standalone phase surface
             elif surf.interaction_model.interaction_type == "phase":
@@ -188,6 +173,31 @@ class OpticalSystem:
         if lens_surfaces:
             self._add_component("lens", lens_surfaces)
 
+    def _add_mirror_component(self, surf, extent, lens_surfaces: list) -> list:
+        """Add a standalone mirror, or close out a second-surface mirror lens.
+
+        Returns the (possibly reset) `lens_surfaces` accumulator.
+        """
+        if lens_surfaces:  # Second surface mirror (lens + mirror)
+            lens_surfaces.append(self._get_lens_surface(surf, extent))
+            self._add_component("lens", lens_surfaces)
+            return []
+        self._add_component("mirror", surf, extent)
+        return lens_surfaces
+
+    def _add_lens_edge_component(
+        self, surf, extent, n_k: float, lens_surfaces: list
+    ) -> list:
+        """Append a front or back lens surface; close out the lens on the back one.
+
+        Returns the (possibly reset) `lens_surfaces` accumulator.
+        """
+        lens_surfaces.append(self._get_lens_surface(surf, extent))
+        if n_k == 1:  # back surface: n drops back to 1, closing out the lens
+            self._add_component("lens", lens_surfaces)
+            return []
+        return lens_surfaces
+
     def _add_component(self, component_name, *args):
         """Adds a component to the list of components."""
         if component_name in _CUSTOM_RENDERER_REGISTRY:
@@ -196,16 +206,117 @@ class OpticalSystem:
             self.components.append(
                 _CustomRendererAdapter(renderer, component_data, self.projection)
             )
-        elif component_name in self.component_registry:
+            return
+        if component_name in self.component_registry:
             component_class = self.component_registry[component_name][self.projection]
             self.components.append(component_class(*args))
-        else:
-            raise ValueError(f"Component {component_name} not found in registry.")
+            return
+        raise ValueError(f"Component {component_name} not found in registry.")
 
     def _get_lens_surface(self, surface, *args):
         """Gets the lens surface based on the projection type."""
         surface_class = self.component_registry["surface"][self.projection]
         return surface_class(surface, *args)
+
+    @staticmethod
+    def _is_lens_surface(n, idx: int) -> bool:
+        if idx > 0:
+            return n[idx] > 1 or (n[idx] == 1 and n[idx - 1] > 1)
+        return n[idx] > 1
+
+    def _aperture_indicator_extent(self, surface, idx: int, n):
+        """The (x_min, x_max, y_min, y_max) box for this surface's aperture
+        indicator, or None if this surface shouldn't get one at all.
+
+        Lens surfaces are skipped unless they're the stop, and non-stop
+        surfaces without an aperture are skipped too.
+        """
+        if self._is_lens_surface(n, idx) and not surface.is_stop:
+            return None
+        if surface.aperture is None and not surface.is_stop:
+            return None
+        return self._aperture_extent(surface, idx)
+
+    def _aperture_extent(self, surface, idx: int):
+        """The (x_min, x_max, y_min, y_max) box to draw this surface's
+        aperture indicator in, or None if there's nothing to draw.
+        """
+        if surface.aperture is not None:
+            return surface.aperture.extent
+
+        r = self._aperture_radius(surface, idx)
+        if r is None:
+            return None
+        return -r, r, -r, r
+
+    def _aperture_radius(self, surface, idx: int) -> float | None:
+        """The isotropic radius to draw for a circular aperture indicator
+        (semi-aperture, float-by-stop-size, or ray extent at the stop), or
+        None if none applies.
+        """
+        if surface.semi_aperture is not None:
+            return surface.semi_aperture
+        if (
+            surface.is_stop
+            and self.optic.aperture is not None
+            and self.optic.aperture.ap_type == "float_by_stop_size"
+        ):
+            return 0.5 * self.optic.aperture.value
+        if surface.is_stop and self.rays is not None:
+            r = be.to_numpy(self.rays.r_extent[idx]).item()
+            return r if r > 0 else None
+        return None
+
+    @staticmethod
+    def _local_aperture_coords(projection: str, extent: tuple):
+        # Only the axis actually shown in this projection is swept between
+        # its aperture bounds; the other is held at 0 (its axis-of-symmetry
+        # value) rather than paired corner-to-corner, which would otherwise
+        # mix in the wrong sag contribution for offset apertures.
+        x_min, x_max, y_min, y_max = extent
+        if projection == "XZ":
+            return be.array([x_min, x_max]), be.array([0.0, 0.0])
+        return be.array([0.0, 0.0]), be.array([y_min, y_max])  # YZ
+
+    @staticmethod
+    def _aperture_indicator_globals(surface, projection, x_local, y_local):
+        """Sag-projected global (z, in-plane) coordinates of an aperture
+        indicator's two endpoints.
+
+        The sag is evaluated at each point (instead of assuming z=0) so the
+        indicator line follows the true, possibly-tilted surface instead of
+        a flat plane through the vertex. Apertures with an unbounded extent
+        (e.g. an annular obstruction defined with r_max = inf) have no
+        well-defined sag at their outer edge; fall back to the vertex plane
+        there rather than evaluating sag() out of its domain.
+        """
+        finite = be.isfinite(x_local) & be.isfinite(y_local)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            z_local = be.where(finite, surface.geometry.sag(x_local, y_local), 0.0)
+        x_global, y_global, z_global = transform(
+            x_local, y_local, z_local, surface, is_global=False
+        )
+        axis_vals = x_global if projection == "XZ" else y_global
+        return be.to_numpy(z_global), be.to_numpy(axis_vals)
+
+    @staticmethod
+    def _draw_aperture_indicator(ax, z_global, axis_vals, facecolor: str):
+        (line,) = ax.plot(z_global, axis_vals, color="black", linewidth=0.3)
+
+        eps = 1e-6
+        arrowprops = {"arrowstyle": "-|>", "facecolor": facecolor, "linewidth": 0}
+        for z_val, axis_val, sign in (
+            (z_global[1], axis_vals[1], 1),  # top
+            (z_global[0], axis_vals[0], -1),  # bottom
+        ):
+            ax.annotate(
+                "",
+                xy=(z_val, axis_val),
+                xytext=(z_val, axis_val + sign * eps),
+                arrowprops=arrowprops,
+            )
+        return line
 
     def _plot_apertures(self, ax, projection="YZ"):
         if projection == "XY":
@@ -219,90 +330,17 @@ class OpticalSystem:
         artists = {}
         n = self.optic.surfaces.n(self.optic.primary_wavelength)
         for idx, surface in enumerate(self.optic.surfaces):
-            if idx > 0:
-                is_lens_surface = n[idx] > 1 or (n[idx] == 1 and n[idx - 1] > 1)
-            else:
-                is_lens_surface = n[idx] > 1
-            if is_lens_surface and not surface.is_stop:
-                continue
-            # Skip surfaces without apertures (unless stop)
-            if surface.aperture is None and not surface.is_stop:
+            extent = self._aperture_indicator_extent(surface, idx, n)
+            if extent is None:
                 continue
 
-            # Determine aperture extent
-            if surface.aperture is not None:
-                x_min, x_max, y_min, y_max = surface.aperture.extent
-            elif surface.semi_aperture is not None:
-                r = surface.semi_aperture
-                x_min, x_max, y_min, y_max = -r, r, -r, r
-            elif (
-                surface.is_stop
-                and self.optic.aperture is not None
-                and self.optic.aperture.ap_type == "float_by_stop_size"
-            ):
-                r = 0.5 * self.optic.aperture.value
-                x_min, x_max, y_min, y_max = -r, r, -r, r
-            elif surface.is_stop and self.rays is not None:
-                r = be.to_numpy(self.rays.r_extent[idx]).item()
-                if r <= 0:
-                    continue
-                x_min, x_max, y_min, y_max = -r, r, -r, r
-            else:
-                continue
-
-            # Define local coordinates based on projection. Only the axis
-            # actually shown in this projection is swept between its aperture
-            # bounds; the other is held at 0 (its axis-of-symmetry value)
-            # rather than paired corner-to-corner, which would otherwise mix
-            # in the wrong sag contribution for offset apertures. The sag is
-            # evaluated at each point (instead of assuming z=0) so the
-            # indicator line follows the true, possibly-tilted surface
-            # instead of a flat plane through the vertex.
-            if projection == "XZ":
-                x_local = be.array([x_min, x_max])
-                y_local = be.array([0.0, 0.0])
-            else:  # YZ
-                x_local = be.array([0.0, 0.0])
-                y_local = be.array([y_min, y_max])
-            # Apertures with an unbounded extent (e.g. an annular
-            # obstruction defined with r_max = inf) have no well-defined
-            # sag at their outer edge; fall back to the vertex plane there
-            # rather than evaluating sag() out of its domain.
-            finite = be.isfinite(x_local) & be.isfinite(y_local)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                z_local = be.where(finite, surface.geometry.sag(x_local, y_local), 0.0)
-            x_global, y_global, z_global = transform(
-                x_local, y_local, z_local, surface, is_global=False
+            x_local, y_local = self._local_aperture_coords(projection, extent)
+            z_global, axis_vals = self._aperture_indicator_globals(
+                surface, projection, x_local, y_local
             )
-            x_global = be.to_numpy(x_global)
-            y_global = be.to_numpy(y_global)
-            z_global = be.to_numpy(z_global)
 
-            # Draw line for aperture edge
-            axis_vals = x_global if projection == "XZ" else y_global
-            (line,) = ax.plot(
-                z_global,
-                axis_vals,
-                color="black",
-                linewidth=0.3,
-            )
-            artists[line] = surface
-
-            # Add arrows to indicate aperture extent
-            eps = 1e-6
             facecolor = stop_color if surface.is_stop else aperture_color
-            arrowprops = {"arrowstyle": "-|>", "facecolor": facecolor, "linewidth": 0}
-            axis_vals = x_global if projection == "XZ" else y_global
-            for z_val, axis_val, sign in (
-                (z_global[1], axis_vals[1], 1),  # top
-                (z_global[0], axis_vals[0], -1),  # bottom
-            ):
-                ax.annotate(
-                    "",
-                    xy=(z_val, axis_val),
-                    xytext=(z_val, axis_val + sign * eps),
-                    arrowprops=arrowprops,
-                )
+            line = self._draw_aperture_indicator(ax, z_global, axis_vals, facecolor)
+            artists[line] = surface
 
         return artists

--- a/tests/test_angle_vs_height.py
+++ b/tests/test_angle_vs_height.py
@@ -256,16 +256,16 @@ class TestAngleVsHeightErrors:
             # Case 1: Field is scanned (PupilIncidentAngleVsHeight)
             pupil_scan_analysis = PupilIncidentAngleVsHeight(cooke_triplet, axis=0)
             pupil_scan_analysis.view()
-            # Get the keyword arguments from the last call to the mock
-            kwargs = mock_plot.call_args.kwargs
-            assert "Normalized Pupil Coordinate (Px)" in kwargs["color_label"]
+            # Get the plot spec passed to the last call to the mock
+            plot_spec = mock_plot.call_args.args[0]
+            assert "Normalized Pupil Coordinate (Px)" in plot_spec.color_label
 
             mock_plot.reset_mock()
 
             # Case 2: Pupil is scanned (FieldIncidentAngleVsHeight)
             field_scan_analysis = FieldIncidentAngleVsHeight(cooke_triplet, axis=1)
             field_scan_analysis.view()
-            kwargs = mock_plot.call_args.kwargs
-            assert "Normalized Field Coordinate (Hy)" in kwargs["color_label"]
+            plot_spec = mock_plot.call_args.args[0]
+            assert "Normalized Field Coordinate (Hy)" in plot_spec.color_label
 
         plt.close("all")


### PR DESCRIPTION
## Summary
- Reduce cyclomatic complexity in checks.py, angle_vs_height, multiconfig, InteractionManager, and OpticalSystem visualization
- Dedupe the RMS-vs-field view() implementations
- Split MaterialRegistry into separate registry, parsing, and matching modules

## Test plan
- [ ] Run relevant unit tests for touched modules