### PR TITLE
Finite-conjugate paraxial chief ray misses the stop

### DIFF
--- a/optiland/fields/field_types/object_height.py
+++ b/optiland/fields/field_types/object_height.py
@@ -68,7 +68,7 @@ class ObjectHeightField(BaseFieldDefinition):
         self._reject_non_z_entry(optic)
         obj = optic.object_surface
         field_y = optic.fields.max_field * Hy
-        y = -field_y
+        y = field_y
         z = obj.geometry.cs.z
         y0 = be.ones_like(y1) * y
         z0 = be.ones_like(y1) * z
@@ -91,8 +91,10 @@ class ObjectHeightField(BaseFieldDefinition):
         Returns:
             float: The scaling factor.
         """
+        # Negated because chief_ray applies the reverse-to-forward flip to the
+        # height it scales, and Hy=+1 must land on object height +max_y_field.
         max_field_height = optic.fields.max_y_field
-        return max_field_height / y_obj_unit
+        return -max_field_height / y_obj_unit
 
     def _validate_object_infinite(self, optic):
         """Check if the object surface is at infinity.

--- a/optiland/fields/field_types/paraxial_image_height.py
+++ b/optiland/fields/field_types/paraxial_image_height.py
@@ -56,8 +56,10 @@ class ParaxialImageHeightField(BaseFieldDefinition):
             y0 = Py * EPD / 2 * vy + y
             z0 = be.full_like(Px, z)
         else:
-            y_obj = y_obj_unit * (y_img_target / y_img_unit)
-            x_obj = y_obj_unit * (x_img_target / y_img_unit)
+            # The two unit traces leave the stop with u=+1 in opposite directions,
+            # so the reverse ray's object point pairs with image height -y_img_unit.
+            y_obj = -y_obj_unit * (y_img_target / y_img_unit)
+            x_obj = -y_obj_unit * (x_img_target / y_img_unit)
             x_local = be.atleast_1d(be.array(x_obj))
             y_local = be.atleast_1d(be.array(y_obj))
             z_local = optic.object_surface.geometry.sag(x_local, y_local)
@@ -100,7 +102,7 @@ class ParaxialImageHeightField(BaseFieldDefinition):
             y0 = y1 + y
             z0 = be.ones_like(y1) * z
         else:
-            y_obj = y_obj_unit * (y_img_target / y_img_unit)
+            y_obj = -y_obj_unit * (y_img_target / y_img_unit)
             y = y_obj
             z = optic.object_surface.geometry.cs.z
             y0 = be.ones_like(y1) * y
@@ -163,4 +165,9 @@ class ParaxialImageHeightField(BaseFieldDefinition):
             y, u = optic.paraxial.trace_generic(
                 y=0, u=1, z=z_start, wavelength=wavelength, reverse=True, skip=skip
             )
-            return y[-1], u[-1]
+            y_obj, u_obj = y[-1], u[-1]
+            if not optic.object_surface.is_infinite:
+                # The reverse trace stops refracting at surface 1 -- the object
+                # surface only records it -- so carry the height back to the object.
+                y_obj = y_obj + (pos[1] - optic.object_surface.geometry.cs.z) * u_obj
+            return y_obj, u_obj

--- a/optiland/fields/field_types/real_image_height.py
+++ b/optiland/fields/field_types/real_image_height.py
@@ -195,7 +195,11 @@ class RealImageHeightField(BaseFieldDefinition):
                 "solve."
             )
 
+        # A reverse-frame object height pairs with image height -y_img_unit, so the
+        # finite seed needs the sign conversion the infinite slope scale does not.
         scale = obj_unit / y_img_unit
+        if not optic.object_surface.is_infinite:
+            scale = -scale
         return be.atleast_1d(target_x * scale), be.atleast_1d(target_y * scale)
 
     # ------------------------------------------------------------------

--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 
 import optiland.backend as be
 from optiland._deprecation import deprecated
-from optiland.fields import ObjectHeightField, ParaxialImageHeightField
 from optiland.raytrace.paraxial_ray_tracer import ParaxialRayTracer
 
 if TYPE_CHECKING:
@@ -564,9 +563,9 @@ class Paraxial:
         u_obj_unit = u_rev_unit[-1]
 
         field_definition = self.optic.fields.field_definition
