### PR TITLE
Fix OPD class docstring and clarify meaning of num_rays

### DIFF
--- a/optiland/optic/optic.py
+++ b/optiland/optic/optic.py
@@ -774,8 +774,9 @@ class Optic:
             Hx: The normalized x field coordinate(s).
             Hy: The normalized y field coordinate(s).
             wavelength (float): The wavelength of the rays in microns.
-            num_rays: The number of rays to trace.
-                Defaults to 100.
+            num_rays (int, optional): The sampling parameter that determines the
+                number of rays in the pupil. Its meaning depends on the value of
+                `distribution`. Defaults to 100.
             distribution:
                 The distribution of rays. Can be a string identifier (e.g.,
                 'hexapolar', 'uniform') or a `BaseDistribution` object.
@@ -788,6 +789,12 @@ class Optic:
 
         Returns:
             RealRays: A `RealRays` object containing the traced rays.
+
+        Notes:
+            The interpretation of the `num_rays` argument depends on the value of
+            `distribution`. For example, if `distribution` is `hexapolar`, `num_rays`
+            specifies the number of rings, whereas when `distribution` is `uniform`, it
+            specifies the total number of rays per axis.
 
         """
         return self.ray_tracer.trace(

--- a/optiland/raytrace/real_ray_tracer.py
+++ b/optiland/raytrace/real_ray_tracer.py
@@ -71,8 +71,10 @@ class RealRayTracer(BaseRayTracer):
             Hx (float or numpy.ndarray): The normalized x field coordinate.
             Hy (float or numpy.ndarray): The normalized y field coordinate.
             wavelength (float): The wavelength of the rays.
-            num_rays (int, optional): The number of rays to be traced. Defaults
-                to 100.
+            num_rays (int, optional): The sampling parameter that determines the
+                number of rays in the pupil. Its meaning depends on the value of
+                `distribution`.
+                Defaults to 100.
             distribution (str or Distribution, optional): The distribution of
                 the rays. Defaults to 'hexapolar'.
             record (bool, optional): Whether to store per-surface snapshots of
@@ -82,6 +84,12 @@ class RealRayTracer(BaseRayTracer):
 
         Returns:
             RealRays: The RealRays object containing the traced rays."
+
+        Notes:
+            The interpretation of the `num_rays` argument depends on the value of
+            `distribution`. For example, if `distribution` is `hexapolar`, `num_rays`
+            specifies the number of rings, whereas when `distribution` is `uniform`, it
+            specifies the total number of rays per axis.
         """
         self._validate_normalized_coordinates(Hx, Hy, "field")
 

--- a/optiland/wavefront/opd.py
+++ b/optiland/wavefront/opd.py
@@ -44,8 +44,11 @@ class OPD(Wavefront):
         field (tuple): The field at which to calculate the OPD.
         wavelength (str | float): The wavelength of the wavefront. Can be 'primary'
             or a float value.
-        num_rings (int, optional): The number of rings for ray tracing.
+        num_rays (int, optional): The sampling parameter that determines the number of
+            rays in the pupil. Its meaning depends on the value of `distribution`.
             Defaults to 15.
+        distribution (DistributionType, optional): The pupil sampling distribution.
+            Defaults to "hexapolar".
         strategy (str): The calculation strategy to use. Supported options are
             "chief_ray", "centroid", and "best_fit".
             Defaults to "chief_ray".
@@ -69,6 +72,14 @@ class OPD(Wavefront):
         view(projection='2d', num_points=256, figsize=(7, 5.5)): Visualizes
             the OPD wavefront.
         rms(): Calculates the root mean square (RMS) of the OPD wavefront.
+
+    Notes:
+        The interpretation of the `num_rays` argument depends on the value of
+        `distribution`. For example, if `distribution` is `hexapolar`, `num_rays`
+        specifies the number of rings, whereas when `distribution` is `uniform`, it
+        specifies the total number of rays per axis.
+
+        The `afocal` argument is forwarded to `Wavefront.__init__()` via `kwargs`.
 
     """
 

--- a/optiland/wavefront/wavefront.py
+++ b/optiland/wavefront/wavefront.py
@@ -38,7 +38,9 @@ class Wavefront:
             Can be "all" to use all fields defined in the optic.
         wavelengths (str or list[float]): The wavelengths to analyze. Can be
             "all" for all wavelengths or "primary" for the primary wavelength.
-        num_rays (int): The number of rays to use for pupil sampling.
+        num_rays (int, optional): The sampling parameter that determines the number of
+            rays in the pupil. Its meaning depends on the value of `distribution`.
+            Defaults to 12.
         distribution (str or Distribution): The ray distribution pattern. Can
             be a name (e.g., "hexapolar") or a Distribution object.
         strategy (str): The calculation strategy to use. Supported options are
@@ -51,6 +53,12 @@ class Wavefront:
     Attributes:
         data (dict): A dictionary containing the computed `WavefrontData` for
             each (field, wavelength) pair.
+
+    Notes:
+        The interpretation of the `num_rays` argument depends on the value of
+        `distribution`. For example, if `distribution` is `hexapolar`, `num_rays`
+        specifies the number of rings, whereas when `distribution` is `uniform`, it
+        specifies the total number of rays per axis.
     """
 
     def __init__(


### PR DESCRIPTION
This fix addresses #761 by changing the documented argument to `OPD.__init__()` from `num_rings` to `num_rays` and adds the missing `distribution` argument to the docstring.

As discussed in the issue, I have also added a note explaining that the interpretation of `num_rays` depends on the value of `distribution` in several user-facing entry points; I avoided being too precise to help avoid future drift between the docstring and interpretation of the `num_rays` value.

Finally, I mention in the `OPD` class docstring that the `afocal` argument is passed to the `Wavefront` parent `__init__()` via `kwargs`. It probably makes the most sense to make it an explicit argument to the `OPD` class, but I decided it was safer to keep this PR scoped to docstrings only.