### PR TITLE
Remove __version__ from __init__.py

### DIFF
--- a/optiland/__init__.py
+++ b/optiland/__init__.py
@@ -23,5 +23,3 @@ from optiland.surfaces.factories.surface_factory import (
 from optiland.visualization.component_renderer import (
     ComponentRenderer as ComponentRenderer,
 )
-
-__version__ = "0.6.1"

--- a/optiland/prescription/renderers/pdf.py
+++ b/optiland/prescription/renderers/pdf.py
@@ -14,9 +14,12 @@ if TYPE_CHECKING:
 
     from optiland.prescription.document import Document
 
-import optiland as _optiland_pkg
+import importlib.metadata
 
-_VERSION = getattr(_optiland_pkg, "__version__", "")
+try:
+    _VERSION = importlib.metadata.version("optiland")
+except importlib.metadata.PackageNotFoundError:
+    _VERSION = ""
 
 _MARGIN_H = 25 * 2.8346  # 25 mm in points
 _MARGIN_V = 20 * 2.8346  # 20 mm in points


### PR DESCRIPTION
Remove version declaration from __init__.py

__version__ is obsolete, since package versions are now managed through versioningit.

Closes #782.