-        if not self.optic.object_surface.is_infinite and isinstance(
-            field_definition, ObjectHeightField
-        ):
+        if not self.optic.object_surface.is_infinite:
+            # The reverse trace stops refracting at surface 1 -- the object
+            # surface only records it -- so carry the height back to the object.
             first_surface_z = pos[1, 0]
             object_z = self.optic.object_surface.geometry.cs.z
             y_obj_unit = y_obj_unit + (first_surface_z - object_z) * u_obj_unit
@@ -583,11 +582,9 @@ class Paraxial:
             self.optic, y_obj_unit, u_obj_unit, y_img_unit
         )
 
-        # Determine initial ray parameters for final forward trace
-        if isinstance(self.optic.fields.field_definition, ParaxialImageHeightField):
-            y_obj_start = y_obj_unit * scaling_factor
-        else:
-            y_obj_start = -(y_obj_unit * scaling_factor)
+        # Determine initial ray parameters for final forward trace. A reverse-frame
+        # (y, u) is (-y, u) forward, up to the overall sign, which is free.
+        y_obj_start = -(y_obj_unit * scaling_factor)
         u_obj_start = u_obj_unit * scaling_factor
 
         if self.optic.object_surface.is_infinite:

--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -292,7 +292,8 @@ class TestFiniteConjugateAberrations:
 
         assert not be.any(~be.isfinite(y))
         assert not be.any(~be.isfinite(u))
