### PR TITLE
perf(backend): keep reductions on the device and skip autograd bookkeeping in forward traces

### DIFF
--- a/optiland/backend/base.py
+++ b/optiland/backend/base.py
@@ -6,11 +6,12 @@ Kramer Harrison, 2025
 
 from __future__ import annotations
 
+import contextlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Generator, Sequence
     from types import ModuleType
 
 
@@ -212,6 +213,17 @@ class AbstractBackend(ABC):
         raise BackendCapabilityError(
             f"autograd is not supported by backend '{self.name}'."
         )
+
+    @contextlib.contextmanager
+    def no_grad_unless_enabled(self) -> Generator[None, None, None]:
+        """Context in which gradient bookkeeping may be suppressed.
+
+        A no-op for backends without gradient support. The torch backend
+        runs the context under ``torch.no_grad`` unless gradients were
+        globally requested via ``grad_mode``, sparing per-op autograd
+        dispatch during plain forward computations.
+        """
+        yield
 
     def set_device(self, device: str) -> None:
         """Set the compute device (torch only).

--- a/optiland/backend/torch_backend/capabilities.py
+++ b/optiland/backend/torch_backend/capabilities.py
@@ -7,12 +7,13 @@ optiland/backend/torch_backend/__init__.py).
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Generator, Sequence
 
     from numpy.typing import ArrayLike
     from torch import Tensor
@@ -59,6 +60,22 @@ class CapabilitiesMixin:
     def autograd(self) -> Any:
         """Return the torch.autograd submodule."""
         return torch.autograd
+
+    @contextlib.contextmanager
+    def no_grad_unless_enabled(self) -> Generator[None, None, None]:
+        """Suppress autograd bookkeeping unless gradients were requested.
+
+        With ``grad_mode`` disabled no tensor requires grad, so no graph is
+        built either way; running under ``torch.no_grad`` additionally skips
+        the per-op autograd dispatch and version-counter work, which adds up
+        over the hundreds of kernels a trace launches. With ``grad_mode``
+        enabled this is a no-op so differentiable workflows are untouched.
+        """
+        if self._config.grad_mode.requires_grad:
+            yield
+        else:
+            with torch.no_grad():
+                yield
 
     @property
     def nn(self) -> Any:

--- a/optiland/backend/torch_backend/reductions.py
+++ b/optiland/backend/torch_backend/reductions.py
@@ -79,7 +79,10 @@ class ReductionsMixin:
             float: Maximum value as a Python scalar.
         """
         if isinstance(x, torch.Tensor):
-            return x.detach().cpu().max().item()
+            # Reduce on the device and transfer one scalar; copying the whole
+            # tensor to the host first stalls the pipeline and moves N values
+            # to compute one.
+            return x.detach().max().item()
         return np.max(x)
 
     def min(self, x: Any) -> Any:
@@ -92,7 +95,7 @@ class ReductionsMixin:
             float: Minimum value as a Python scalar.
         """
         if isinstance(x, torch.Tensor):
-            return x.detach().cpu().min().item()
+            return x.detach().min().item()
         return np.min(x)
 
     def argmin(self, x: Any, axis: int | None = None) -> Tensor:
@@ -238,8 +241,13 @@ class ReductionsMixin:
         """
         if isinstance(x, bool):
             return x
-        t = torch.as_tensor(x, dtype=self._dtype(), device=self._device())
-        return bool(torch.all(t).item())
+        if isinstance(x, torch.Tensor):
+            # Reduce in the tensor's own dtype: casting a bool mask to the
+            # working float precision allocates a full-size temporary for a
+            # reduction that torch performs on bool directly.
+            return bool(torch.all(x).item())
+        # Host data (lists, numpy arrays) reduces on the host.
+        return bool(np.all(x))
 
     def any(self, x: Any) -> bool:
         """Return True if any element of x is True.
@@ -252,8 +260,9 @@ class ReductionsMixin:
         """
         if isinstance(x, bool):
             return x
