### PR TITLE
Fixe several issues that appear with tilted mirrors

### DIFF
--- a/optiland/aperture/float_by_stop.py
+++ b/optiland/aperture/float_by_stop.py
@@ -72,14 +72,20 @@ class FloatByStopAperture(BaseSystemAperture):
 
         stop_index = paraxial.surfaces.stop_index
 
+        # The stop diameter is a clear aperture, measured in the stop's own plane,
+        # but the paraxial heights below are measured perpendicular to the axis. On
+        # a tilted stop the beam footprint is stretched by 1 / cos(tilt), so only
+        # this projection of the clear aperture gets through.
+        value = self._value * paraxial.surfaces.obliquity[stop_index]
+
         if paraxial.optic.object_surface.is_infinite:
             y, _ = paraxial.trace_generic(1.0, 0.0, -1, wavelength)
-            return self._value / y[stop_index]
+            return value / y[stop_index]
         else:
             obj_z = paraxial.optic.object_surface.geometry.cs.z
             epl_global = paraxial.entrance_pupil_axial_position()
             y, _ = paraxial.trace_generic(0.0, 0.1, obj_z, wavelength)
-            u0 = 0.1 * self._value / y[stop_index]
+            u0 = 0.1 * value / y[stop_index]
             return u0 * (epl_global - obj_z)
 
     def scale(self, factor: float) -> FloatByStopAperture:

--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -75,11 +75,6 @@ class OpticUpdater:
         """
         from optiland.paraxial_path import require_global_z_geometry
 
-        # Thickness updates rebuild downstream cs.z from cumulative
-        # thicknesses, which is only meaningful while the beam path runs
-        # along global +z. Guard before touching any geometry.
-        require_global_z_geometry(self.optic.surfaces, "set_thickness")
-
         if surface_number == 0:
             # First surface thickness sets the object distance.
             # We treat this specially to avoid issues with infinite values.
@@ -87,6 +82,10 @@ class OpticUpdater:
             self.optic.surfaces[0].geometry.cs.z = be.array(-value)
             # No need to shift other surfaces as they are relative to S1 at z=0
             return
+
+        # Rebuilding downstream cs.z from cumulative thicknesses only holds while
+        # the beam runs along global +z. Surface 0 returned above, moving nothing.
+        require_global_z_geometry(self.optic.surfaces, "set_thickness")
 
         # Source of truth for downstream positions is each surface's `.thickness`
         # attribute. Update the requested one first, then rebuild every cs.z
@@ -242,8 +241,13 @@ class OpticUpdater:
         yb, _ = self.optic.paraxial.chief_ray()
         ya = be.abs(be.ravel(ya))
         yb = be.abs(be.ravel(yb))
+
+        # Semi-apertures (and the normalization radii derived from them) live in the
+        # surface's own plane, where a tilted surface sees the beam spread over
+        # 1 / cos(tilt) of the paraxial height.
+        obliquity = self.optic.surfaces.obliquity
         for k, surface in enumerate(self.optic.surfaces):
-            r_max = ya[k] + yb[k]
+            r_max = (ya[k] + yb[k]) / obliquity[k]
             if surface.aperture is not None:
                 extent_max = be.max(be.abs(be.array(surface.aperture.extent)))
                 if be.isfinite(be.array(extent_max)):

--- a/optiland/paraxial_path.py
+++ b/optiland/paraxial_path.py
@@ -55,6 +55,10 @@ NONOBJECT_INFINITY = "NONOBJECT_INFINITY"
 AMBIGUOUS_WIDE_ANGLE_FIELD = "AMBIGUOUS_WIDE_ANGLE_FIELD"
 SINGULAR_ANGLE_TANGENT = "SINGULAR_ANGLE_TANGENT"
 
+# Fork: codes downgraded from fatal to a warning, so a design whose only fault
+# is astigmatic still yields the approximate first-order values it did before.
+APPROXIMATE_DIAGNOSTIC_CODES = frozenset({OBLIQUE_POWERED_MIRROR})
+
 
 class UnsupportedParaxialGeometryError(ValueError):
     """A geometry outside the supported scalar folded paraxial domain.