-        assert_allclose(y[0], -5.0)
+        # Hy=+1 is the +max_y_field object point, so the chief ray starts at +5.
+        assert_allclose(y[0], 5.0)
         assert_allclose(y[1], 0.0, atol=1e-12)
 
     def test_third_order_coefficients_are_finite(

--- a/tests/test_field_types.py
+++ b/tests/test_field_types.py
@@ -44,7 +44,11 @@ def test_paraxial_image_height_finite_object(set_test_backend):
 
     # verify that the ray's y-coordinate at the image plane matches the
     # expected paraxial image height
-    assert_allclose(y[-1], 9.67243803, rtol=1e-5)
+    assert_allclose(y[-1], 10, rtol=1e-5)
+
+    # the chief ray is the ray through the centre of the stop, so it must cross
+    # the axis there; the intercept above passes even when it misses by units
+    assert_allclose(y[optic.surfaces.stop_index], 0.0, atol=1e-9)
 
 
 def test_field_definition_to_dict(set_test_backend):


### PR DESCRIPTION
(see: https://github.com/optiland/optiland/issues/779 )

(1) For a finite conjugate the paraxial chief ray is started at the object plane with the
height the reverse trace had at surface 1, so it does not pass through the stop — for
every field definition except object height.
(2) The image-height field definitions repeat that error in their own unit trace, so the
object point they hand both real and paraxial rays is at the wrong height.
(3) The image-height field definitions place that object point on the wrong side of the axis.
(4) The object-height field definition places its paraxial object point, and its chief ray,
on the opposite side of the axis from its own real rays.
(5) The real-image-height solve is seeded on the wrong side of the axis, and where the stop
is on surface 1 it cannot be seeded at all and raises.

Current master already carries a partial fix for (1), applied only when the field
definition is `ObjectHeightField` (#685). That is why the object-height rows below pass
on master in section (1) and fail everywhere else.

## Files touched

```
paraxial.py
  21-23    drop an import the two changes below leave unused              (1,3)
  566-571  carry the reverse trace back to the object plane for every
           finite conjugate, not only for object height                   (1)
  585-588  drop the image-height sign special case                        (3)

fields/field_types/paraxial_image_height.py
  168-173  carry the unit reverse trace back to the object plane          (2)
  59-62    negate the object point in get_ray_origins                     (3)
  105      negate it in get_paraxial_object_position                      (3)

fields/field_types/object_height.py
  71       place the paraxial object point at +field, not -field          (4)
  94-97    negate the chief-ray scale so Hy=+1 is +max_y_field            (4)

fields/field_types/real_image_height.py
  198-202  negate the paraxial seed scale for a finite object             (5)
```

## Reproducing

```
python finite_conjugate_chief_ray.py    ->  this branch      41/41 checks pass
                                        ->  current master    9/40, each bug named
```

The totals differ by one because on master section (8) raises on one system instead of
returning a number, which is itself the symptom described in (5).

The script carries two finite-conjugate systems in constant-index media, so every
reference number is exact and no dispersion data is needed:

- **SINGLE** — one refracting surface with the stop on it. Its conjugates and
  magnification are closed form (`s' = 187.5`, `m = -0.25`) and its chief ray runs
  through the vertex, so the expected numbers are arithmetic. It is also the case a stop
  on surface 1 exercises: tracing back from the stop leaves no surface to refract at.
- **TRIPLET** — three refracting surfaces with the stop on an interior one, so the
  reverse trace really does refract on the way back. Its reference chief ray comes from
  `march()`, twenty lines of first-principles paraxial optics in the script itself.

Section (4) of the script checks `march()` against the closed form before anything is
judged against it.

---

## (1) The chief ray does not pass through the stop

**Description of the bug.** A chief ray is the ray that crosses the axis at the centre of
the stop; that is what makes it the chief ray. For an object at a finite distance it does
not. Every quantity derived from it is then wrong in a way that grows with field: the
third-order sums that take their field dependence from it, the field-dependent part of any
aberration expansion built on it, and any caller asking where the chief ray strikes a
surface.

The cause is in `chief_ray`. A unit ray is traced in reverse from the stop back towards the
object to find the object-space chief ray, and the last value that trace produces is taken
as the height at the object plane. It is not. The reverse trace stops refracting at surface
1, because the object surface only records the ray rather than propagating to it, so the
height returned is the height at **surface 1** — and it is then used as though it were the
height at the object plane, a whole object distance away.

Where the stop is on surface 1 the reverse trace has no surface left to refract at and
returns its own starting height of zero, which is the degenerate form of the same error.

Chief-ray height at the stop, which must be 0:

| system | field definition | master | this branch |
|---|---|---|---|
| SINGLE (stop on surface 1) | object_height | 3.6e-15 | -3.6e-15 |
| | angle | **20** | 0 |
| | paraxial_image_height | **20** | 3.6e-15 |
| TRIPLET (stop on surface 2) | object_height | 1.4e-15 | -1.4e-15 |
| | angle | **11.3089** | 1.4e-15 |
| | paraxial_image_height | **11.6245** | -2.8e-16 |

The cause in one number — the object-space height of the unit reverse trace, which the
script prints on every row of that section:

| system | master | this branch |
|---|---|---|
| SINGLE | 0 | 50 |
| TRIPLET | 0.8 | 58.1333 |

**Description of Fix.**

```
paraxial.py:566-571 — apply the propagation from surface 1 back to the object plane
                      whenever the object is finite. The step was already present but
                      guarded by isinstance(field_definition, ObjectHeightField); the
                      guard is geometry, not field parameterisation, so it is dropped.
paraxial.py:21-23   — the guard was the only use of the ObjectHeightField import, and
                      the change in (3) removes the only use of the other one.
```

---

## (2) The image-height definitions take the same height from the same place

**Description of the bug.** `ParaxialImageHeightField` does not call `chief_ray`. It runs
its own unit reverse trace in `_trace_unit_chief_ray(plane="object")` and has the identical
defect: the value returned is the height at surface 1, and both callers use it as an object
plane height. `get_ray_origins` puts real rays there and `get_paraxial_object_position` puts
paraxial ones there, so a caller asking for a field by image height gets rays from the wrong
object point entirely. `RealImageHeightField` reaches the same helper for its solver seed.

This is why "do the real and paraxial origins agree?" is not on its own a test for it: both
callers read the same wrong number, so they agree with each other while both being wrong.
The script compares each to the reference as well as to the other.

Object point for the full field, real and paraxial (identical in each cell):

| system | requested image height | master | this branch | reference |
|---|---|---|---|---|
| SINGLE | +5 | **0** | -20 | -20 |
| TRIPLET | +1.56899 | **0.165138** | -12 | -12 |

**Description of Fix.**

```
fields/field_types/paraxial_image_height.py:168-173 — in _trace_unit_chief_ray, carry the
                      reverse trace's height from surface 1 back to the object plane when
                      the object is finite. Fixed in the helper rather than at either call
                      site, so get_ray_origins, get_paraxial_object_position and the
                      RealImageHeightField seed are all corrected at once. The infinite
                      branch of every caller uses only the slope, so it cannot be affected.
```

---

## (3) The image-height definitions place that point on the wrong side of the axis

**Description of the bug.** Independent of the height being wrong, the object point is
mirrored. The two unit traces both leave the stop with `u = +1` but in opposite directions,
so the object point recovered from the reverse trace belongs to a chief ray that continues
forward through the stop with slope `-1`, landing at image height `-y_img_unit` rather than
`+y_img_unit`. The scaling omits that minus, so asking for image height `+q` produces the
object point that forms `-q`.

`chief_ray` carried a compensating special case for the same reason: it negated the scaled
height for every field definition **except** `ParaxialImageHeightField`. Once (1) and (2)
supply the correct height, that exception is what is left over, and it made `chief_ray` and
the ray-trace path disagree in sign for the same optic.

Isolated by correcting the height of (2) but not the sign, so only this defect is left:

| system | requested image height | height fix only | both fixes | reference |
|---|---|---|---|---|
| SINGLE | +5 | **+20** | -20 | -20 |
| TRIPLET | +1.56899 | **+12** | -12 | -12 |

The magnitude is right and the side is wrong.

**Description of Fix.**

```
fields/field_types/paraxial_image_height.py:59-62 — negate the object point in
                      get_ray_origins, in x as well as y.
fields/field_types/paraxial_image_height.py:105   — the same negation in
                      get_paraxial_object_position.
paraxial.py:585-588 — drop the ParaxialImageHeightField branch in chief_ray. With the
                      height correct, -(y_obj_unit * scaling_factor) is right for every
                      field definition. The branch only ever altered y_obj_start, which
                      an infinite conjugate does not use, so that path is untouched.
```

---

## (4) The object-height definition contradicts its own real rays

**Description of the bug.** `ObjectHeightField` defines a field as a height on the object
surface, and `get_ray_origins` implements exactly that: `Hy = +1` places real rays at
`+max_field`. Its two paraxial routes disagree with it. `get_paraxial_object_position`
returns `-field_y`, and `scale_chief_ray_for_field` combines with the flip in `chief_ray` to
put the chief ray at `-max_y_field`. So paraxial rays and real rays drawn for the same field
sit on opposite sides of the axis.

The closed-form case settles which is right. A single refracting surface with `m = -0.25`
images an object at `+20` to `-5`: the image is inverted, so a positive object height must
give a negative image height. `-20 → +5` is the opposite field point, which is `Hy = -1`.

| quantity | master | this branch | closed form |
|---|---|---|---|
| SINGLE object point, real | +20 | +20 | +20 |
| SINGLE object point, paraxial | **-20** | +20 | +20 |
| SINGLE chief-ray image height | **+5** | -5 | -5 |
| TRIPLET object point, paraxial | **-12** | +12 | +12 |
| TRIPLET chief-ray image height | **+1.56899** | -1.56899 | -1.56899 |

**Description of Fix.**

```
fields/field_types/object_height.py:71    — get_paraxial_object_position returns +field_y,
                      matching what get_ray_origins already does for real rays.
fields/field_types/object_height.py:94-97 — scale_chief_ray_for_field returns
                      -max_y_field / y_obj_unit. chief_ray applies the reverse-to-forward
                      flip to the height it scales, so without the negation here the chief
                      ray lands on -max_y_field. Fixing only line 71 would leave chief_ray
                      as the one route out of three still on the far side.
```

---

## (5) The real-image-height solve is seeded on the wrong side, or not at all

**Description of the bug.** `RealImageHeightField` solves for the object point that puts a
*real* chief ray on a requested image height, and seeds that solve from the paraxial
answer. `_paraxial_scales` reads the same corrected `_trace_unit_chief_ray` as (2), so the
seed now has the right magnitude — but `_initial_field_parameters` forms
`scale = obj_unit / y_img_unit` without the reverse-to-forward conversion of (3), so for a
finite object the seed is mirrored. The infinite-object branch supplies a slope rather than
a height and is already in the forward frame, so it must not be negated.

The solve converges from the wrong-side seed, which is why nothing downstream shows it:
the intercept it finally lands on is correct either way. Only the seed itself is evidence,
which is what section (8) of the script asserts.

Where the stop is on surface 1 the defect in (2) leaves the object-space scale at exactly
zero, and the seed is not merely mirrored — it trips the singular-scale guard and the field
definition raises, so a finite conjugate with a first-surface stop cannot be used at all:

| system | requested image height | master | this branch | reference |
|---|---|---|---|---|
| SINGLE (stop on surface 1) | +5 | **ValueError, scale 0.000e+00** | -20 | -20 |
| TRIPLET (stop on surface 2) | +1.56899 | **+0.165138** | -12 | -12 |

The intercept the solve reaches, which moves hardly at all and is the reason the seed has
to be asserted directly:

| system | master | this branch |
|---|---|---|
| TRIPLET | 1.5689939 | 1.5689939 |

**Description of Fix.**

```
fields/field_types/real_image_height.py:198-202 — negate the seed scale when the object is
                      finite, matching the conversion (3) applies to the paraxial field
                      definition this one seeds from. The infinite branch scales a slope
                      already in the forward frame and is left alone.
```

---

## Behaviour changes

**Aberration terms odd in field change sign for object-height fields at a finite
conjugate.** The chief ray now runs on the other side of the axis, so the third-order sums
that are linear and cubic in field — coma and distortion — change sign. Magnitudes are
unchanged, and the terms even in field are unchanged. A caller that had compensated for the
old sign will see it twice.

**Image-height fields at a finite conjugate move the object point.** It changes both height
and side; see the table in (2). Rays traced for such a field were previously starting from a
different object point than the one named.

**Two existing expectations encode the old values and are updated with this change.** Both
are the first-surface-stop case, and both are reproduced as section (9) of the script:

| expectation | asserted | becomes |
|---|---|---|
| `test_chief_ray_is_finite`, `y[0]` | `-5.0` | `+5.0` |
| `test_paraxial_image_height_finite_object`, `y[-1]` | `9.67243803` | `10.0` |

The first is the sign of (4): the field is an object height of `5`, so `Hy = +1` is the
`+5` object point. The test's own subject is unaffected — the chief ray is finite either
way, and its `y[1] == 0` assertion holds before and after.

The second is (1) and (2) together: the field asks for a paraxial image height of `10` and
now receives it. That case also gains an assertion, because the one it had could not see
what was wrong with it — its chief-ray height at the stop is `4.840` as it stands and
`8.9e-16` corrected, so it passed while its chief ray missed the stop by 4.84 units:

```
tests/test_aberrations.py:296  — assert_allclose(y[0], 5.0), was -5.0
tests/test_field_types.py:47   — assert_allclose(y[-1], 10, rtol=1e-5), was 9.67243803
tests/test_field_types.py:51   — new: assert_allclose(y[optic.surfaces.stop_index], 0.0,
                                 atol=1e-9), the stop crossing the intercept alone missed
```

These are the only expectations that move. Over every test naming the changed API surface,
on both backends, reverting this change and leaving all other local state untouched turns
exactly these four results — two cases across two backends — and no others.

**A pre-existing defect in the angle definition becomes visible.** For a finite object,
`AngleField.get_paraxial_object_position` does not return a point on the object plane, and
it is not corrected here. On master this was masked, because `chief_ray` was wrong in a way
that happened to match it; with `chief_ray` corrected the two now disagree openly:

| system | get_paraxial_object_position | chief_ray object y | master: both |
|---|---|---|---|
| SINGLE | 0 | -20 | 0 and -0 |
| TRIPLET | -0.165138 | -12 | -0.165138 and -0.165138 |

**Infinite conjugates are untouched.** Every change is inside a `not is_infinite` branch or
on a quantity an infinite conjugate does not read. Measured identical across the two trees,
to every digit:

| system | field definition | master | this branch |
|---|---|---|---|
| SINGLE | angle | 4.3650962 | 4.3650962 |
| SINGLE | paraxial_image_height | 3 | 3 |
| TRIPLET | angle | 1.851833 | 1.851833 |
| TRIPLET | paraxial_image_height | 3 | 3 |

## What is not fixed

`AngleField.get_paraxial_object_position` for a finite object, described above. It is a
distinct defect in a file this change does not touch, and the numbers above are the
measurement of it rather than a fix for it.

Field definitions are checked here only at the two conjugates the script builds, in
constant-index media, on rotationally symmetric systems with the stop on a real surface.
Tilted and decentred stops, folded paths and non-symmetric fields are outside what these
measurements cover.
