### PR TITLE
NurbsGeometry: six bugs — a NURBS surface could not be built, evaluated, intersected or fitted correctly

### DIFF
--- a/optiland/geometries/nurbs/nurbs_geometry.py
+++ b/optiland/geometries/nurbs/nurbs_geometry.py
@@ -25,6 +25,12 @@ from .nurbs_basis_functions import (
 )
 from .nurbs_fitting import approximate_surface
 
+# Data points per control point along each axis when a surface is sampled to be
+# fitted. One apiece makes the least squares square -- interpolation in disguise --
+# and the net that comes back runs to 1e10 mm for a surface a few mm deep. Two
+# settles it and is worth four orders of accuracy; more buys nothing measurable.
+FIT_DATA_FACTOR = 2
+
 
 class NurbsGeometry(BaseGeometry):
     """Creates a NURBS (Non-Uniform Rational Basis Spline) geometry.
@@ -75,6 +81,19 @@ class NurbsGeometry(BaseGeometry):
             are passed.
         tol: The tolerance for Newton-Raphson iteration.
         max_iter: The maximum number of iterations for Newton-Raphson.
+        max_stall: How many iterations a ray may go without improving before it
+            is taken as settled. A root off the patch is pinned by the clamp and
+            never reaches tol; without this it would iterate to max_iter.
+
+            Every net this module fits now lands at 2 -- measured over 24 of
+            them, spanning n_points 24 to 48 and radii 25 to 200. 12 is headroom
+            for control points supplied by a CALLER, which this module cannot
+            vouch for: a badly conditioned net does not converge steadily, its
+            residual falling in fits, and three quiet iterations are then not
+            evidence a ray is done. The headroom is close to free -- a ray ON the
+            patch lands in a single iteration whatever this says, and only a ray
+            off the patch pays, exactly max_stall + 1 against the 100 it used
+            to.
 
     References:
         - The NURBS Book. See references to equations and algorithms throughout
@@ -104,6 +123,7 @@ class NurbsGeometry(BaseGeometry):
         n_points_v=4,
         tol=1e-10,
         max_iter=100,
+        max_stall=12,
     ):
         super().__init__(coordinate_system)
         self.P = be.asarray(control_points) if control_points is not None else None
@@ -127,6 +147,7 @@ class NurbsGeometry(BaseGeometry):
         self.k = conic
         self.tol = tol
         self.max_iter = max_iter
+        self.max_stall = max_stall
 
         self.is_symmetric = False
 
@@ -135,8 +156,12 @@ class NurbsGeometry(BaseGeometry):
         if control_points is None:
             self.is_fitted = True
             self.ndim = 3
-            self.P_size_u = n_points_u + 1
-            self.P_size_v = n_points_v + 1
+            # The CONTROL count, which is what n_points_u is documented to be.
+            # It used to be that plus one, being read as a data count by the
+            # standard-surface fit and as a control count by the plane one -- so
+            # the same n_points_u gave nets a size apart depending on the branch.
+            self.P_size_u = n_points_u
+            self.P_size_v = n_points_v
 
         # Polynomial Bezier surface initialization
         elif (
@@ -276,6 +301,15 @@ class NurbsGeometry(BaseGeometry):
                     )
                 )
             self.ndim = be.shape(control_points)[0]
+
+        # The branches above fill in whatever the caller left out -- weights, a
+        # degree, a clamped knot vector -- as locals. Written back here, or the
+        # surface keeps the None it was constructed with and evaluates to nothing.
+        for name, value in (("W", weights), ("p", u_degree), ("q", v_degree),
+                            ("U", u_knots), ("V", v_knots)):
+            if getattr(self, name) is None and value is not None:
+                setattr(self, name, be.asarray(value)
+                        if name not in ("p", "q") else value)
 
     def set_radius(self, value: float) -> None:
         """Set the radius of curvature.
@@ -664,7 +698,7 @@ class NurbsGeometry(BaseGeometry):
 
         Returns:
             A tuple containing the correction steps for u and v parameters,
-            and the maximum distance between all rays and surface intersection.
+            and the distance between each ray and its surface intersection.
         """
         S_uv = self.get_value(u, v).T
         r = be.stack(
@@ -691,7 +725,9 @@ class NurbsGeometry(BaseGeometry):
         invj = adj / detJ
 
         correction = be.einsum("ijk,ki->ji", invj, r)
-        residual = be.max(be.abs(r))
+        # One residual PER RAY: _newton has to tell a ray still closing on its root
+        # from one the clamp has pinned, and a bundle-wide max hides that
+        residual = be.maximum(be.abs(r[0, :]), be.abs(r[1, :]))
 
         return correction, residual
 
@@ -710,7 +746,7 @@ class NurbsGeometry(BaseGeometry):
             d2: A parameter related to the ray's position.
 
         Returns:
-            A tuple containing the correction steps and the residual.
+            A tuple containing the correction steps and the per-ray residual.
         """
         S_uv = self.get_value(u, v)
         r = be.stack([S_uv[1, :] + d1, S_uv[0, :] + d2], axis=0)
@@ -734,9 +770,56 @@ class NurbsGeometry(BaseGeometry):
         invj = adj / detJ
 
         correction = be.einsum("ijk,ki->ji", invj, r)
-        residual = be.max(be.abs(r))
+        # One residual PER RAY: _newton has to tell a ray still closing on its root
+        # from one the clamp has pinned, and a bundle-wide max hides that
+        residual = be.maximum(be.abs(r[0, :]), be.abs(r[1, :]))
 
         return correction, residual