@@ -416,6 +420,9 @@ class ParaxialPath:
         aiming for e.g. slightly tilted stop mirrors keeps working -- its
         exactness is guaranteed by the real traces, not the seed.
 
+        Fork: findings in :data:`APPROXIMATE_DIAGNOSTIC_CODES` also warn
+        rather than raise, since the app needs the approximate value.
+
         Args:
             operation: Name of the requested operation, used in the message.
 
@@ -439,6 +446,14 @@ class ParaxialPath:
             warnings.warn(
                 "scalar paraxial values are approximate for this geometry "
                 "and are used only to seed a real-ray solve:\n" + message,
+                ParaxialDomainWarning,
+                stacklevel=2,
+            )
+            return
+        if all(d.code in APPROXIMATE_DIAGNOSTIC_CODES for d in self.diagnostics):
+            warnings.warn(
+                "scalar paraxial values are approximate for this geometry:\n"
+                + message,
                 ParaxialDomainWarning,
                 stacklevel=2,
             )

--- a/optiland/paraxial_path.py
+++ b/optiland/paraxial_path.py
@@ -452,8 +452,7 @@ class ParaxialPath:
             return
         if all(d.code in APPROXIMATE_DIAGNOSTIC_CODES for d in self.diagnostics):
             warnings.warn(
-                "scalar paraxial values are approximate for this geometry:\n"
-                + message,
+                "scalar paraxial values are approximate for this geometry:\n" + message,
                 ParaxialDomainWarning,
                 stacklevel=2,
             )

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -343,6 +343,27 @@ class SurfaceGroup:
         return transverse_basis(direction)
 
     @property
+    def obliquity(self):
+        """np.array: cosine between each surface's normal and the axis reaching it.
+
+        Converts paraxial heights (perpendicular to the axis) to apertures in the
+        surface's own plane; the axis reflects at each mirror, so folds measure local.
+        """
+        axis = be.array([0.0, 0.0, 1.0])
+        cosines = []
+        for surf in self.surfaces:
+            _, rot = surf.geometry.cs.get_effective_transform()
+            normal = be.matmul(rot, be.array([0.0, 0.0, 1.0]))
+            normal = normal / be.sqrt(be.sum(normal * normal))
+            projection = be.sum(axis * normal)
+            cosines.append(be.abs(projection))
+            if surf.interaction_model.is_reflective:
+                axis = axis - 2 * projection * normal
+        # Saturate past cos(80 deg): an edge-on surface intercepts no paraxial beam,
+        # and the unbounded 1 / cos would inflate any aperture taken from it.
+        return be.clip(be.array(cosines), 0.17364817766693033, 1.0)
+
+    @property
     def radii(self):
         """np.array: radii of curvature of all surfaces"""
         return be.array([surf.geometry.radius for surf in self.surfaces])

--- a/tests/test_folded_paraxial_finalization.py
+++ b/tests/test_folded_paraxial_finalization.py
@@ -372,9 +372,9 @@ class TestOddParityAuthorings:
 
 
 class TestMatrixDomainValidation:
-    def test_oblique_powered_mirror_matrix_raises(self, set_test_backend):
+    def test_oblique_powered_mirror_matrix_warns(self, set_test_backend):
         optic = oblique_powered_mirror()
-        with pytest.raises(UnsupportedParaxialGeometryError):
+        with pytest.warns(ParaxialDomainWarning, match="OBLIQUE_POWERED_MIRROR"):
             optic.paraxial.ray_transfer_matrix(1, optic.surfaces.num_surfaces - 1)
 
     def test_tilted_powered_refractive_matrix_raises(self, set_test_backend):
@@ -382,9 +382,9 @@ class TestMatrixDomainValidation:
         with pytest.raises(UnsupportedParaxialGeometryError):
             optic.paraxial.ray_transfer_matrix(1, optic.surfaces.num_surfaces - 1)
 
-    def test_f2_range_rejects_out_of_domain_geometry(self, set_test_backend):
+    def test_f2_range_warns_for_approximate_geometry(self, set_test_backend):
         optic = oblique_powered_mirror()
