### PR TITLE
Fix typos in the documentation

### DIFF
--- a/optiland/database/data-nk/main/Sn/Golovashkin-4.2K.yml
+++ b/optiland/database/data-nk/main/Sn/Golovashkin-4.2K.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperaturs, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
+REFERENCES: "A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperatures, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
 COMMENTS: "4.2 K (-268.95 °C)"
 DATA:
   - type: tabulated nk

--- a/optiland/database/data-nk/main/Sn/Golovashkin-78K.yml
+++ b/optiland/database/data-nk/main/Sn/Golovashkin-78K.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "1) A. I. Golovashkin and G. P. Motulevich. Optical and electrical properties of tin, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/19/2/p310?a=list\"><i>Sov. Phys. JETP</i> <b>19</b>, 310-317 (1964)</a><br>2) A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperaturs, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
+REFERENCES: "1) A. I. Golovashkin and G. P. Motulevich. Optical and electrical properties of tin, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/19/2/p310?a=list\"><i>Sov. Phys. JETP</i> <b>19</b>, 310-317 (1964)</a><br>2) A. I. Golovashkin and G. P. Motulevich. Optical properties of tin at helium temperatures, <a href=\"http://jetp.ac.ru/cgi-bin/e/index/e/20/1/p44?a=list\"><i>Sov. Phys. JETP</i> <b>20</b>, 44-49 (1965)</a>"
 COMMENTS: "78 K (-195.15 °C)"
 DATA:
   - type: tabulated nk

--- a/optiland/database/data-nk/organic/C5H12 - pentane/Anderson.yml
+++ b/optiland/database/data-nk/organic/C5H12 - pentane/Anderson.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "M. R. Anderson. <i>Determination of infrared optical constatns for single components hydrocarbon fuels</i>, Master Thesis (2009) [<a href=\"https://refractiveindex.info/download/data/2000/Anderson - thesis - Determination of infrared optical constants for single component hydrocarbon fuels.pdf\">pdf</a>]"
+REFERENCES: "M. R. Anderson. <i>Determination of infrared optical constants for single components hydrocarbon fuels</i>, Master Thesis (2009) [<a href=\"https://refractiveindex.info/download/data/2000/Anderson - thesis - Determination of infrared optical constants for single component hydrocarbon fuels.pdf\">pdf</a>]"
 COMMENTS: "Iso-pentane"
 DATA:
   - type: tabulated nk

--- a/optiland/database/data-nk/organic/C8H18 - octane/Anderson.yml
+++ b/optiland/database/data-nk/organic/C8H18 - octane/Anderson.yml
@@ -2,7 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
-REFERENCES: "M. R. Anderson. <i>Determination of infrared optical constatns for single components hydrocarbon fuels</i>, Master Thesis (2009) [<a href=\"https://refractiveindex.info/download/data/2000/Anderson - thesis - Determination of infrared optical constants for single component hydrocarbon fuels.pdf\">pdf</a>]"
+REFERENCES: "M. R. Anderson. <i>Determination of infrared optical constants for single components hydrocarbon fuels</i>, Master Thesis (2009) [<a href=\"https://refractiveindex.info/download/data/2000/Anderson - thesis - Determination of infrared optical constants for single component hydrocarbon fuels.pdf\">pdf</a>]"
 COMMENTS: "Iso-octane"
 DATA:
   - type: tabulated nk


### PR DESCRIPTION
Fixes 4 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.