+
+    def _seed(self, x, y):
+        """Where in (u, v) to start the Newton for points at x, y: their place across
+        the patch, u running with x and v with y. Seeded at a corner instead, the
+        iteration walks off the patch or onto a neighbouring root, and no number of
+        restarts brings it back.
+
+        Measured off the FOUR CORNER control points, which a clamped spline
+        interpolates, not off the whole net -- a least squares run near
+        interpolation leaves interior control points decades away from the surface
+        they describe, and a box drawn round those seeds every point at one edge.
+        """
+        corners = self.P[:, :: self.P.shape[1] - 1, :: self.P.shape[2] - 1]
+
+        def fraction(values, axis):
+            low, high = be.min(corners[axis]), be.max(corners[axis])
+            span = high - low
+            return be.clip((values - low) / be.where(span > 0.0, span, 1.0), 0.0, 1.0)
+
+        return fraction(be.ravel(x), 0), fraction(be.ravel(y), 1)
+
+    def _newton(self, corrector, u, v):
+        """Drive one of the two correction steps to its root, clamped to the patch.
+        A root off the patch never reaches `tol` -- the clamp pins it and the same
+        correction returns for ever -- so a ray is done once it stops IMPROVING.
+        """
+        best_u, best_v = u, v
+        best = be.full(be.shape(u), be.inf)
+        stalled = be.zeros(be.shape(u))
+        for _ in range(self.max_iter):
+            correction, residual = corrector(u, v)
+
+            # Kept by residual rather than by iteration: the pinned rays wander
+            # along the rim, so the last (u, v) need not be the closest one
+            improved = residual < best - self.tol
+            best_u = be.where(improved, u, best_u)
+            best_v = be.where(improved, v, best_v)
+            best = be.where(improved, residual, best)
+            stalled = be.where(improved, 0.0, stalled + 1.0)
+
+            if be.all(be.logical_or(best < self.tol, stalled >= self.max_stall)):
+                break
+            u = be.clip(u - correction[0, :], 0.0, 1.0)
+            v = be.clip(v - correction[1, :], 0.0, 1.0)
+        return best_u, best_v
 
     def sag(self, x=0, y=0):
         """Computes the surface sag.
@@ -752,21 +835,14 @@ class NurbsGeometry(BaseGeometry):
         Returns:
             The surface sag.
         """