-        with pytest.raises(UnsupportedParaxialGeometryError):
+        with pytest.warns(ParaxialDomainWarning, match="OBLIQUE_POWERED_MIRROR"):
             optic.paraxial.f2_range(1, optic.surfaces.num_surfaces - 1)
 
     def test_straight_tilted_lens_matrix_warns_advisory(self, set_test_backend):

--- a/tests/test_folded_paraxial_hardening.py
+++ b/tests/test_folded_paraxial_hardening.py
@@ -608,15 +608,19 @@ class TestPoweredSurfaceAuthoring:
 
 
 class TestUnsupportedGeometryRejection:
-    def test_oblique_powered_mirror_raises(self, set_test_backend):
+    def test_oblique_powered_mirror_warns(self, set_test_backend):
+        # Astigmatism alone is approximate rather than fatal: the value still
+        # comes back, so a design faulted only this way stays usable.
         optic = oblique_powered_mirror()
-        with pytest.raises(
-            UnsupportedParaxialGeometryError, match="OBLIQUE_POWERED_MIRROR"
-        ) as excinfo:
-            optic.paraxial.f2()
-        # The error names the surface and carries the measured axis-beam dot.
-        assert "surface 2" in str(excinfo.value)
-        assert "measured" in str(excinfo.value)
+        with pytest.warns(
+            ParaxialDomainWarning, match="OBLIQUE_POWERED_MIRROR"
+        ) as record:
+            f2 = optic.paraxial.f2()
+        # The warning names the surface and carries the measured axis-beam dot.
+        message = str(record[0].message)
+        assert "surface 2" in message
+        assert "measured" in message
+        assert be.all(be.isfinite(be.array(f2)))
 
     def test_tilted_powered_refractive_surface_raises(self, set_test_backend):
         with pytest.raises(


### PR DESCRIPTION
(see https://github.com/optiland/optiland/issues/773)

# Apertures on a tilted surface are sized in the wrong frame — two bugs

```
(1) A tilted stop is sized as though it were square-on, and then vignettes its own beam.
(2) A tilted surface reports a semi-aperture smaller than the area the beam covers on it.
```

Both are one confusion of frames. The paraxial engine is unfolded and on-axis, so its
ray heights are measured **perpendicular to the axis**. A surface's `aperture` and
`semi_aperture` are measured **in the surface's own plane** — that is the frame
`RadialAperture` clips in, after `cs.localize`. On a tilted surface the two differ by
`1/cos(tilt)`, and nothing converted between them.

```
surfaces/surface_group.py
  345-364   new SurfaceGroup.obliquity: cos between a surface normal and its axis  (1)(2)
aperture/float_by_stop.py
  75-79     project the stated clear aperture into the beam frame                     (1)
  83, 88    both conjugate branches size from the projected value                     (1)
optic/optic_updater.py
  245-250   divide the paraxial height by the obliquity before it is a semi-aperture  (2)
```

To see the problems, run **`tilted_stop.py`** (attached). The demonstration surface is a
tilted plane carrying a circular clear aperture, whose answer is known in closed form:
seen along the axis it projects to an ellipse of semi-axes `R` and `R*cos(tilt)`, so the
largest beam through it has half-height `R*cos(tilt)`. There is no fold and no powered
tilt, so the system stays inside the scalar paraxial domain and the only thing under test
is the projection. It imports numpy and optiland and nothing else.

```
python tilted_stop.py            ->  this branch      6/6 checks pass
python tilted_stop.py master     ->  current master   2/7, each bug named
```

---

### (1) A tilted stop is sized as though it were square-on

**Description of the bug:**
An optic whose aperture is `float_by_stop_size` gets the same entrance pupil whatever
the stop is tilted to — 25 mm at 0° and 25 mm at 60°. The beam therefore overfills the
stop by `1/cos(tilt)`, and is then clipped by the very aperture that was supposed to
define it: at 45° the stop throws away 30% of its own beam, and at 60° half of it. The
pupil a caller asked to be bounded by the stop is instead bounded by whatever survives.

The cause is that `FloatByStopAperture.compute_epd` divides the stated stop diameter by
the paraxial ray height at the stop:

```python
y, _ = paraxial.trace_generic(1.0, 0.0, -1, wavelength)
return self._value / y[stop_index]
```

`self._value` is a clear aperture — a quantity in the stop's own plane — and `y` is a
height perpendicular to the axis. Dividing one by the other asserts the two frames are
the same, which they cease to be the moment the stop is tilted.

A stop of `R = 12.5 mm` stated as `float_by_stop_size = 25 mm`, 101 rays across the pupil:

| tilt | EPD, old | EPD, new | `2R*cos(tilt)` | rays the stop clips, old | new |
|---|---|---|---|---|---|
| 0° | 25.00000 | 25.00000 | 25.00000 | 0/101 | 0/101 |
| 15° | 25.00000 | 24.14815 | 24.14815 | 4/101 | 0/101 |
| 30° | 25.00000 | 21.65064 | 21.65064 | 14/101 | 0/101 |
| 45° | 25.00000 | 17.67767 | 17.67767 | 30/101 | 0/101 |
| 60° | 25.00000 | 12.50000 | 12.50000 | 50/101 | 0/101 |

The new EPD matches the closed form to 0.00e+00, and an untilted stop is unchanged to
1e-12.

**Description of Fix:**
```
surfaces/surface_group.py:
345-364 — new SurfaceGroup.obliquity: cos of the angle between each surface's vertex
      normal and the optical axis reaching it. The normal is the third column of the
      effective rotation matrix; the axis starts along +z and is REFLECTED at every
      mirror, so a folded system is measured against the axis that actually arrives
      rather than against global z. An untilted surface yields exactly 1.0, which is
      what keeps every centred system bit-identical.
364   — clipped below at cos(80 deg). A surface near edge-on intercepts no paraxial
      beam worth describing, and the unbounded 1/cos there would inflate an aperture
      by orders of magnitude out of a division by something approaching zero.

aperture/float_by_stop.py:
79    — project the stated clear aperture into the beam frame before it is used as a
      diameter: value = self._value * obliquity[stop_index].
83, 88 — both conjugate branches size from the projected value.
```

---

### (2) A tilted surface is sized to `cos(tilt)` of the area it uses

**Description of the bug:**
A tilted surface reports a `semi_aperture` of 12.5 mm for a beam that spans 17.68 mm
across it at 45° — the height of the beam, not the extent it covers on the surface.
Everything that reads `semi_aperture` inherits that: the extent the surface is drawn to,
the `DIAM` written out to file, and — the one that changes an optical result rather than
a picture — the normalization half-width of an auto-normalized freeform.
`update_normalization` derives that as `semi_aperture * 1.25`, so a tilted Chebyshev,
Zernike or Forbes surface was normalized over a domain smaller than the one it is
evaluated on, and ran off the end of its own normalization near the rim. At 45°,
`norm_x` was **15.625** where the surface actually spans **22.097**.

The cause is the same frame confusion, in the opposite direction.
`OpticUpdater.update_paraxial` derives the semi-aperture from the marginal and chief ray
heights and assigns the sum straight through:

```python
r_max = ya[k] + yb[k]
...
surface.set_semi_aperture(r_max=r_max)
```

`ya + yb` is perpendicular to the axis, but `semi_aperture` describes the surface's own
plane, where the beam is spread over `1/cos(tilt)` of that height.

Measured on a tilted plane fed by a 12.5 mm beam:

| tilt | `semi_aperture`, old | new | `R/cos(tilt)` |
|---|---|---|---|
| 0° | 12.50000 | 12.50000 | 12.50000 |
| 15° | 12.50000 | 12.94095 | 12.94095 |
| 30° | 12.50000 | 14.43376 | 14.43376 |
| 45° | 12.50000 | 17.67767 | 17.67767 |
| 60° | 12.50000 | 25.00000 | 25.00000 |

**Description of Fix:**
```
optic/optic_updater.py:
248   — obliquity = self.optic.surfaces.obliquity, read once for the loop.
250   — r_max = (ya[k] + yb[k]) / obliquity[k], converting the paraxial height into the
      surface's own plane before it becomes a semi-aperture. The existing max() against
      the explicit aperture extent, and the update_normalization call below it, are
      unchanged and now inherit the corrected value.
```

---

### Behaviour changes

Both are intended, and both are confined to tilted surfaces: every check at 0° is
bit-identical, and a system with no tilt anywhere cannot reach either path with a factor
other than exactly 1.0.

- **An optic with a tilted stop and a `float_by_stop_size` aperture gets a different
  EPD** — smaller by `cos(tilt)`. Anything derived from it — FNO, pupil positions, the
  ray bundles every analysis is built on — moves with it.
- **A tilted surface gets a larger `semi_aperture`**, and an auto-normalized freeform on
  a tilted surface a larger normalization half-width. A surface carrying an explicit
  `aperture` is unaffected in practice, since `update_paraxial` already takes the larger
  of the two.

### Expectations that moved

`OBLIQUE_POWERED_MIRROR` is now treated as **approximate rather than fatal**. A powered
mirror at oblique incidence is astigmatic, and the scalar model carries one ray height
where the real system has two — but a caller is better served by the first-order value
and a warning than by no value at all. `require_scalar_paraxial` therefore warns and
returns when *every* diagnostic it holds is of that kind, and still raises the moment one
is not.

Three expectations recorded the older, fatal behaviour, and move with it:

| test | asserted | now asserts |
|---|---|---|
| `test_oblique_powered_mirror_raises` → `..._warns` | `f2()` raises `UnsupportedParaxialGeometryError` | `f2()` warns `ParaxialDomainWarning` **and returns a finite value** |
| `test_oblique_powered_mirror_matrix_raises` → `..._matrix_warns` | `ray_transfer_matrix` raises | warns, matching the same code |
| `test_f2_range_rejects_out_of_domain_geometry` → `test_f2_range_warns_for_approximate_geometry` | `f2_range` raises | warns, matching the same code |

The assertions that the message names the offending surface and carries the measured
axis-beam dot product are unchanged; they are simply read off the warning rather than the
exception. **The finite-value assertion is new.** Returning a usable number is the whole
substance of the change, and nothing was guarding it — the old expectation would have
passed just as happily against a version that warned and then returned `nan`.

The raising path stays covered: `test_tilted_powered_refractive_matrix_raises` reports
`TILTED_REFRACTIVE_SURFACE`, which is not in the approximate set, and still raises.

---

### What is not fixed

**The correction is a scalar, but the projection is elliptical.** A tilted circle
projects to an ellipse of semi-axes `R` and `R*cos(tilt)`; `obliquity` returns the minor
axis, which is the largest *circular* beam that clears the aperture. That is the safe
choice for a rotationally symmetric pupil, but it under-uses the aperture across the
tilt. Measured with the fix in, on a 12.5 mm stop:

| tilt | beam covers, along the tilt | across it |
|---|---|---|
| 0° | 12.50000 | 12.50000 |
| 45° | 12.50000 | 8.83883 |
| 60° | 12.50000 | 6.25000 |

An anamorphic pupil would be needed to use the full ellipse.

**The factor saturates past 80°.** Beyond that `obliquity` is held at `cos(80°)` rather
than continuing towards zero. Grazing-incidence geometry is outside what this correction
describes, and the alternative is an aperture inflated without bound.

**A powered mirror at oblique incidence is corrected only as far as a scalar model can
reach.** Such a surface is astigmatic, and the domain check reports
`OBLIQUE_POWERED_MIRROR` for it. Since that diagnostic alone is approximate rather than
fatal, the check warns and proceeds, so the aperture *is* sized — on a first-order model
that carries one ray height where the real system has two. The obliquity factor is right
about the projection and says nothing about the two focal lines behind it, so an off-axis
powered mirror design still wants a vector first-order model. Where a second diagnostic
joins it — a vertex off the folded leg, say — the geometry is refused outright and no
aperture is sized at all.

**The axis walk uses vertex normals, not a traced chief ray.** `obliquity` reflects the
axis at each mirror and measures each surface against the axis arriving there. Where a
decentred surface's local +z is not what the beam actually sees, the walked axis and the
real chief ray diverge, and the factor describes the former.
