### PR TITLE
docs: note GPU throughput cliff on VRAM-limited cards

### DIFF
--- a/docs/developers_guide/configurable_backend.rst
+++ b/docs/developers_guide/configurable_backend.rst
@@ -90,6 +90,18 @@ Example usage:
    # now every be.* call (e.g. be.matmul, be.exp) uses torch.cuda.FloatTensor,
    # with gradient support enabled.
 
+.. tip::
+   On VRAM-limited GPUs (e.g. 4-8 GB laptop/consumer cards), throughput is
+   **not monotonic** with ray count. As allocations approach the physical
+   VRAM limit, the CUDA driver starts spilling/evicting memory, and trace
+   speed can collapse by 5-10x well before you get an actual out-of-memory
+   error -- which makes the underlying cause easy to misdiagnose. If a
+   ``trace()`` call is much slower than expected, check
+   ``torch.cuda.max_memory_allocated()`` first: if it is close to your
+   card's total VRAM, reduce ``num_rays`` (or split the trace into smaller
+   batches) or switch to ``be.set_precision("float32")`` rather than
+   assuming there is a bug.
+
 Adding New Functionality
 ------------------------
 


### PR DESCRIPTION
Adds a tip that PyTorch/CUDA trace throughput isn't monotonic with ray count near a card's VRAM limit — it can collapse well before an actual OOM. Raised in #743; confirmed locally on an 8 GB card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)