-        t = torch.as_tensor(x, dtype=self._dtype(), device=self._device())
-        return bool(torch.any(t).item())
+        if isinstance(x, torch.Tensor):
+            return bool(torch.any(x).item())
+        return bool(np.any(x))
 
     def nanmax(
         self, x: Tensor, axis: int | None = None, keepdim: bool = False

--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -67,8 +67,12 @@ def _uniform_scalar(value) -> float | None:
     """
     try:
         if torch is not None and isinstance(value, torch.Tensor):
-            first = value.reshape(-1)[0]
-            if bool(torch.eq(value, first).all()):
+            # The key only needs the numeric value; detaching avoids the
+            # scalar-conversion warning for grad-attached bundles and keeps
+            # the uniformity probe off the autograd graph.
+            detached = value.detach()
+            first = detached.reshape(-1)[0]
+            if bool(torch.eq(detached, first).all()):
                 return float(first)
             return None
         array = np.asarray(value)

--- a/optiland/raytrace/real_ray_tracer.py
+++ b/optiland/raytrace/real_ray_tracer.py
@@ -91,32 +91,36 @@ class RealRayTracer(BaseRayTracer):
         Px = distribution.x
         Py = distribution.y
 
-        Hx = be.atleast_1d(Hx)
-        Hy = be.atleast_1d(Hy)
+        # With gradients globally disabled, the whole trace runs without
+        # autograd bookkeeping; with gradients enabled this context is a
+        # no-op and differentiable tracing works as before.
+        with be.no_grad_unless_enabled():
+            Hx = be.atleast_1d(Hx)
+            Hy = be.atleast_1d(Hy)
 
-        # expand coordinates to create a ray for each field point at each pupil point
-        num_fields = len(Hx)
-        num_pupil_points = len(Px)
+            # expand coordinates: one ray per field point at each pupil point
+            num_fields = len(Hx)
+            num_pupil_points = len(Px)
 
-        Hx_full = be.repeat(Hx, num_pupil_points)
-        Hy_full = be.repeat(Hy, num_pupil_points)
-        Px_full = be.tile(Px, num_fields)
-        Py_full = be.tile(Py, num_fields)
+            Hx_full = be.repeat(Hx, num_pupil_points)
+            Hy_full = be.repeat(Hy, num_pupil_points)
+            Px_full = be.tile(Px, num_fields)
+            Py_full = be.tile(Py, num_fields)
 
-        rays = self.ray_generator.generate_rays(
-            Hx_full, Hy_full, Px_full, Py_full, wavelength
-        )
-        self.optic.surfaces.trace(rays, record=record)
-
-        # Propagate to the image surface
-        if self.optic.image_surface:
-            last_surface = self.optic.surfaces[-1]
-            last_surface.material_post.propagation_model.propagate(
-                rays, last_surface.thickness
+            rays = self.ray_generator.generate_rays(
+                Hx_full, Hy_full, Px_full, Py_full, wavelength
             )
+            self.optic.surfaces.trace(rays, record=record)
 
-        if isinstance(rays, PolarizedRays):
-            rays.update_intensity(self.optic.polarization_state)
+            # Propagate to the image surface
+            if self.optic.image_surface:
+                last_surface = self.optic.surfaces[-1]
+                last_surface.material_post.propagation_model.propagate(
+                    rays, last_surface.thickness
+                )
+
+            if isinstance(rays, PolarizedRays):
+                rays.update_intensity(self.optic.polarization_state)
 
         return rays
 
@@ -136,22 +140,23 @@ class RealRayTracer(BaseRayTracer):
         self._validate_normalized_coordinates(Hx, Hy, "field")
         self._validate_normalized_coordinates(Px, Py, "pupil")
 
-        vx, vy = self.optic.fields.get_vig_factor(Hx, Hy)
+        with be.no_grad_unless_enabled():
+            vx, vy = self.optic.fields.get_vig_factor(Hx, Hy)
 
-        Px = Px * (1 - vx)
-        Py = Py * (1 - vy)
+            Px = Px * (1 - vx)
+            Py = Py * (1 - vy)
 
-        # assure all variables are arrays of the same size
-        Hx, Hy, Px, Py = self._validate_array_size(Hx, Hy, Px, Py)
+            # assure all variables are arrays of the same size
+            Hx, Hy, Px, Py = self._validate_array_size(Hx, Hy, Px, Py)
 
-        rays = self.ray_generator.generate_rays(Hx, Hy, Px, Py, wavelength)
-        self.optic.surfaces.trace(rays, record=record)
+            rays = self.ray_generator.generate_rays(Hx, Hy, Px, Py, wavelength)
+            self.optic.surfaces.trace(rays, record=record)
 
-        # Propagate to the image surface
-        last_surface = self.optic.surfaces[-1]
-        last_surface.material_post.propagation_model.propagate(
-            rays, last_surface.thickness
-        )
+            # Propagate to the image surface
+            last_surface = self.optic.surfaces[-1]
+            last_surface.material_post.propagation_model.propagate(
+                rays, last_surface.thickness
+            )
 
         return rays
 

--- a/tests/test_backend_functions.py
+++ b/tests/test_backend_functions.py
@@ -165,6 +165,29 @@ def test_all_any(set_test_backend):
     assert not be.any(be.array([False, False]))
 
 
+def test_all_any_native_masks_and_host_data(set_test_backend):
+    """Comparison masks reduce in their own dtype and host data stays on the
+    host; both paths return plain Python bools."""
+    x = be.array([1.0, 2.0, 3.0])
+    assert be.all(x > 0)
+    assert not be.all(x > 2.0)
+    assert be.any(x > 2.0)
+    assert not be.any(x > 3.0)
+    assert isinstance(be.all(x > 0), bool)
+    assert isinstance(be.any(x > 0), bool)
+    # lists, tuples, and numpy arrays never touch the compute device
+    assert be.all([True, True])
+    assert not be.all(np.array([True, False]))
+    assert be.any((False, True))
+
+
+def test_max_min_return_python_scalars(set_test_backend):
+    x = be.array([3.0, 1.0, 2.0])
+    assert be.max(x) == 3.0
+    assert be.min(x) == 1.0
+    assert float(be.max(x)) == 3.0  # usable directly in host-side math
+
+
 def test_cross_product(set_test_backend):
     if hasattr(be, "cross"):
         a = be.array([1.0, 0.0, 0.0])

--- a/tests/test_optic.py
+++ b/tests/test_optic.py
@@ -358,6 +358,38 @@ class TestOptic:
         rays = lens.trace_generic(0.0, 0.0, 0.0, 0.0, 0.55)
         assert rays is not None
 
+    def test_trace_respects_grad_mode(self, set_test_backend):
+        """Tracing runs free of autograd bookkeeping when gradients are
+        globally disabled, and stays fully differentiable when enabled."""
+        if be.get_backend() != "torch":
+            pytest.skip("torch-only behavior")
+        import torch
+
+        # the test fixture enables grad mode; exercise the disabled branch
+        was_enabled = be.grad_mode.requires_grad
+        be.grad_mode.disable()
+        try:
+            rays = HeliarLens().trace(0.0, 0.0, 0.55, num_rays=16)
+            assert not rays.x.requires_grad
+        finally:
+            if was_enabled:
+                be.grad_mode.enable()
+
+        with be.grad_mode.temporary_enable():
+            lens = HeliarLens()
+            geometry = lens.surfaces.surfaces[1].geometry
+            radius = torch.tensor(
+                float(be.to_numpy(geometry.radius)),
+                dtype=getattr(torch, f"float{be.get_precision()}"),
+                requires_grad=True,
+            )
+            geometry.radius = radius
+            traced = lens.trace(0.0, 0.0, 0.55, num_rays=16)
+            loss = (traced.x**2 + traced.y**2).sum()
+            loss.backward()
+        assert radius.grad is not None
+        assert bool(torch.isfinite(radius.grad))
+
     def test_trace_without_recording(self, set_test_backend):
         """record=False returns identical rays but stores no per-surface
         snapshots, halving peak memory for large traces."""


### PR DESCRIPTION
Second batch of the performance pass that started with #748, this time targeting data that was moved between GPU and host for no reason.

- **`be.max` / `be.min` copied the entire tensor to the CPU** to compute a single scalar. They now reduce on the device and transfer one value. This ran on the full ray bundle once per trace of every Newton–Raphson surface (aspheres, freeforms).
- **`be.all` / `be.any` cast boolean masks to the working float precision** before reducing — a full-size temporary allocation and several times the bandwidth, a few times per surface and once per Newton iteration in the convergence check. They now reduce in the mask's own dtype, and plain host data (lists, numpy arrays) reduces on the host instead of being shipped to the GPU.
- **The real ray tracer now runs under `torch.no_grad` when gradients are globally disabled**, sparing per-op autograd bookkeeping across the hundreds of kernels a trace launches. With `grad_mode` enabled the context is a no-op, so differentiable tracing is untouched — a new test pins both behaviors.

It also silences a scalar-conversion warning from #748 when the wavelength bundle is grad-attached.

Measured effect (float64, forward traces, single wavelength, RTX 5070, torch 2.13, medians of 5): Newton–Raphson systems get consistently faster across the sweep —

| rays | before | after | |
|---|---|---|---|
| 250k | 21.6 ms | 16.8 ms | −22% |
| 1M | 31.2 ms | 24.9 ms | −20% |
| 8M | 253 ms | 205 ms | −19% |

![Forward trace latency, even-asphere singlet, before vs after](https://raw.githubusercontent.com/optiland/optiland/ec5a3ef71d384d36d11ba4fa98da7a2bcc61502c/bench-figures/backend-host-transfers.png)

Closed-form systems (Cooke triplet) are unchanged within run-to-run noise: their remaining per-trace overhead is dominated by repeated paraxial entrance-pupil computation and host syncs on static surface properties, which are the next items from the same audit.

The full suite passes on both backends (8334 tests).