-        shape = x.shape
-        u = be.zeros(be.size(x))
-        v = be.zeros(be.size(x))
-        for _ in range(self.max_iter):
-            correction, residual = self._corr(u, v, -be.ravel(y), -be.ravel(x))
-            u = u - correction[0, :]
-            v = v - correction[1, :]
-            u[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            v[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            u[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-            v[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-
-            if residual < self.tol:
-                break
-        return self.get_value(u, v)[2, :].reshape(shape)
+        # Scalars are as legal an argument as arrays -- a caller sampling one
+        # height at a time is asking the same question of the same surface
+        x, y = be.asarray(x), be.asarray(y)
+        shape = be.shape(x)
+        u, v = self._newton(
+            lambda u, v: self._corr(u, v, -be.ravel(y), -be.ravel(x)), *self._seed(x, y)
+        )
+        return be.reshape(self.get_value(u, v)[2, :], shape)
 
     def distance(self, rays):
         """Finds the propagation distance to the geometry for the given rays.
@@ -786,26 +862,16 @@ class NurbsGeometry(BaseGeometry):
         N1z = be.zeros_like(rays.x)
         mask = be.logical_and(rays.L > rays.M, rays.L > rays.N)
 
-        N1x = be.where(
-            mask,
-            rays.M / be.sqrt(rays.L**2 + rays.M**2),
-            N1x,
-        )
-        N1y = be.where(
-            mask,
-            -rays.L / be.sqrt(rays.L**2 + rays.M**2),
-            N1y,
-        )
-        N1y = be.where(
-            ~mask,
-            rays.N / be.sqrt(rays.N**2 + rays.M**2),
-            N1y,
-        )
-        N1z = be.where(
-            ~mask,
-            -rays.M / be.sqrt(rays.N**2 + rays.M**2),
-            N1z,
-        )
+        # be.where evaluates both sides, so the branch a ray did NOT take still
+        # divides -- and an axial ray makes the unused one 0/0. Floored rather
+        # than warned about: the quotient is discarded either way.
+        def normalized(numerator, first, second):
+            return numerator / be.maximum(be.sqrt(first**2 + second**2), 1e-14)
+
+        N1x = be.where(mask, normalized(rays.M, rays.L, rays.M), N1x)
+        N1y = be.where(mask, normalized(-rays.L, rays.L, rays.M), N1y)
+        N1y = be.where(~mask, normalized(rays.N, rays.N, rays.M), N1y)
+        N1z = be.where(~mask, normalized(-rays.M, rays.N, rays.M), N1z)
 
         N1 = be.column_stack((N1x, N1y, N1z))
 
@@ -818,21 +884,20 @@ class NurbsGeometry(BaseGeometry):
         d1 = -be.sum(N1 * P0, axis=1)
         d2 = -be.sum(N2 * P0, axis=1)
 
-        u = be.zeros_like(rays.x)
-        v = be.zeros_like(u)
+        # Where the ray crosses the vertex plane, which is the seed the sag takes
+        # -- the surface departs from that plane by its sag and nothing more
+        along = be.where(be.abs(rays.N) > 1e-14, rays.N, 1e-14)
+        u, v = self._newton(
+            lambda u, v: self._corr_general(u, v, d1, d2, N1, N2),
+            *self._seed(rays.x - rays.L * rays.z / along,
+                        rays.y - rays.M * rays.z / along),
+        )
 
-        for _ in range(self.max_iter):
-            correction, residual = self._corr_general(u, v, d1, d2, N1, N2)
-            u = u - correction[0, :]
-            v = v - correction[1, :]
-            u[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            v[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            u[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-            v[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-            if residual < self.tol:
-                break
-
-        t = be.sqrt(be.sum((self.get_value(u, v).T - P0) ** 2, axis=1))
+        # Signed ALONG the ray rather than |S - P0|: an intersection behind the ray
+        # is a step backwards, and reporting it as an equal step forward puts the
+        # ray on the wrong side of itself. A plain trace rarely looks back, but an
+        # iterative aimer probes both ways, and no line search recovers from that.
+        t = be.sum((self.get_value(u, v).T - P0) * d, axis=1)
 
         return t
 
@@ -848,18 +913,8 @@ class NurbsGeometry(BaseGeometry):
         """
         x = rays.x
         y = rays.y
-        u = be.zeros_like(x)
-        v = be.zeros_like(u)
-        for _ in range(self.max_iter):
-            correction, residual = self._corr(u, v, -y, -x)
-            u = u - correction[0, :]
-            v = v - correction[1, :]
-            u[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            v[be.logical_or(u < 0.0, v < 0.0)] = be.rand()
-            u[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-            v[be.logical_or(u > 1.0, v > 1.0)] = be.rand()
-            if residual < self.tol:
-                break
+        # The rays are already ON the surface here, so their own x, y is the seed
+        u, v = self._newton(lambda u, v: self._corr(u, v, -y, -x), *self._seed(x, y))
         n = self.get_normals(u, v)
         nx = n[0, :]
         ny = n[1, :]
@@ -890,24 +945,41 @@ class NurbsGeometry(BaseGeometry):
         nurbs_norm_y = self.nurbs_norm_y
         xc = self.x_center
         yc = self.y_center
-        P_size_u = self.P_size_u
-        P_size_v = self.P_size_v
         P_ndim = self.ndim
-
-        x = be.linspace(xc - nurbs_norm_x, xc + nurbs_norm_x, P_size_u)
-        y = be.linspace(yc - nurbs_norm_y, yc + nurbs_norm_y, P_size_v)
-        x, y = be.meshgrid(x, y)
-        r2 = x**2 + y**2
-        z = r2 / (radius * (1 + be.sqrt(1 - (1 + k) * r2 / radius**2)))
-        points = be.stack((x.T, y.T, z.T), axis=0)
-
-        xp = (points.reshape(P_ndim, -1).T).tolist()
 
         u_degree = 3
         v_degree = 3
 
+        # The control net keeps the size it was ASKED for, and the data grid is
+        # its own and denser. Reading both off P_size_u made the least squares
+        # square, and made every RE-fit shrink the net by one -- which matters
+        # because update_normalization refits on each paraxial pass.
+        num_cpts_u = max(self.P_size_u, u_degree + 1)
+        num_cpts_v = max(self.P_size_v, v_degree + 1)
+        size_u = FIT_DATA_FACTOR * num_cpts_u
+        size_v = FIT_DATA_FACTOR * num_cpts_v
+
+        x = be.linspace(xc - nurbs_norm_x, xc + nurbs_norm_x, size_u)
+        y = be.linspace(yc - nurbs_norm_y, yc + nurbs_norm_y, size_v)
+        x, y = be.meshgrid(x, y)
+        r2 = x**2 + y**2
+
+        # A conic has no sag past its own edge, and the corners of a square box
+        # reach there on a fast surface. The root is floored so those corners
+        # carry the edge's own slope on instead of coming back NaN, which the
+        # fit does not accept -- it raises rather than fitting anything at all.
+        radicand = 1 - (1 + k) * r2 / radius**2
+        root = be.sqrt(be.where(radicand > 0.0, radicand, 0.0))
+        z = r2 / (radius * (1 + root))
+
+        points = be.stack((x.T, y.T, z.T), axis=0)
+        xp = (points.reshape(P_ndim, -1).T).tolist()
+
         ctrlpts, u_degree, v_degree, num_cpts_u, num_cpts_v, kv_u, kv_v = (
-            approximate_surface(xp, P_size_u, P_size_v, u_degree, v_degree)
+            approximate_surface(
+                xp, size_u, size_v, u_degree, v_degree,
+                ctrlpts_size_u=num_cpts_u, ctrlpts_size_v=num_cpts_v,
+            )
         )
 
         self.P_size_u = num_cpts_u

--- a/optiland/geometries/nurbs/nurbs_geometry.py
+++ b/optiland/geometries/nurbs/nurbs_geometry.py
@@ -305,11 +305,17 @@ class NurbsGeometry(BaseGeometry):
         # The branches above fill in whatever the caller left out -- weights, a
         # degree, a clamped knot vector -- as locals. Written back here, or the
         # surface keeps the None it was constructed with and evaluates to nothing.
-        for name, value in (("W", weights), ("p", u_degree), ("q", v_degree),
-                            ("U", u_knots), ("V", v_knots)):
+        for name, value in (
+            ("W", weights),
+            ("p", u_degree),
+            ("q", v_degree),
+            ("U", u_knots),
+            ("V", v_knots),
+        ):
             if getattr(self, name) is None and value is not None:
-                setattr(self, name, be.asarray(value)
-                        if name not in ("p", "q") else value)
+                setattr(
+                    self, name, be.asarray(value) if name not in ("p", "q") else value
+                )
 
     def set_radius(self, value: float) -> None:
         """Set the radius of curvature.
@@ -889,8 +895,9 @@ class NurbsGeometry(BaseGeometry):
         along = be.where(be.abs(rays.N) > 1e-14, rays.N, 1e-14)
         u, v = self._newton(
             lambda u, v: self._corr_general(u, v, d1, d2, N1, N2),
-            *self._seed(rays.x - rays.L * rays.z / along,
-                        rays.y - rays.M * rays.z / along),
+            *self._seed(
+                rays.x - rays.L * rays.z / along, rays.y - rays.M * rays.z / along
+            ),
         )
 
         # Signed ALONG the ray rather than |S - P0|: an intersection behind the ray
@@ -977,8 +984,13 @@ class NurbsGeometry(BaseGeometry):
 
         ctrlpts, u_degree, v_degree, num_cpts_u, num_cpts_v, kv_u, kv_v = (
             approximate_surface(
-                xp, size_u, size_v, u_degree, v_degree,
-                ctrlpts_size_u=num_cpts_u, ctrlpts_size_v=num_cpts_v,
+                xp,
+                size_u,
+                size_v,
+                u_degree,
+                v_degree,
+                ctrlpts_size_u=num_cpts_u,
+                ctrlpts_size_v=num_cpts_v,
             )
         )
 

--- a/optiland/surfaces/factories/geometry_configs.py
+++ b/optiland/surfaces/factories/geometry_configs.py
@@ -192,6 +192,9 @@ class NurbsConfig(GeometryConfig):
     n_points_v: int = 5
     tol: float = 1e-6
     max_iter: int = 100
+    # Kept in step with NurbsGeometry's own default -- without this field the
+    # factory cannot pass one, and every surface on a bench took the constructor's
+    max_stall: int = 12
 
 
 @dataclass

--- a/optiland/surfaces/factories/geometry_factory.py
+++ b/optiland/surfaces/factories/geometry_factory.py
@@ -342,6 +342,7 @@ def _create_nurbs(cs: CoordinateSystem, config: NurbsConfig):
         config.n_points_v,
         config.tol,
         config.max_iter,
+        config.max_stall,
     )
 
 

--- a/tests/test_nurbs_geometry_regression.py
+++ b/tests/test_nurbs_geometry_regression.py
@@ -22,7 +22,6 @@ import pytest
 
 from optiland import backend as be
 from optiland.coordinate_system import CoordinateSystem
-from optiland.geometries.nurbs import approximate_surface
 from optiland.geometries.nurbs.nurbs_geometry import NurbsGeometry
 from tests.utils import assert_allclose
 
@@ -52,41 +51,26 @@ def fitted_sphere(count=COUNT, radius=RADIUS, half=HALF):
     return geometry
 
 
-def square_fit_sphere(count=32, radius=RADIUS, half=HALF):
-    """The same sphere through a SQUARE least squares -- count control points from
-    count + 1 data points, which is what _standard_surface did before fix 6.
-
-    Kept deliberately: the net it returns is ill conditioned, its interior control
-    points sitting decades away from the surface they describe, and that is the
-    case the solver has to cope with. A caller may supply control points of its own,
-    and nothing vouches for those.
-    """
-    size = count + 1
-    axis = np.linspace(-half, half, size)
-    x, y = np.meshgrid(axis, axis)
-    z = conic_sag(x, y, radius)
-    points = np.stack((x.T, y.T, z.T), axis=0).reshape(3, -1).T.tolist()
-
-    table, degree_u, degree_v, n_u, n_v, knots_u, knots_v = approximate_surface(
-        points, size, size, 3, 3
-    )
-    net = np.asarray(table).T.reshape((3, n_u, n_v))
-    return NurbsGeometry(
-        CoordinateSystem(),
-        control_points=be.asarray(net),
-        weights=be.asarray(np.ones((n_u, n_v))),
-        u_degree=degree_u,
-        v_degree=degree_v,
-        u_knots=be.asarray(np.asarray(knots_u)),
-        v_knots=be.asarray(np.asarray(knots_v)),
-        nurbs_norm_x=half,
-        nurbs_norm_y=half,
-    )
-
-
 def probe(n=13, reach=12.0):
     """Sample heights across the patch, out to its rim where a lost root shows."""
     x = np.linspace(-reach, reach, n)
+    return (
+        be.asarray(x, dtype=be.float64),
+        be.asarray(np.zeros_like(x), dtype=be.float64),
+        x,
+    )
+
+
+def off_patch(n=7):
+    """Heights well beyond the patch, whose root is not on it at all.
+
+    This is the case that used to hand every ray a fresh random (u, v), and it does
+    so on ANY net -- which is why nothing here needs an ill conditioned one. A net
+    whose control points run to 1e10 does expose the same bugs, but its arithmetic
+    is all cancellation, so whether it converges depends on the BLAS underneath and
+    the test passes on one machine and fails on the next.
+    """
+    x = np.linspace(HALF + 2.0, HALF + 20.0, n)
     return (
         be.asarray(x, dtype=be.float64),
         be.asarray(np.zeros_like(x), dtype=be.float64),
@@ -153,44 +137,58 @@ def test_knot_vectors_are_built_when_omitted(set_test_backend):
 # ── 2. the Newton was seeded at a corner and restarted at random ─────────────
 
 
-def test_solver_lands_on_the_point_it_was_asked_about(set_test_backend):
-    """On an ill conditioned net, which is where the seed used to matter.
+def test_seed_places_a_point_across_the_patch(set_test_backend):
+    """The seed is the fix itself: a point's place across the patch, rather than the
+    corner every ray used to start from however far away its root was.
 
-    Landing error -- how far the point the solver settled on is from the point it
-    was asked about -- is the solver's own error, and says nothing about whether the
-    net is a good sphere. A corner seed leaves it around 1e-1 mm here.
+    A clamped net interpolates its corner control points, so the box those span is
+    the patch's own extent and the fraction across it is exact.
     """
-    geometry = square_fit_sphere()
-    x, y, _ = probe()
+    geometry = fitted_sphere()
+    points = np.array([-HALF, -HALF / 2, 0.0, HALF / 2, HALF])
+    u, v = geometry._seed(
+        be.asarray(points, dtype=be.float64), be.asarray(points, dtype=be.float64)
+    )
+    expected = (points + HALF) / (2 * HALF)
+    assert_allclose(be.to_numpy(u), expected, atol=1e-9)
+    assert_allclose(be.to_numpy(v), expected, atol=1e-9)
+
+
+def test_solver_lands_on_the_point_it_was_asked_about(set_test_backend):
+    """Landing error -- how far the point the solver settled on is from the point it
+    was asked about -- is the solver's own error, and says nothing about whether the
+    net is a good sphere. Probed out to the rim, where a lost root shows.
+    """
+    geometry = fitted_sphere()
+    x, y, _ = probe(reach=HALF)
     u, v = geometry._newton(
         lambda u, v: geometry._corr(u, v, -be.ravel(y), -be.ravel(x)),
         *geometry._seed(x, y),
     )
     surface = be.to_numpy(geometry.get_value(u, v))
-    assert_allclose(surface[0], be.to_numpy(x), atol=1e-6)
-    assert_allclose(surface[1], be.to_numpy(y), atol=1e-6)
+    assert_allclose(surface[0], be.to_numpy(x), atol=1e-9)
+    assert_allclose(surface[1], be.to_numpy(y), atol=1e-9)
 
 
-def test_sag_is_repeatable(set_test_backend):
+def test_sag_is_repeatable_off_the_patch(set_test_backend):
     """The old recovery threw a random (u, v) at every ray that left the patch, so
     the same call on the same surface did not have to give the same answer twice.
+    Four consecutive calls on master return four different sags.
     """
-    geometry = square_fit_sphere()
-    x, y, _ = probe()
+    geometry = fitted_sphere()
+    x, y, _ = off_patch()
     first = be.to_numpy(geometry.sag(x, y))
     for _ in range(4):
         assert_allclose(be.to_numpy(geometry.sag(x, y)), first, atol=0.0, rtol=0.0)
 
 
-def test_sag_is_symmetric_about_a_symmetric_surface(set_test_backend):
+@pytest.mark.parametrize("sampler", [probe, off_patch], ids=["on the patch", "off it"])
+def test_sag_is_symmetric_about_a_symmetric_surface(set_test_backend, sampler):
     """A sphere is even in x, so any left-right difference is the solver rather than
     the surface. This needs no reference to compare against, which is why it is here.
-
-    On the ill conditioned net, where a corner seed settles on a different root
-    depending on which side it approaches from.
     """
-    geometry = square_fit_sphere()
-    x, y, _ = probe()
+    geometry = fitted_sphere()
+    x, y, _ = sampler()
     left = be.to_numpy(geometry.sag(-x, y))
     right = be.to_numpy(geometry.sag(x, y))
     assert_allclose(left, right[::-1], atol=1e-9)

--- a/tests/test_nurbs_geometry_regression.py
+++ b/tests/test_nurbs_geometry_regression.py
@@ -1,0 +1,374 @@
+"""Regression pins for six fixed NurbsGeometry defects.
+
+Each test names the defect it pins and fails if it comes back. They are kept apart
+from test_nurbs_geometry.py, which covers ordinary behaviour, because these exist to
+stop a refactor silently reintroducing something specific:
+
+    1. weights, degrees and knot vectors were computed in __init__ and discarded
+    2. the Newton was seeded at a corner of the patch and restarted at random
+    3. sag() opened on x.shape, so a scalar raised
+    4. distance() returned |S - P0|, unsigned
+    5. a root off the patch iterated to max_iter every time
+    6. _standard_surface fitted n control points to n + 1 data points
+
+A sphere is the reference throughout: its sag is known in closed form, so nothing
+here is checked against the code that produces it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from optiland import backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.geometries.nurbs import approximate_surface
+from optiland.geometries.nurbs.nurbs_geometry import NurbsGeometry
+from tests.utils import assert_allclose
+
+RADIUS = 50.0
+HALF = 13.0
+COUNT = 16
+
+
+def conic_sag(x, y, radius=RADIUS, conic=0.0):
+    """Closed-form sag of the reference conic, in plain numpy."""
+    r2 = np.asarray(x, dtype=float) ** 2 + np.asarray(y, dtype=float) ** 2
+    return r2 / (radius * (1 + np.sqrt(1 - (1 + conic) * r2 / radius**2)))
+
+
+def fitted_sphere(count=COUNT, radius=RADIUS, half=HALF):
+    """The reference sphere as optiland fits it for itself."""
+    geometry = NurbsGeometry(
+        CoordinateSystem(),
+        radius=radius,
+        conic=0.0,
+        nurbs_norm_x=half,
+        nurbs_norm_y=half,
+        n_points_u=count,
+        n_points_v=count,
+    )
+    geometry.fit_surface()
+    return geometry
+
+
+def square_fit_sphere(count=32, radius=RADIUS, half=HALF):
+    """The same sphere through a SQUARE least squares -- count control points from
+    count + 1 data points, which is what _standard_surface did before fix 6.
+
+    Kept deliberately: the net it returns is ill conditioned, its interior control
+    points sitting decades away from the surface they describe, and that is the
+    case the solver has to cope with. A caller may supply control points of its own,
+    and nothing vouches for those.
+    """
+    size = count + 1
+    axis = np.linspace(-half, half, size)
+    x, y = np.meshgrid(axis, axis)
+    z = conic_sag(x, y, radius)
+    points = np.stack((x.T, y.T, z.T), axis=0).reshape(3, -1).T.tolist()
+
+    table, degree_u, degree_v, n_u, n_v, knots_u, knots_v = approximate_surface(
+        points, size, size, 3, 3
+    )
+    net = np.asarray(table).T.reshape((3, n_u, n_v))
+    return NurbsGeometry(
+        CoordinateSystem(),
+        control_points=be.asarray(net),
+        weights=be.asarray(np.ones((n_u, n_v))),
+        u_degree=degree_u,
+        v_degree=degree_v,
+        u_knots=be.asarray(np.asarray(knots_u)),
+        v_knots=be.asarray(np.asarray(knots_v)),
+        nurbs_norm_x=half,
+        nurbs_norm_y=half,
+    )
+
+
+def probe(n=13, reach=12.0):
+    """Sample heights across the patch, out to its rim where a lost root shows."""
+    x = np.linspace(-reach, reach, n)
+    return (
+        be.asarray(x, dtype=be.float64),
+        be.asarray(np.zeros_like(x), dtype=be.float64),
+        x,
+    )
+
+
+class MockRays:
+    """The attributes distance() and surface_normal() read off a ray bundle."""
+
+    def __init__(self, x, y, z, L, M, N):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.L = L
+        self.M = M
+        self.N = N
+
+
+# ── 1. weights, degrees and knots were computed and discarded ────────────────
+
+
+def test_weights_are_supplied_when_omitted(set_test_backend):
+    """A B-spline's weights are all 1, so a caller should not have to say so.
+
+    They used to be worked out into a local and dropped, leaving self.W as None and
+    the first evaluation dying on W.ndim.
+    """
+    fitted = fitted_sphere()
+    geometry = NurbsGeometry(
+        CoordinateSystem(),
+        control_points=fitted.P,
+        u_knots=fitted.U,
+        v_knots=fitted.V,
+        u_degree=fitted.p,
+        v_degree=fitted.q,
+        nurbs_norm_x=HALF,
+        nurbs_norm_y=HALF,
+    )
+    assert geometry.W is not None
+    assert be.shape(geometry.W) == be.shape(fitted.P)[1:]
+
+    # and it evaluates rather than raising
+    x, y, _ = probe(3)
+    assert np.all(np.isfinite(be.to_numpy(geometry.sag(x, y))))
+
+
+def test_knot_vectors_are_built_when_omitted(set_test_backend):
+    """The branch that builds a clamped knot vector for you also kept it to itself."""
+    fitted = fitted_sphere()
+    geometry = NurbsGeometry(
+        CoordinateSystem(),
+        control_points=fitted.P,
+        u_degree=fitted.p,
+        v_degree=fitted.q,
+        nurbs_norm_x=HALF,
+        nurbs_norm_y=HALF,
+    )
+    assert geometry.U is not None
+    assert geometry.V is not None
+    assert geometry.W is not None
+
+
+# ── 2. the Newton was seeded at a corner and restarted at random ─────────────
+
+
+def test_solver_lands_on_the_point_it_was_asked_about(set_test_backend):
+    """On an ill conditioned net, which is where the seed used to matter.
+
+    Landing error -- how far the point the solver settled on is from the point it
+    was asked about -- is the solver's own error, and says nothing about whether the
+    net is a good sphere. A corner seed leaves it around 1e-1 mm here.
+    """
+    geometry = square_fit_sphere()
+    x, y, _ = probe()
+    u, v = geometry._newton(
+        lambda u, v: geometry._corr(u, v, -be.ravel(y), -be.ravel(x)),
+        *geometry._seed(x, y),
+    )
+    surface = be.to_numpy(geometry.get_value(u, v))
+    assert_allclose(surface[0], be.to_numpy(x), atol=1e-6)
+    assert_allclose(surface[1], be.to_numpy(y), atol=1e-6)
+
+
+def test_sag_is_repeatable(set_test_backend):
+    """The old recovery threw a random (u, v) at every ray that left the patch, so
+    the same call on the same surface did not have to give the same answer twice.
+    """
+    geometry = square_fit_sphere()
+    x, y, _ = probe()
+    first = be.to_numpy(geometry.sag(x, y))
+    for _ in range(4):
+        assert_allclose(be.to_numpy(geometry.sag(x, y)), first, atol=0.0, rtol=0.0)
+
+
+def test_sag_is_symmetric_about_a_symmetric_surface(set_test_backend):
+    """A sphere is even in x, so any left-right difference is the solver rather than
+    the surface. This needs no reference to compare against, which is why it is here.
+
+    On the ill conditioned net, where a corner seed settles on a different root
+    depending on which side it approaches from.
+    """
+    geometry = square_fit_sphere()
+    x, y, _ = probe()
+    left = be.to_numpy(geometry.sag(-x, y))
+    right = be.to_numpy(geometry.sag(x, y))
+    assert_allclose(left, right[::-1], atol=1e-9)
+
+
+# ── 3. sag() opened on x.shape, so a scalar raised ───────────────────────────
+
+
+def test_sag_accepts_scalars(set_test_backend):
+    """Every other geometry takes a float. A caller sampling one height at a time --
+    sizing an aperture, say -- had every probe raise AttributeError.
+    """
+    geometry = fitted_sphere()
+    value = float(be.to_numpy(geometry.sag(0.0, 5.0)))
+    assert value == pytest.approx(float(conic_sag(0.0, 5.0)), abs=1e-5)
+
+
+def test_sag_returns_the_callers_own_shape(set_test_backend):
+    """A scalar in, a scalar out; a grid in, that grid out."""
+    geometry = fitted_sphere()
+    assert be.to_numpy(geometry.sag(0.0, 0.0)).shape == ()
+
+    grid = np.linspace(-5.0, 5.0, 6).reshape(2, 3)
+    shaped = geometry.sag(
+        be.asarray(grid, dtype=be.float64),
+        be.asarray(np.zeros_like(grid), dtype=be.float64),
+    )
+    assert be.to_numpy(shaped).shape == (2, 3)
+
+
+# ── 4. distance() returned |S - P0|, unsigned ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("start", "sign"),
+    [(-5.0, 1.0), (5.0, -1.0)],
+    ids=["ray in front of the surface", "ray behind it"],
+)
+def test_distance_is_signed_along_the_ray(set_test_backend, start, sign):
+    """An intersection BEHIND a ray used to come back as an equal step in front of
+    it, putting the ray on the wrong side of itself. A plain trace rarely looks
+    back; an iterative aimer probes both ways and cannot recover from the sign.
+    """
+    geometry = fitted_sphere()
+    ones = be.asarray(np.ones(3), dtype=be.float64)
+    zeros = be.asarray(np.zeros(3), dtype=be.float64)
+    rays = MockRays(
+        x=be.asarray(np.array([0.0, 2.0, -2.0]), dtype=be.float64),
+        y=be.asarray(np.array([0.0, 1.0, 1.0]), dtype=be.float64),
+        z=be.asarray(np.full(3, start), dtype=be.float64),
+        L=zeros,
+        M=zeros,
+        N=ones,
+    )
+    distance = be.to_numpy(geometry.distance(rays))
+    assert np.all(np.sign(distance) == sign)
+
+    # and its magnitude is still the gap to the surface
+    sag = conic_sag(np.array([0.0, 2.0, -2.0]), np.array([0.0, 1.0, 1.0]))
+    assert_allclose(distance, sag - start, atol=1e-4)
+
+
+# ── 5. a root off the patch iterated to max_iter every time ──────────────────
+
+
+def test_a_pinned_ray_stops_once_it_stops_improving(set_test_backend):
+    """Clamping to the patch leaves a ray whose root is outside it pinned on the
+    rim, where the residual never reaches tol. Without an early out that is the
+    full max_iter every time, for an answer reached in a handful.
+    """
+    geometry = fitted_sphere()
+    assert geometry.max_stall < geometry.max_iter
+
+    outside = np.linspace(20.0, 40.0, 9)  # well beyond the +-13 mm patch
+    x = be.asarray(outside, dtype=be.float64)
+    y = be.asarray(np.zeros_like(outside), dtype=be.float64)
+
+    calls = []
+    original = geometry._corr
+
+    def counted(*args, **kwargs):
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    geometry._corr = counted
+    geometry.sag(x, y)
+
+    assert len(calls) <= geometry.max_stall + 1
+    assert len(calls) < geometry.max_iter
+
+
+def test_max_stall_reaches_a_surface_built_through_the_factory(set_test_backend):
+    """NurbsConfig has to carry it, or the factory cannot pass one and every surface
+    on an optic is stuck on the constructor's default whatever the caller asked.
+    """
+    from optiland.surfaces.factories.geometry_factory import GeometryFactory
+
+    geometry = GeometryFactory.create(
+        "nurbs",
+        CoordinateSystem(),
+        radius=RADIUS,
+        conic=0.0,
+        nurbs_norm_x=HALF,
+        nurbs_norm_y=HALF,
+        n_points_u=COUNT,
+        n_points_v=COUNT,
+        max_stall=7,
+    )
+    assert geometry.max_stall == 7
+
+
+# ── 6. the fit asked n control points of n + 1 data points ───────────────────
+
+
+def test_fit_is_idempotent(set_test_backend):
+    """update_normalization refits on every paraxial pass, so a fit that shrinks the
+    net degrades the surface as the optic updates. It used to lose one per fit.
+    """
+    geometry = fitted_sphere()
+    sizes = []
+    for _ in range(4):
+        geometry.fit_surface()
+        sizes.append(tuple(be.shape(geometry.P)[1:]))
+    assert sizes == [(COUNT, COUNT)] * 4
+
+
+def test_the_fitted_net_describes_its_own_surface(set_test_backend):
+    """A square least squares leaves control points decades from the surface: 1e10 mm
+    of control z for a surface a few mm deep, cancelling to something nearly right.
+    """
+    geometry = fitted_sphere(count=32)
+    control_z = be.to_numpy(geometry.P)[2]
+    depth = float(conic_sag(HALF, HALF))
+    assert control_z.min() > -depth
+    assert control_z.max() < 2 * depth
+
+
+def test_the_fit_reproduces_the_sphere(set_test_backend):
+    """Accuracy follows from the conditioning above -- four orders of it."""
+    geometry = fitted_sphere(count=32)
+    x, y, raw = probe(21)
+    error = np.abs(be.to_numpy(geometry.sag(x, y)) - conic_sag(raw, 0.0)).max()
+    assert error < 1e-6
+
+
+def test_a_box_reaching_past_the_conic_edge_still_fits(set_test_backend):
+    """The sag has no real root past the conic's own edge, and the corners of a
+    square box reach there whenever 2.half^2 > R^2. A bare square root gives NaN,
+    which the fitter rejects outright rather than fitting anything at all.
+    """
+    geometry = fitted_sphere(count=COUNT, radius=15.0, half=13.0)
+    assert not np.any(np.isnan(be.to_numpy(geometry.P)))
+
+    # and it is still the sphere well inside the edge
+    x, y, raw = probe(9, reach=10.0)
+    error = np.abs(
+        be.to_numpy(geometry.sag(x, y)) - conic_sag(raw, 0.0, radius=15.0)
+    ).max()
+    assert error < 1e-2
+
+
+@pytest.mark.parametrize("count", [4, 8, 16])
+def test_n_points_is_the_control_count_for_either_branch(set_test_backend, count):
+    """It is documented as the grid size of control points, but was read as a DATA
+    count by the conic branch and a control count by the plane one, so the same
+    n_points_u gave nets a size apart depending on which surface it was.
+    """
+    conic = fitted_sphere(count=count)
+
+    plane = NurbsGeometry(
+        CoordinateSystem(),
+        radius=be.inf,
+        nurbs_norm_x=HALF,
+        nurbs_norm_y=HALF,
+        n_points_u=count,
+        n_points_v=count,
+    )
+    plane.fit_surface()
+
+    assert tuple(be.shape(conic.P)[1:]) == (count, count)
+    assert tuple(be.shape(plane.P)[1:]) == (count, count)


### PR DESCRIPTION
(see: https://github.com/optiland/optiland/issues/777)

(1) A NURBS surface built without weights cannot be evaluated at all. 
(2) The sag/intersection solver is seeded at a corner of the patch and restarts at random. 
(3) sag() cannot be called with a scalar.
(4) distance() returns an unsigned distance.
(5) A ray whose root lies off the patch iterates to max_iter every time. 
(6) The auto-fit does not produce the surface it was asked to fit.

To see the problems, run nurbs_sphere.py (see issue 777). It fits a sphere — the one surface whose answer is known in closed form — as a NURBS, and prints for each bug what the old code gave beside the new.

-------------------------------------------------------------------- 
(1) A NURBS surface built without weights cannot be evaluated at all

Description of the BUG:

__init__ classifies the surface (Bezier / R-Bezier / B-Spline / NURBS) and, in each branch, computes whatever the caller left out — weights, a degree, a clamped knot vector — into local variables that are then discarded. self.W, self.p, self.q, self.U, self.V keep the None they were assigned at the top of the constructor.

Passing control points and knots but no weights — the ordinary way to state a B-spline, whose weights are all 1 — leaves self.W = None, and the first evaluation dies inside compute_nurbs_coordinates on W.ndim:

AttributeError: 'NoneType' object has no attribute 'ndim' Every branch except "everything supplied" and the auto-fit path is affected, so a Bezier or R-Bezier surface cannot be built at all, and a B-spline cannot be traced.

Description of FIX:

nurbs_geometry.py:
305-312 — write the locals back after the branch chain, for any field the caller
          did not supply. Nothing else in the constructor changes.

-------------------------------------------------------------------- 
(2) The solver is seeded at a corner of the patch and restarts at random

Description of the BUG:

sag, distance and surface_normal each started Newton at u = v = 0 — a corner of the patch, not a point near the answer — and recovered from a step outside [0,1] by assigning one be.rand() to every ray that had left, judged against a single bundle-wide residual.

On a well-conditioned net this converges anyway. On an ill-conditioned one the answer is a lottery: the same call, on the same surface, with the same arguments, does not have to give the same number twice. Measured on a 32×32 net over 20 draws of the RNG:

sag error vs the sphere	worst landing error
old, 20 draws	2.96e-02 to 1.39e+01 mm	8.58e-01 mm
new	deterministic	9.65e-12 mm
Landing error is the solver's own error — how far the point it settled on is from the point it was asked about. It isolates the solver from the quality of the net, which matters here because a bad net and a bad solve otherwise look alike.

Description of FIX:

nurbs_geometry.py:
779 — new _seed: place each point across the patch by its position in the box
      spanned by the FOUR CORNER control points, which a clamped spline
      interpolates. Measured off the corners rather than the whole net, because a
      least squares run near interpolation leaves interior control points decades
      from the surface they describe, and a box drawn round those seeds every
      point at one edge.
799 — new _newton: one shared iteration that CLAMPS to [0,1] instead of
      restarting at random, and keeps the best (u, v) by residual rather than the
      last one visited -- pinned rays wander along the rim, so the last is not
      the closest.
730, 775 — _corr and _corr_general return one residual PER RAY rather than a
      bundle-wide max, so _newton can tell a ray still closing on its root from
      one the clamp has pinned.
842, 890, 917 — the three call sites use them. distance seeds from where the ray
      crosses the vertex plane; surface_normal seeds from the ray's own x, y,
      its rays being already on the surface.

-------------------------------------------------------------------- 
(3) sag() cannot be called with a scalar

Description of the BUG:

sag opened on shape = x.shape, so any scalar argument raised:

AttributeError: 'float' object has no attribute 'shape' Every other geometry accepts a float. A caller that samples one height at a time — sizing an aperture, say — therefore has every probe fail; and where that failure is caught rather than raised, the surface is silently clipped to zero radius and blocks the whole beam.

Description of FIX:

nurbs_geometry.py:
840 — be.asarray both arguments and take the shape from that, so scalars and
      arrays are both legal and the result returns in the caller's own shape.

-------------------------------------------------------------------- 
(4) distance() returns an unsigned distance

Description of the BUG:

It ended on t = be.sqrt(be.sum((self.get_value(u, v).T - P0) ** 2, axis=1))   # |S - P0|
where every analytic geometry returns a distance signed along the ray. An intersection behind a ray was reported as an equal distance in front of it, so the ray was propagated to the wrong side of itself.

A plain trace marches forward and hardly ever asks about a surface behind it, so the sign never shows. An iterative aimer probes both ways by construction — 38.6% of its queries in one case had the intersection behind the ray — and its backtracking line search then halves the step for ever, hunting a decrease the sign error prevents:

                 rays kept	RMS sag
unsigned	414 / 972	5.36 mm	        diverging
signed	        972 / 972	0.048 mm	converging
The give-away, once looked for, was the query count: 159 809 calls into distance() for one fit, against 1 746 for the same fit on a conic. The aimer was not quietly losing rays, it was thrashing.

Description of FIX:

nurbs_geometry.py:
900 — dot with the ray direction instead of taking the norm:
      t = be.sum((S - P0) * d, axis=1)
868 — while here: the plane pair was built with be.where(mask, M/sqrt(L²+M²), …),
      and be.where evaluates BOTH sides, so the branch a ray did not take still
      divides -- 0/0 for an axial ray. The quotient was always discarded, so this
      was noise rather than a wrong answer; floored so it stops emitting
      RuntimeWarning: invalid value encountered in divide on every trace.

-------------------------------------------------------------------- 
(5) A ray whose root lies off the patch iterates to max_iter every time

Description of the BUG:

With (2) clamping to [0,1], a ray whose root lies outside the patch is pinned on the rim and its residual never reaches tol, so the loop always ran the full max_iter — 100 iterations, for a correct answer, at 25× the necessary cost.

bundle	before	after
rays on the patch	100	1
rays off the patch	100	13

Description of FIX:

nurbs_geometry.py:
799-819 — _newton tracks per-ray improvement and stops once every ray has either
      converged or gone max_stall iterations without improving.
126, 150 — new max_stall parameter, default 12.

geometry_configs.py:
197 — NurbsConfig gains max_stall. Without this field the factory could not pass
      one, so every surface built on a bench was stuck on the constructor's.

geometry_factory.py:
345 — _create_nurbs passes it through.
On the default: with (6) fixed, every net this module fits lands at max_stall = 2 — measured over 24 of them, n_points 24 to 48 and radii 25 to 200. 12 is headroom for control points a caller supplies, which the module cannot vouch for; an ill-conditioned net does not converge steadily, its residual falling in fits, and three quiet iterations are then not evidence a ray is done. The headroom is close to free: a ray on the patch takes one iteration whatever this says, only off-patch rays pay, and a real trace showed no measurable wall-clock difference. Drop it to 3 if you would rather not carry the margin.

-------------------------------------------------------------------- 
(6) The auto-fit does not produce the surface it was asked to fit

Description of the BUG:

_standard_surface samples the conic on a grid and least-squares a control net through it. Three faults in six lines.

(a) The least squares is square. It read P_size_u as the data count and let approximate_surface default the control count to size_u - 1 — n control points from n+1 data points, which is interpolation in disguise. The net that comes back is wildly ill-conditioned:

32×32 net	control z span	max sag error to r = 12
old	−8.25e+10 to 2.25e+09 mm	2.96e-02 mm
new	−0.004 to 3.503 mm	1.03e-08 mm
— for a surface 3.5 mm deep. Four orders of accuracy, and a net that describes its own surface rather than a cancellation of enormous numbers.

(b) A re-fit shrinks the net. self.P_size_u was overwritten with the control count it had just derived, one fewer than it went in with. update_normalization calls fit_surface() on every paraxial pass in auto mode, so the net degrades silently as the optic updates:

fit 1 -> (16, 16)   fit 2 -> (15, 15)   fit 3 -> (14, 14)   fit 4 -> (13, 13)

(c) A fast surface cannot be fitted at all. z = r2 / (radius * (1 + sqrt(1 - (1+k) r2/radius²))) has no real root past the conic's own edge, and the corners of a square box reach there whenever 2·half² > R². The bare square root gives NaN, which the fitter rejects outright:

R = 15 over ±13 (corner r²/R² = 1.50)
  -> ValueError: array must not contain infs or NaNs

Description of FIX:

nurbs_geometry.py:
32  — new FIT_DATA_FACTOR = 2: data points per control point per axis. Two
      settles the conditioning; more buys nothing measurable.
953-982 — the control net keeps the size it was ASKED for and the data grid is
      its own and denser, with ctrlpts_size_u / ctrlpts_size_v passed
      explicitly. Fixes (a), and makes the fit idempotent, which fixes (b). The
      control count is also clamped to degree + 1, which stops n_points_u = 3
      raising ZeroDivisionError and n_points_u = 2 returning a degenerate 2x2.
971-973 — the root is floored at zero, so points past the conic's edge carry the
      rim's own slope on instead of coming back NaN. Fixes (c).
163 — P_size_u is now n_points_u, not n_points_u + 1. See below. Behaviour change worth calling out. n_points_u is documented as "the grid size of control points", but P_size_u was set to n_points_u + 1 and then read as a data count by _standard_surface and as a control count by _plane_surface. The same n_points_u = 16 therefore produced a 16×16 net from one branch and 17×17 from the other. Both now return exactly what the docstring promises, so anyone relying on the old off-by-one gets a net one smaller from the plane branch.

-------------------------------------------------------------------- 
-------------------------------------------------------------------- 
One limitation that remains, deliberately
A fit box wider than the surface it covers is fitted to a clamped extension, because past the conic's edge there is no sag to fit:

R = 50.0 over ±13.0  (corner r²/R² = 0.14):  sag error 2.71e-07 mm
R = 15.0 over ±13.0  (corner r²/R² = 1.50):  sag error 2.23e-02 mm
R =  8.0 over ±10.0  (corner r²/R² = 3.12):  sag error 1.94e-01 mm

This is inherent rather than a defect — but it beats raising, and it is worth knowing that nurbs_norm_x/y set much wider than the conic costs accuracy across the whole patch, not just at the corners.