### PR TITLE
Point the public documentation links at optiland.org/docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ This helps us respond more effectively and keeps the issue tracker focused. -->
 ### Checklist
 
 - [ ] I have searched the [existing issues](https://github.com/HarrisonKramer/optiland/issues) and [discussions](https://github.com/HarrisonKramer/optiland/discussions) for a similar question or problem.
-- [ ] I have read the [documentation](https://optiland.readthedocs.io/en/latest/) and tried to find an answer there.
+- [ ] I have read the [documentation](https://www.optiland.org/docs/) and tried to find an answer there.
 - [ ] I am using the **latest version** of Optiland (if not, please update and retry).
 - [ ] I have tried to reproduce or debug the issue myself before opening this.
 - [ ] I have included **all necessary context**, such as version info, error messages, or minimal reproducible examples.

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -12,7 +12,7 @@ This helps us respond more effectively and keeps the issue tracker focused. -->
 
 ### Checklist
 
-- [ ] I have read the [documentation](https://optiland.readthedocs.io/en/latest/) and tried to find an answer there.
+- [ ] I have read the [documentation](https://www.optiland.org/docs/) and tried to find an answer there.
 - [ ] I have included **all necessary context**.
 
 *Thanks for taking the time to go through this — it really helps us help you!*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,7 +13,7 @@ This helps us respond more effectively and keeps the issue tracker focused. -->
 ### Checklist
 
 - [ ] I have searched the [existing issues](https://github.com/HarrisonKramer/optiland/issues) and [discussions](https://github.com/HarrisonKramer/optiland/discussions) for a similar question or feature request.
-- [ ] I have read the [documentation](https://optiland.readthedocs.io/en/latest/) and tried to find an answer there.
+- [ ] I have read the [documentation](https://www.optiland.org/docs/) and tried to find an answer there.
 - [ ] I am using the **latest version** of Optiland.
 - [ ] I have included **all necessary context**.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,9 @@ jobs:
           cache-environment: true
           cache-environment-key: docs-env-${{ hashFiles('docs/build-environment.yml', 'pyproject.toml', 'uv.lock') }}
 
+      - name: Reject links to the retired Read the Docs site
+        run: python3 scripts/docs/check_no_rtd_links.py
+
       - name: Build documentation
         shell: bash -el {0}
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.14588962
 repository-code: 'https://github.com/optiland/optiland'
-url: 'https://optiland.readthedocs.io/'
+url: 'https://www.optiland.org/docs/'
 license: MIT
 version: 0.6.1
 date-released: '2026-02-08'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Optiland
 
-> For a deep dive into Optiland's architecture and step-by-step extension recipes, see the [Developer's Guide](https://optiland.readthedocs.io/en/latest/developers_guide/introduction.html) on Read the Docs.
+> For a deep dive into Optiland's architecture and step-by-step extension recipes, see the [Developer's Guide](https://www.optiland.org/docs/developers_guide/introduction.html).
 
 Thank you for your interest in contributing to **Optiland**! Contributions are welcome in many forms, including but not limited to:
 
@@ -241,7 +241,7 @@ Once `optiland-my-surface` is installed alongside Optiland,
 to Optiland itself.
 
 The same mechanism works for material catalogs (`optiland.materials`) and analyses
-(`optiland.analyses`) — see the [Plugin Packages](https://optiland.readthedocs.io/en/latest/developers_guide/plugin_packages.html)
+(`optiland.analyses`) — see the [Plugin Packages](https://www.optiland.org/docs/developers_guide/plugin_packages.html)
 guide for full worked examples of all three.
 
 ## Dead-Code Audits

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Tests](https://github.com/optiland/optiland/actions/workflows/ci.yml/badge.svg?label=Tests)
-[![Documentation Status](https://readthedocs.org/projects/optiland/badge/?version=latest)](https://optiland.readthedocs.io/en/latest/?badge=latest)
+[![Docs](https://github.com/optiland/optiland/actions/workflows/docs.yml/badge.svg)](https://www.optiland.org/docs/)
 [![codecov](https://codecov.io/github/optiland/optiland/graph/badge.svg?token=KAOE152K5O)](https://codecov.io/github/optiland/optiland)
 [![Maintainability](https://qlty.sh/gh/optiland/projects/optiland/maintainability.svg)](https://qlty.sh/gh/optiland/projects/optiland)
 ![Stars](https://img.shields.io/github/stars/optiland/optiland.svg)
@@ -9,7 +9,7 @@
 
 
 <div align="center">
-  <a href="https://optiland.readthedocs.io/">
+  <a href="https://www.optiland.org/docs/">
     <img src="https://github.com/optiland/optiland/raw/master/docs/images/optiland.svg" alt="Optiland">
   </a>
 </div>
@@ -70,7 +70,7 @@ print(lens.paraxial.f2())         # effective focal length -> 37.04 mm
 Stuck? `from optiland.diagnostics import check_system; print(check_system(lens))` reports what
 is missing or inconsistent about a system, each finding with a runnable fix.
 
-→ [Start Here](https://optiland.readthedocs.io/en/latest/start_here.html) · [Conventions](https://optiland.readthedocs.io/en/latest/conventions.html) · [How do I …?](https://optiland.readthedocs.io/en/latest/how_do_i.html) · [5-minute quickstart](https://optiland.readthedocs.io/en/latest/quickstart.html) · [Example Gallery](https://optiland.readthedocs.io/en/latest/gallery/introduction.html) · [Full Learning Guide](https://optiland.readthedocs.io/en/latest/learning_guide.html)
+→ [Start Here](https://www.optiland.org/docs/start_here.html) · [Conventions](https://www.optiland.org/docs/conventions.html) · [How do I …?](https://www.optiland.org/docs/how_do_i.html) · [5-minute quickstart](https://www.optiland.org/docs/quickstart.html) · [Example Gallery](https://www.optiland.org/docs/gallery/introduction.html) · [Full Learning Guide](https://www.optiland.org/docs/learning_guide.html)
 
 
 
@@ -109,7 +109,7 @@ is missing or inconsistent about a system, each finding with a runnable fix.
 - If you're using a non-NVIDIA GPU or running on Apple Silicon, use the CPU-only installation instead.
 
 
-For more details, see the [installation guide](https://optiland.readthedocs.io/en/latest/installation.html) in the docs.
+For more details, see the [installation guide](https://www.optiland.org/docs/installation.html) in the docs.
 
 ## Core Capabilities
 
@@ -130,7 +130,7 @@ For more details, see the [installation guide](https://optiland.readthedocs.io/e
 | **🤖 ML Integration** | Compatible with PyTorch pipelines for deep learning, differentiable modeling, and end-to-end training. |
 
 
-For a full breakdown of Optiland’s functionalities, see the [complete feature list](https://optiland.readthedocs.io/en/latest/functionalities.html).
+For a full breakdown of Optiland’s functionalities, see the [complete feature list](https://www.optiland.org/docs/functionalities.html).
 
 > [!NOTE]
 > The code itself is in constant flux and new functionalities are always being added.
@@ -142,7 +142,7 @@ For a full breakdown of Optiland’s functionalities, see the [complete feature 
 Optiland is continually evolving to provide new functionalities for optical design and analysis. Below are some of the planned features and enhancements we aim to implement in future versions. We welcome contributions in any of these areas:
 
 ### Physics & Core Engine
-- [x] **Non-Sequential Ray Tracing** (pre-release) — differentiable illumination, stray-light & ghost analysis, with coatings, required mirror reflectance, Beer–Lambert absorption, and self-diagnosing results. See the [Limitations & Roadmap](https://optiland.readthedocs.io/en/latest/gallery/nonsequential/limitations_and_roadmap.html) page (canonical) for the full capability envelope and these follow-ups:
+- [x] **Non-Sequential Ray Tracing** (pre-release) — differentiable illumination, stray-light & ghost analysis, with coatings, required mirror reflectance, Beer–Lambert absorption, and self-diagnosing results. See the [Limitations & Roadmap](https://www.optiland.org/docs/gallery/nonsequential/limitations_and_roadmap.html) page (canonical) for the full capability envelope and these follow-ups:
   - [ ] Reparameterization for visibility gradients (silhouette/vignetting)
   - [ ] Optimization-system integration (Variable/operand wiring)
   - [ ] Path Replay Backpropagation (constant-memory gradients)
@@ -205,7 +205,7 @@ If you have a **question** or would like to start a broader **discussion**, plea
 This keeps all project-related communication public, searchable, and helpful for others who may encounter the same problems or questions.
 
 Before opening an issue or discussion, please make sure you have:  
-- Checked the [documentation](https://optiland.readthedocs.io/en/latest/) and API reference  
+- Checked the [documentation](https://www.optiland.org/docs/) and API reference  
 - Searched existing [issues](https://github.com/optiland/optiland/issues) and [discussions](https://github.com/optiland/optiland/discussions)  
 - Made a reasonable attempt to solve the problem on your own  
 

--- a/docs/examples/Tutorial_3c_User_Defined_Optimization.ipynb
+++ b/docs/examples/Tutorial_3c_User_Defined_Optimization.ipynb
@@ -132,7 +132,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "Next, we define a simple singlet value with a polynomial surface type on the first surface. Other tutorials (see [here](https://github.com/optiland/optiland/blob/master/docs/examples/Tutorial_7c_Freeform_Surfaces.ipynb)) and the documentation elaborate on polynomial surfaces. We will omit those details here."
+                "Next, we define a simple singlet value with a polynomial surface type on the first surface. Other tutorials (see [here](Tutorial_4b_Raytracing_Aspheres_and_Freeforms.ipynb)) and the documentation elaborate on polynomial surfaces. We will omit those details here."
             ]
         },
         {

--- a/docs/gallery/reflective/three_mirror_anastigmat.ipynb
+++ b/docs/gallery/reflective/three_mirror_anastigmat.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Three Mirror Anastigmat\n",
     "\n",
-    "The design process for this mirror system is demonstrated in [Tutorial 7d - Three Mirror Anastigmat](https://github.com/optiland/optiland/blob/master/docs/examples/Tutorial_7d_Three_Mirror_Anastigmat.ipynb)."
+    "The design process for this mirror system is demonstrated in [Tutorial 4f - Three Mirror Anastigmat](../../examples/Tutorial_4f_Three_Mirror_Anastigmat.ipynb)."
    ]
   },
   {

--- a/optiland/nonsequential/__init__.py
+++ b/optiland/nonsequential/__init__.py
@@ -200,7 +200,7 @@ capped at ~1e5 rays. These gaps and the full roadmap
 (reparameterization → optimization integration → PRB → GUI → volumetric
 scattering → polarisation → Dr.Jit/Mitsuba) are tracked on the canonical
 **NSQ Limitations & Roadmap** documentation page:
-https://optiland.readthedocs.io/en/latest/gallery/nonsequential/limitations_and_roadmap.html
+https://www.optiland.org/docs/gallery/nonsequential/limitations_and_roadmap.html
 
 Call to Action
 --------------

--- a/optiland_gui/widgets/custom_title_bar.py
+++ b/optiland_gui/widgets/custom_title_bar.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
 )
 
 _GITHUB_URL = "https://github.com/optiland/optiland"
-_HELP_URL = "https://optiland.readthedocs.io/en/latest/index.html"
+_HELP_URL = "https://www.optiland.org/docs/"
 
 _BTN_SIZE = QSize(30, 30)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ torch = ["torch"]
 [project.urls]
 Homepage = "https://github.com/optiland/optiland"
 Repository = "https://github.com/optiland/optiland"
-Documentation = "https://optiland.readthedocs.io/en/latest/"
+Documentation = "https://www.optiland.org/docs/"
 "Bug Tracker" = "https://github.com/optiland/optiland/issues"
 
 [project.scripts]

--- a/scripts/docs/check_no_rtd_links.py
+++ b/scripts/docs/check_no_rtd_links.py
@@ -1,0 +1,56 @@
+"""Fail when a reference to the retired Read the Docs site is (re)introduced.
+
+The canonical documentation URL is https://www.optiland.org/docs/. A short
+allowlist covers the files that legitimately mention the old host: the
+validation tooling that rejects such links and the operations runbook that
+documents the migration.
+
+Usage::
+
+    python scripts/docs/check_no_rtd_links.py          # scan the git tree
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOST = "optiland.readthedocs.io"
+ALLOWLIST = {
+    "scripts/docs/check_no_rtd_links.py",
+    "scripts/docs/validate_build.py",
+    "scripts/docs/smoke_test.py",
+    "docs/developers_guide/documentation_operations.rst",
+    ".github/workflows/docs.yml",
+}
+
+
+def main() -> int:
+    result = subprocess.run(
+        ["git", "grep", "-n", "-I", "--", HOST],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    offenders = []
+    for line in result.stdout.splitlines():
+        path = line.split(":", 1)[0].replace("\\", "/")
+        if path not in ALLOWLIST:
+            offenders.append(line)
+    for line in offenders:
+        print(f"ERROR: {line}")
+    if offenders:
+        print(
+            f"\n{len(offenders)} reference(s) to {HOST}. Link to "
+            "https://www.optiland.org/docs/ instead, or add a documented "
+            "allowlist entry in scripts/docs/check_no_rtd_links.py."
+        )
+        return 1
+    print(f"no references to {HOST} outside the allowlist")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docs/smoke_test.py
+++ b/scripts/docs/smoke_test.py
@@ -16,9 +16,11 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import gzip
 import json
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 
@@ -47,13 +49,42 @@ ASSETS = [
 UA = "optiland-docs-smoke-test/1.0"
 
 
+def _decode(headers: dict, body: bytes) -> bytes | None:
+    """Undo a Content-Encoding; None when the body cannot be decoded."""
+    enc = headers.get("Content-Encoding") or headers.get("content-encoding") or ""
+    enc = enc.strip().lower()
+    if enc in ("", "identity"):
+        return body
+    if enc == "gzip":
+        return gzip.decompress(body)
+    if enc == "br":
+        try:
+            import brotli  # type: ignore[import-not-found]
+        except ImportError:
+            try:
+                import brotlicffi as brotli  # type: ignore[import-not-found,no-redef]
+            except ImportError:
+                return None
+        return brotli.decompress(body)
+    return None
+
+
 def fetch(url: str, timeout: float = 30.0):
-    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    # A unique query string bypasses CDN caches so every check observes the
+    # current deployment rather than a previously cached variant (the edge may
+    # otherwise serve a compressed cached copy regardless of Accept-Encoding).
+    sep = "&" if "?" in url else "?"
+    req = urllib.request.Request(
+        f"{url}{sep}smoke={int(time.time() * 1000)}",
+        headers={"User-Agent": UA, "Accept-Encoding": "identity"},
+    )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return resp.status, dict(resp.headers), resp.read(), resp.geturl()
+            headers = dict(resp.headers)
+            return resp.status, headers, _decode(headers, resp.read()), resp.geturl()
     except urllib.error.HTTPError as exc:
-        return exc.code, dict(exc.headers), exc.read(), exc.geturl()
+        headers = dict(exc.headers)
+        return exc.code, headers, _decode(headers, exc.read()), exc.geturl()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -96,6 +127,12 @@ def main(argv: list[str] | None = None) -> int:
                 errors.append(f"{url}: not cacheable: Cache-Control: {cc}")
             if "set-cookie" in {k.lower() for k in headers}:
                 errors.append(f"{url}: response sets a cookie")
+        if body is None:
+            enc = headers.get("Content-Encoding") or headers.get("content-encoding")
+            errors.append(
+                f"{url}: cannot decode Content-Encoding {enc!r} (pip install brotli)"
+            )
+            return status, headers, b""
         if expect_html and status == expect_status:
             text = body.decode("utf-8", errors="replace")
             if "<html" not in text.lower():


### PR DESCRIPTION
# Point the public documentation links at optiland.org/docs

The documentation is now served first-party at https://www.optiland.org/docs/ (#763 and
optiland/optiland-website#17). This follow-up moves every public reference from
`optiland.readthedocs.io` to the new address so users land on the canonical site:

- README badge (now the Docs workflow status) and links, `CONTRIBUTING.md`, `CITATION.cff`,
  the `Documentation` URL in `pyproject.toml` (picked up by PyPI at the next release),
  the three issue templates, the GUI help button and the non-sequential module docstring.
- A CI step (`scripts/docs/check_no_rtd_links.py`) fails the docs workflow if a link to the
  retired host is reintroduced; the runbook, validator and smoke test are the only allowed
  mentions.

Read the Docs keeps building as a fallback during the stabilisation period; its redirects to
the first-party site are configured separately once the new route has proven stable.

Also included: the production smoke test no longer depends on CDN cache state (it asks for
identity encoding, decodes gzip/brotli if served anyway, and cache-busts each request), which
is what made the first `production-smoke` run against the live route report `/docs/` as
"not HTML". With this change the live route passes: 0 errors, commit assertion included.
