### PR TITLE
fix: align Torch histogram2d bin edge semantics

### DIFF
--- a/optiland/backend/torch_backend/misc.py
+++ b/optiland/backend/torch_backend/misc.py
@@ -184,8 +184,9 @@ class MiscMixin:
         nx = x_edges.numel() - 1
         ny = y_edges.numel() - 1
 
-        x_bin_indices = torch.searchsorted(x_edges, x, right=False) - 1
-        y_bin_indices = torch.searchsorted(y_edges, y, right=False) - 1
+        # Match NumPy: internal edges belong to the bin on their right.
+        x_bin_indices = torch.searchsorted(x_edges, x, right=True) - 1
+        y_bin_indices = torch.searchsorted(y_edges, y, right=True) - 1
         x_bin_indices = torch.clamp(x_bin_indices, 0, nx - 1)
         y_bin_indices = torch.clamp(y_bin_indices, 0, ny - 1)
 

--- a/tests/test_backend_functions.py
+++ b/tests/test_backend_functions.py
@@ -175,14 +175,13 @@ def test_cross_product(set_test_backend):
 
 def test_histogram2d(set_test_backend):
     if hasattr(be, "histogram2d"):
-        x = be.array([0.5, 1.5])
-        y = be.array([0.5, 1.5])
+        x = be.array([0.0, 1.0, 2.0, 1.0, 0.5, -0.1, 1.0])
+        y = be.array([0.0, 1.0, 2.0, 0.5, 1.0, 0.5, 2.1])
         bins = (be.array([0, 1, 2]), be.array([0, 1, 2]))
-        H, _, _ = be.histogram2d(x, y, bins)
-        # Should have count 1 at (0,0) and (1,1)
-        # H is (ny, nx) -> (2, 2)
-        assert H[0, 0] == 1
-        assert H[1, 1] == 1
+        histogram, _, _ = be.histogram2d(x, y, bins)
+
+        expected = be.array([[1.0, 1.0], [1.0, 2.0]])
+        assert be.allclose(histogram, expected)
 
 
 def test_poly(set_test_backend):


### PR DESCRIPTION
## Summary

- align the Torch backend's internal bin-edge assignment with NumPy's
  `histogram2d` semantics
- extend the backend-parametrized regression test to cover lower, internal,
  upper, and out-of-range samples

## Testing

- `tests/test_backend_functions.py`: 63 passed, 1 skipped
- `TestIncoherentIrradiance` and `TestRadiantIntensity`: 37 passed, 3 skipped
- `ruff check .`
- `ruff format --check .`

Fixes #762
