### PR TITLE
Expand OSLO imports with strict diagnostics and verified command mappings

### DIFF
--- a/docs/api/api_fileio.rst
+++ b/docs/api/api_fileio.rst
@@ -7,6 +7,11 @@ The ``optiland.fileio`` package handles saving and loading of optical systems.
 It supports the native Optiland JSON format, as well as Zemax (.zmx), CODE V (.seq), 
 and OSLO (.len) files.
 
+.. toctree::
+   :maxdepth: 1
+
+   /oslo_import
+
 .. autosummary::
    :toctree: generated
    :nosignatures:

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -115,6 +115,9 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        unsatisfied solves restore saved values with a warning in permissive mode;
        strict mode rejects. General simultaneous constraint solving is not provided:
        a coupled case can be rejected even if a joint solution exists in OSLO.
+       EC verifies physical contact at the first surface's local meridional edge
+       after positioning both surfaces. Relative transforms that prevent this
+       contact restore the saved prescription rather than accepting TH alone.
        Telecentric PYC/PUC solves are not mapped because the native paraxial chief
        ray used by those solves does not implement the telecentric launch.
    * - ``GSP``, ``GOR``

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -153,6 +153,8 @@ custom interaction, material or propagation models, ideal-material absorption, c
 scattering raise before the destination file is opened. Names and notes must fit
 on a single line. Use native JSON for those systems. Finite-object and floating-stop
 apertures export the actual axial beam radius at surface 1.
+The standard and even-asphere handlers also validate the concrete geometry;
+a surface label cannot authorize dropping or changing its actual sag terms.
 The writer rejects finite object distances that OSLO would interpret as infinite
 and preserves thickness precision to avoid rounding across that boundary.
 It writes the physical final gap with zero image defocus, so exporting an imported

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -33,8 +33,15 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        its other data. The first prescription is imported.
    * - ``UNI``, ``EBR``, ``FNO``, ``NAO``, ``NAP``, ``PUK``, ``TELE``
      - Lens units converted to millimeters. Working f-number/image NA/slope
-       determine the entrance pupil via a paraxial trace; TELE sets object-space
-       telecentricity. These specifications require valid paraxial geometry.
+       determine the entrance pupil via a paraxial trace. EBR specifies the axial
+       beam radius at surface 1; finite-object imports account for the displaced
+       entrance pupil. These specifications require valid paraxial geometry.
+       TELE sets object-space telecentricity and is preserved in native JSON.
+       Real telecentric launch supports finite object-height fields in air with
+       entry along +z, using an equivalent object NA. Other launch combinations
+       warn in permissive mode and fail in strict mode.
+       Native paraxial chief-ray analysis still aims at the stop; use real rays
+       to evaluate the imported telecentric launch.
    * - ``ANG``, ``OBH``, ``GIH``; ``RST NEW`` / ``F``
      - Maximum field or explicit fractional X/Y positions, weights and symmetric
        pupil vignetting. Fractional object positions are converted through tangent
@@ -46,6 +53,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        Direct-index glass retains the wavelengths active when it was defined.
    * - ``RD``, ``RDF``, ``CV``, ``CVF``, ``TH``, ``THF``, ``CC``
      - Spheres/conics, planar RD=0, signed thickness and infinity sentinels.
+       Object distances with magnitude at least 1e8 lens units are infinite,
+       independently of the conversion to millimeters.
        Fixed markers describe editing constraints and do not change the snapshot.
    * - ``AD`` through ``AG``; ``ASP ADO/ASR/ARA/ASX`` and ``ASn``
      - AD starts at r^4. ASR uses even radial powers, ARA all positive radial
@@ -87,6 +96,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        unsatisfied solves restore saved values with a warning in permissive mode;
        strict mode rejects. General simultaneous constraint solving is not provided:
        a coupled case can be rejected even if a joint solution exists in OSLO.
+       Telecentric PYC/PUC solves are not mapped because the native paraxial chief
+       ray used by those solves does not implement the telecentric launch.
    * - ``GSP``, ``GOR``
      - Ruled gratings through the existing phase model, with grooves parallel
        to local X. Lens-unit spacing is converted to millimeters. Blaze efficiency
@@ -122,9 +133,13 @@ preferred way to retain imported general geometry, aperture composition and pose
 The OSLO writer supports its documented surface subset, direct spectral samples,
 correct even-asphere powers, explicit angular/object-height fields and radial
 aperture checking flags, and object-space telecentricity. Unsupported field
-definitions, transformed surfaces, phase profiles and non-radial apertures raise
-before the destination file is opened, preventing silent loss of those features.
-Names and notes must fit on a single line. Use native JSON for those systems.
+definitions, transformed surfaces, phase profiles, offset/non-radial apertures,
+custom material or propagation models, ideal-material absorption, coatings and
+scattering raise before the destination file is opened. Names and notes must fit
+on a single line. Use native JSON for those systems. Finite-object and floating-stop
+apertures export the actual axial beam radius at surface 1.
+The writer rejects finite object distances that OSLO would interpret as infinite
+and preserves thickness precision to avoid rounding across that boundary.
 
 Specification and real-file validation
 --------------------------------------
@@ -132,9 +147,11 @@ Specification and real-file validation
 Mappings were checked against Lambda Research's
 `OSLO Program Reference (10 March 2021) <https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf>`_
 (printed pp. 43-50: solves/apertures; 51-68: media/coordinates; 69-85:
-surfaces/gratings; 120-122: system setup; 208-210: fields; 508-514: commands),
+surfaces/gratings; 120-122: system setup; 208-210: fields; 215: telecentricity;
+508-514: commands),
 the `Optics Reference <https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf>`_
-(pp. 142-145: coordinate transforms; 170-171: grating equation), and the
+(pp. 142-145: coordinate transforms; 151: object conjugates/telecentric launch;
+170-171: grating equation), and the
 `official demo library <https://lambdares.com/support-posts/lens-demos>`_.
 The `current release page <https://lambdares.com/support-posts/oslo-current-release>`_
 links the reference editions used during research.
@@ -153,16 +170,19 @@ indices, poses, aperture clipping, grating directions and solve targets.
 
 The 2026-09-08 audit used archive SHA-256
 ``d5d43924d945a0ef5a200a0e5f12e459095b7504c59c946770fe75711814f8cc``.
-Both NumPy and Torch imported 100 of 101 files in permissive mode (5 without
-warnings, 95 with warnings); 10 passed strict import. The on-axis smoke trace
-transmitted at least one finite ray in 79 files, transmitted none in 20, and
-raised an error in 1. None of the strict imports raised a trace error. These
+Both NumPy and Torch imported 98 of 101 files in permissive mode (5 without
+warnings, 93 with warnings); 10 passed strict import. The on-axis smoke trace
+transmitted at least one finite ray in 79 files, transmitted none in 19, and
+raised no errors among imported files. These
 figures include deliberately unsupported examples and are compatibility results,
 not 101 validated optical designs. The audit JSON lists every filename and reason.
-The rejected import is ``demos/edu/prismirr.len``: its BEN bend relies on
+The rejected ``demos/edu/prismirr.len`` has a BEN bend that relies on
 TIR-controlled reflection, which is not mapped. Earlier permissive imports
 accepted this file while tracing the affected surface with a refracting model.
-The remaining trace error is ``demos/edu/ebert.len``: its finite object-height
-field and off-axis entry combination is unsupported by Optiland's field launcher.
+The other rejected files, ``demos/edu/ebert.len`` and
+``demos/premium/nonseq/cherryns.len``, require finite-object EBR conversion on
+geometry outside the native scalar paraxial model. Earlier imports treated EBR
+as an entrance-pupil radius without accounting for their finite object distance;
+the smoke trace failed for ebert and transmitted no rays for cherryns.
 Legacy ``RCO 0`` records in the demo archive are interpreted as the default undo
 of the current local transform, consistently with the examples' surface placement.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -42,6 +42,9 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        warn in permissive mode and fail in strict mode.
        Native paraxial chief-ray analysis still aims at the stop; use real rays
        to evaluate the imported telecentric launch.
+       NAO requires a finite object and an aperture greater than zero and less
+       than the object medium's refractive index; hemisphere/extended launches
+       are outside this mapping.
    * - ``ANG``, ``OBH``, ``GIH``; ``RST NEW`` / ``F``
      - Maximum field or explicit fractional X/Y positions, weights and symmetric
        pupil vignetting. Fractional object positions are converted through tangent
@@ -50,6 +53,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
    * - ``WV``, ``WVn``, ``WW``, ``WWn``
      - Replacement and indexed wavelength/weight assignments. Default d/F/C
        wavelengths are 0.58756/0.48613/0.65627 micrometers; WV1 is primary.
+       Indexed edits preserve untouched wavelengths; a bulk WV replaces the set.
+       The primary wavelength must have positive weight; other weights may be zero.
        Direct-index glass retains the wavelengths active when it was defined.
    * - ``RD``, ``RDF``, ``CV``, ``CVF``, ``TH``, ``THF``, ``CC``
      - Spheres/conics, planar RD=0, signed thickness and infinity sentinels.
@@ -60,6 +65,10 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
      - AD starts at r^4. ASR uses even radial powers, ARA all positive radial
        powers, ASX triangular-indexed XY monomials. Nonzero radial AS0 is rejected.
        Dimensional coefficients scale with their actual polynomial powers.
+       Nonzero ASR AS1, ARA AS1/AS2 and ASX AS0..AS5 retain real-ray geometry
+       but warn because the native paraxial engine omits their changes to vertex,
+       normal or power. Strict mode rejects those cases; derived paraxial pupils,
+       fields and solves must be treated as approximations.
    * - ``CVX``, ``RDX``
      - Toroidal surfaces with supported rotational profiles. Unsupported
        combinations are rejected rather than converted to a different formula.
@@ -74,9 +83,9 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        clipping, matching OSLO spot-diagram behavior. The default stop is surface 1.
    * - ``APN``, ``ATP``, ``AAC``, ``AGN``, ``AAN``, ``AX1/2``, ``AY1/2``,
        ``AVX1..4``, ``AVY1..4``, ``APK``
-     - Ellipses, rectangles, triangles, quadrangles, rotation, obstructions and
-       unions of intersecting aperture groups. Omitted legacy coordinates are
-       zero. Transmitting/obstructing actions are supported; undeviated holes are
+     - Ellipses, rectangles, triangles, quadrangles, centroid-based rotation,
+       obstructions and unions of intersecting aperture groups. Omitted legacy
+       coordinates are zero. Transmitting/obstructing actions are supported; undeviated holes are
        diagnosed. APK copies a preceding special aperture.
    * - ``DCX/Y/Z``, ``TLA/B/C``, ``DT``, ``TOX/Y/Z``, ``GC``, ``RCO``, ``BEN``
      - OSLO intrinsic Euler rotations, signed X/Y tilts, translation order,
@@ -140,6 +149,8 @@ on a single line. Use native JSON for those systems. Finite-object and floating-
 apertures export the actual axial beam radius at surface 1.
 The writer rejects finite object distances that OSLO would interpret as infinite
 and preserves thickness precision to avoid rounding across that boundary.
+Constant refractive indices retain their saved precision, including small
+differences from unity. Invalid object-NA launches are rejected before writing.
 
 Specification and real-file validation
 --------------------------------------
@@ -147,10 +158,11 @@ Specification and real-file validation
 Mappings were checked against Lambda Research's
 `OSLO Program Reference (10 March 2021) <https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf>`_
 (printed pp. 43-50: solves/apertures; 51-68: media/coordinates; 69-85:
-surfaces/gratings; 120-122: system setup; 208-210: fields; 215: telecentricity;
+surfaces/gratings; 120-123: system setup/wavelengths; 208-210: fields; 215: telecentricity;
 508-514: commands),
 the `Optics Reference <https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf>`_
-(pp. 142-145: coordinate transforms; 151: object conjugates/telecentric launch;
+(pp. 105: special-aperture shapes and rotation; 142-145: coordinate transforms;
+151: object conjugates/telecentric launch;
 170-171: grating equation), and the
 `official demo library <https://lambdares.com/support-posts/lens-demos>`_.
 The `current release page <https://lambdares.com/support-posts/oslo-current-release>`_
@@ -170,19 +182,22 @@ indices, poses, aperture clipping, grating directions and solve targets.
 
 The 2026-09-08 audit used archive SHA-256
 ``d5d43924d945a0ef5a200a0e5f12e459095b7504c59c946770fe75711814f8cc``.
-Both NumPy and Torch imported 98 of 101 files in permissive mode (5 without
-warnings, 93 with warnings); 10 passed strict import. The on-axis smoke trace
-transmitted at least one finite ray in 79 files, transmitted none in 19, and
-raised no errors among imported files. These
-figures include deliberately unsupported examples and are compatibility results,
+Both NumPy and Torch imported 97 of 101 files in permissive mode (5 without
+warnings, 92 with warnings); 10 passed strict import. The on-axis smoke trace
+transmitted at least one finite ray in 78 files, transmitted none in 19, and
+raised no errors among imported files. These figures include deliberately
+unsupported examples and are compatibility results,
 not 101 validated optical designs. The audit JSON lists every filename and reason.
 The rejected ``demos/edu/prismirr.len`` has a BEN bend that relies on
 TIR-controlled reflection, which is not mapped. Earlier permissive imports
 accepted this file while tracing the affected surface with a refracting model.
-The other rejected files, ``demos/edu/ebert.len`` and
+Two other rejected files, ``demos/edu/ebert.len`` and
 ``demos/premium/nonseq/cherryns.len``, require finite-object EBR conversion on
 geometry outside the native scalar paraxial model. Earlier imports treated EBR
 as an entrance-pupil radius without accounting for their finite object distance;
 the smoke trace failed for ebert and transmitted no rays for cherryns.
+The fourth rejection is ``demos/edu/xarmdemo.len``: its NAO=1 and XARM mode
+require extended ray aiming. The earlier import's finite smoke rays did not
+represent that specified source cone.
 Legacy ``RCO 0`` records in the demo archive are interpreted as the default undo
 of the current local transform, consistently with the examples' surface placement.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -1,0 +1,151 @@
+OSLO import compatibility
+=========================
+
+Use ``load_oslo_file("design.len")`` to read a sequential OSLO prescription.
+Unsupported optical commands emit warnings; inspect them before relying on the
+result. To reject unsupported commands and known approximations, use::
+
+    from optiland.fileio import load_oslo_file
+
+    optic = load_oslo_file("design.len", strict=True)
+
+Malformed data raises ``ValueError``. Parser errors and unsupported-command
+warnings identify the file, line and surface. The intermediate
+``OsloDataParser(...).parse()`` model also exposes structured ``diagnostics``.
+Strict import is a compatibility check, not a certificate of agreement with OSLO.
+No CCL, include file, optimization program or external executable is executed.
+
+Supported mappings
+------------------
+
+Command names are case insensitive. Quoted strings may contain semicolons and
+``//``; those delimiters split statements and comments only outside strings.
+UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
+
+.. list-table:: Sequential prescription support
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Commands
+     - Mapping and limits
+   * - ``LEN NEW``, ``NXT``, ``GTO``, ``END``
+     - Object, optical and image surfaces; updating a previous surface preserves
+       its other data. The first prescription is imported.
+   * - ``UNI``, ``EBR``, ``FNO``, ``NAO``, ``NAP``, ``PUK``, ``TELE``
+     - Lens units converted to millimeters. Working f-number/image NA/slope
+       determine the entrance pupil via a paraxial trace; TELE sets object-space
+       telecentricity. These specifications require valid paraxial geometry.
+   * - ``ANG``, ``OBH``, ``GIH``; ``RST NEW`` / ``F``
+     - Maximum field or explicit fractional X/Y positions, weights and symmetric
+       pupil vignetting. Fractional object positions are converted through tangent
+       space for angular fields. GIH refers to the Gaussian focal plane.
+       Without a table, generate on-axis, 0.7 and full-field points.
+   * - ``WV``, ``WVn``, ``WW``, ``WWn``
+     - Replacement and indexed wavelength/weight assignments. Default d/F/C
+       wavelengths are 0.58756/0.48613/0.65627 micrometers; WV1 is primary.
+       Direct-index glass retains the wavelengths active when it was defined.
+   * - ``RD``, ``RDF``, ``CV``, ``CVF``, ``TH``, ``THF``, ``CC``
+     - Spheres/conics, planar RD=0, signed thickness and infinity sentinels.
+       Fixed markers describe editing constraints and do not change the snapshot.
+   * - ``AD`` through ``AG``; ``ASP ADO/ASR/ARA/ASX`` and ``ASn``
+     - AD starts at r^4. ASR uses even radial powers, ARA all positive radial
+       powers, ASX triangular-indexed XY monomials. Nonzero radial AS0 is rejected.
+       Dimensional coefficients scale with their actual polynomial powers.
+   * - ``CVX``, ``RDX``
+     - Toroidal surfaces with supported rotational profiles. Unsupported
+       combinations are rejected rather than converted to a different formula.
+   * - ``AIR``, ``AIF``, ``RFL``, ``RFH``, ``GLA``, ``GLF``
+     - Air, reflection, named catalog glass, constant index and sampled index
+       data. Distinct saved indices use ``TabulatedMaterial``: exact at samples,
+       linear between samples, with extrapolation rejected. Two-parameter model
+       glass and historical fallback glasses use approximate Abbe dispersion.
+   * - ``AP``, ``APF``, ``AP CHK/UNC``, ``APCK``, ``AST``
+     - Ordinary AP retains drawing bounds; CHK enables clipping. APCK OFF
+       disables clipping. Default import uses checked/special apertures for
+       clipping, matching OSLO spot-diagram behavior. The default stop is surface 1.
+   * - ``APN``, ``ATP``, ``AAC``, ``AGN``, ``AAN``, ``AX1/2``, ``AY1/2``,
+       ``AVX1..4``, ``AVY1..4``, ``APK``
+     - Ellipses, rectangles, triangles, quadrangles, rotation, obstructions and
+       unions of intersecting aperture groups. Omitted legacy coordinates are
+       zero. Transmitting/obstructing actions are supported; undeviated holes are
+       diagnosed. APK copies a preceding special aperture.
+   * - ``DCX/Y/Z``, ``TLA/B/C``, ``DT``, ``TOX/Y/Z``, ``GC``, ``RCO``, ``BEN``
+     - OSLO intrinsic Euler rotations, signed X/Y tilts, translation order,
+       pivots, preceding global references and coordinate returns. BEN supports
+       single-axis local mirror bends; mixed-axis/global bends are rejected.
+   * - ``PK CV/CVM/TH/THM/LN/LNM/AP/GLA/TD/TDM``
+     - Static preceding-surface pickups, relative references and chains.
+       Curvature and length constants are additive. Forward/self references are
+       rejected. The result is an imported prescription, not live OSLO constraints.
+   * - ``PY``, ``PYC``, ``PU``, ``PUC``, ``EC``
+     - Targeted marginal/chief height, outgoing slope and edge-contact solves.
+       Targets are checked after solving. Unsupported or unsatisfiable solves
+       retain saved values with a warning in permissive mode; strict mode rejects.
+   * - ``GSP``, ``GOR``
+     - Ruled gratings through the existing phase model, with grooves parallel
+       to local X. Lens-unit spacing is converted to millimeters. Blaze efficiency
+       is not inferred.
+   * - ``ATD``, ``CXD``, ``APD``, ``GCD``, ``RCD``, ``BED``, ``PFD``,
+       ``TDD``, ``CSD``, ``TSD``
+     - Clear the corresponding previously entered surface data/constraints.
+   * - ``DES``, ``SNO<n>``, ``NOT``; drawing/group records
+     - Names and notes retained in the intermediate model. Drawing records
+       DRW/LDP/CBK/ELMDF1/2/BDI/BDD/VX/PF and sequential LMO ELE/EGR, LMN,
+       LME do not affect ray tracing. Non-sequential LMO groups are diagnosed.
+
+Limits and deferred commands
+---------------------------
+
+OSLO is a complete optical-design environment. This importer handles a sequential
+snapshot. It does not implement multi-configuration execution (CFG), non-sequential
+NSS/NAC/ELI traversal, GRIN/GRADIUM propagation, user DLL/CCL surfaces, eikonal
+models, spline/ISO/Zernike surfaces, holograms/general diffractive phase polynomials,
+polarization/coating libraries, thermal expansion, lens arrays, optimization and
+general ray-aiming/field-depth controls. Unknown prescription commands produce
+diagnostics rather than disappearing silently. Analysis/optimization footer blocks
+are ignored except for the declarative field table and configuration diagnostics.
+
+``PFL`` describes an OSLO perfect-imaging surface whose exact off-axis behavior
+differs from a paraxial thin lens. Permissive import retains the existing thin-lens
+approximation and warns; strict mode rejects it. ``PFM`` does not restore exact
+perfect imagery. Do not interpret successful imports of GRIN, non-sequential or
+user-surface examples as faithful optical models.
+
+Import coverage is broader than OSLO export coverage. Native Optiland JSON is the
+preferred way to retain imported general geometry, aperture composition and poses.
+The OSLO writer supports its documented surface subset, direct spectral samples,
+correct even-asphere powers and radial aperture checking flags.
+
+Specification and real-file validation
+-------------------------------------
+
+Mappings were checked against Lambda Research's
+`OSLO Program Reference (10 March 2021) <https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf>`_
+(printed pp. 43-50: solves/apertures; 51-68: media/coordinates; 69-85:
+surfaces/gratings; 120-122: system setup; 208-210: fields; 508-514: commands),
+the `Optics Reference <https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf>`_
+(pp. 142-145: coordinate transforms; 170-171: grating equation), and the
+`official demo library <https://lambdares.com/support-posts/lens-demos>`_.
+The `current release page <https://lambdares.com/support-posts/oslo-current-release>`_
+links the reference editions used during research.
+
+Download the official ``OSLOLensDemos.zip`` separately and run from the repository::
+
+    python scripts/audit_oslo_examples.py OSLOLensDemos.zip oslo-audit.json
+    python scripts/audit_oslo_examples.py OSLOLensDemos.zip oslo-audit-torch.json --backend torch
+
+The audit records archive/file SHA-256 hashes, source URL, filenames, backend,
+permissive warnings/errors, strict errors and an on-axis trace smoke check.
+It performs no network access and does not vendor the proprietary example archive.
+Smoke checks do not establish agreement with OSLO ray intercepts. Original minimal
+test prescriptions provide independent numerical assertions for units, sag,
+indices, poses, aperture clipping, grating directions and solve targets.
+
+The 2026-09-08 audit used archive SHA-256
+``d5d43924d945a0ef5a200a0e5f12e459095b7504c59c946770fe75711814f8cc``.
+Both NumPy and Torch imported all 101 files in permissive mode (5 without
+warnings, 96 with warnings); 14 passed strict import. The on-axis smoke trace
+transmitted at least one finite ray in 74 files, transmitted none in 22, and
+raised an error in 5. None of the strict imports raised a trace error. These
+figures include deliberately unsupported examples and are compatibility results,
+not 101 validated optical designs. The audit JSON lists every filename and reason.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -10,8 +10,9 @@ result. To reject unsupported commands and known approximations, use::
     optic = load_oslo_file("design.len", strict=True)
 
 Malformed data raises ``ValueError``. Parser errors and unsupported-command
-warnings identify the file, line and surface. The intermediate
-``OsloDataParser(...).parse()`` model also exposes structured ``diagnostics``.
+warnings identify the file, line and surface. ``OsloDataParser(...).parse()``
+returns an ``OsloDataModel`` containing the parsed prescription before conversion
+to an ``Optic``. This model also exposes structured ``diagnostics``.
 Strict import is a compatibility check, not a certificate of agreement with OSLO.
 No CCL, include file, optimization program or external executable is executed.
 

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -50,7 +50,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
      - Maximum field or explicit fractional X/Y positions, weights and symmetric
        pupil vignetting. Fractional object positions are converted through tangent
        space for angular fields. The angular reference must be below 90 degrees;
-       wide-angle ray aiming (WARM) is not mapped. GIH refers to the Gaussian focal plane.
+       wide-angle ray aiming (WARM) is not mapped. GIH refers to the Gaussian
+       focal plane.
        Without a table, generate on-axis, 0.7 and full-field points.
    * - ``WV``, ``WVn``, ``WW``, ``WWn``
      - Replacement and indexed wavelength/weight assignments. Default d/F/C
@@ -65,7 +66,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        Image-surface TH is a focus shift added to the preceding nominal gap
        after solves and pickups. The physical detector position and final gap
        retain that shift; native image thickness is zero. Focus shifts require
-       an interior surface; combining them with an image GC reference is not mapped.
+       an interior surface; combining them with an image GC reference is not
+       mapped.
        Fixed markers describe editing constraints and do not change the snapshot.
    * - ``AD`` through ``AG``; ``ASP ADO/ASR/ARA/ASX`` and ``ASn``
      - AD starts at r^4. ASR uses even radial powers, ARA all positive radial
@@ -149,10 +151,10 @@ The OSLO writer supports its documented surface subset, direct spectral samples,
 correct even-asphere powers, explicit angular/object-height fields and radial
 aperture checking flags, and object-space telecentricity. Unsupported field
 definitions, transformed surfaces, phase profiles, offset/non-radial apertures,
-custom interaction, material or propagation models, ideal-material absorption, coatings and
-scattering raise before the destination file is opened. Names and notes must fit
-on a single line. Use native JSON for those systems. Finite-object and floating-stop
-apertures export the actual axial beam radius at surface 1.
+custom interaction, material or propagation models, ideal-material absorption,
+coatings and scattering raise before the destination file is opened. Names and
+notes must fit on a single line. Use native JSON for those systems. Finite-object
+and floating-stop apertures export the actual axial beam radius at surface 1.
 The standard and even-asphere handlers also validate the concrete geometry;
 a surface label cannot authorize dropping or changing its actual sag terms.
 The writer rejects finite object distances that OSLO would interpret as infinite

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -145,7 +145,7 @@ The OSLO writer supports its documented surface subset, direct spectral samples,
 correct even-asphere powers, explicit angular/object-height fields and radial
 aperture checking flags, and object-space telecentricity. Unsupported field
 definitions, transformed surfaces, phase profiles, offset/non-radial apertures,
-custom material or propagation models, ideal-material absorption, coatings and
+custom interaction, material or propagation models, ideal-material absorption, coatings and
 scattering raise before the destination file is opened. Names and notes must fit
 on a single line. Use native JSON for those systems. Finite-object and floating-stop
 apertures export the actual axial beam radius at surface 1.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -165,6 +165,8 @@ It writes the physical final gap with zero image defocus, so exporting an import
 focus shift does not apply it twice. Unused native image thickness is not defocus.
 Constant refractive indices retain their saved precision, including small
 differences from unity. Invalid object-NA launches are rejected before writing.
+Field references, object NA, wavelengths and sampled indices preserve floating-point
+precision, avoiding rounded hemisphere boundaries or collapsed spectral samples.
 Explicit surface aperture radii must be finite and positive: zero cannot retain
 a native zero-radius clipping boundary, and infinity is not a finite OSLO radius.
 

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -96,7 +96,7 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        LME do not affect ray tracing. Non-sequential LMO groups are diagnosed.
 
 Limits and deferred commands
----------------------------
+----------------------------
 
 OSLO is a complete optical-design environment. This importer handles a sequential
 snapshot. It does not implement multi-configuration execution (CFG), non-sequential
@@ -122,7 +122,7 @@ non-radial apertures raise before the destination file is opened, preventing
 silent loss of those features. Use native JSON for those systems.
 
 Specification and real-file validation
--------------------------------------
+--------------------------------------
 
 Mappings were checked against Lambda Research's
 `OSLO Program Reference (10 March 2021) <https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf>`_

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -95,6 +95,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        obstructions and unions of intersecting aperture groups. Omitted legacy
        coordinates are zero. Transmitting/obstructing actions are supported; undeviated holes are
        diagnosed. APK copies a preceding special aperture.
+       Polygon boundaries must be nondegenerate; quadrangles must have strictly
+       convex vertices in clockwise or counterclockwise order.
    * - ``DCX/Y/Z``, ``TLA/B/C``, ``DT``, ``TOX/Y/Z``, ``GC``, ``RCO``, ``BEN``
      - OSLO intrinsic Euler rotations, signed X/Y tilts, translation order,
        pivots, preceding global references and coordinate returns. BEN supports

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -49,7 +49,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
    * - ``ANG``, ``OBH``, ``GIH``; ``RST NEW`` / ``F``
      - Maximum field or explicit fractional X/Y positions, weights and symmetric
        pupil vignetting. Fractional object positions are converted through tangent
-       space for angular fields. GIH refers to the Gaussian focal plane.
+       space for angular fields. The angular reference must be below 90 degrees;
+       wide-angle ray aiming (WARM) is not mapped. GIH refers to the Gaussian focal plane.
        Without a table, generate on-axis, 0.7 and full-field points.
    * - ``WV``, ``WVn``, ``WW``, ``WWn``
      - Replacement and indexed wavelength/weight assignments. Default d/F/C

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -77,6 +77,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
      - Static preceding-surface pickups, relative references and chains.
        Curvature and length constants are additive. Forward/self references are
        rejected. The result is an imported prescription, not live OSLO constraints.
+       Solved values feed downstream pickups. TD/TDM retain local pivot data;
+       pickups involving global references, coordinate returns or bends are rejected.
    * - ``PY``, ``PYC``, ``PU``, ``PUC``, ``EC``
      - Targeted marginal/chief height, outgoing slope and edge-contact solves.
        Targets are checked after solving. Unsupported or unsatisfiable solves
@@ -114,7 +116,10 @@ user-surface examples as faithful optical models.
 Import coverage is broader than OSLO export coverage. Native Optiland JSON is the
 preferred way to retain imported general geometry, aperture composition and poses.
 The OSLO writer supports its documented surface subset, direct spectral samples,
-correct even-asphere powers and radial aperture checking flags.
+correct even-asphere powers, explicit angular/object-height fields and radial
+aperture checking flags. Unsupported transformed surfaces, phase profiles and
+non-radial apertures raise before the destination file is opened, preventing
+silent loss of those features. Use native JSON for those systems.
 
 Specification and real-file validation
 -------------------------------------
@@ -144,8 +149,12 @@ indices, poses, aperture clipping, grating directions and solve targets.
 The 2026-09-08 audit used archive SHA-256
 ``d5d43924d945a0ef5a200a0e5f12e459095b7504c59c946770fe75711814f8cc``.
 Both NumPy and Torch imported all 101 files in permissive mode (5 without
-warnings, 96 with warnings); 14 passed strict import. The on-axis smoke trace
-transmitted at least one finite ray in 74 files, transmitted none in 22, and
-raised an error in 5. None of the strict imports raised a trace error. These
+warnings, 96 with warnings); 10 passed strict import. The on-axis smoke trace
+transmitted at least one finite ray in 80 files, transmitted none in 20, and
+raised an error in 1. None of the strict imports raised a trace error. These
 figures include deliberately unsupported examples and are compatibility results,
 not 101 validated optical designs. The audit JSON lists every filename and reason.
+The remaining trace error is ``demos/edu/ebert.len``: its finite object-height
+field and off-axis entry combination is unsupported by Optiland's field launcher.
+Legacy ``RCO 0`` records in the demo archive are interpreted as the default undo
+of the current local transform, consistently with the examples' surface placement.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -62,6 +62,10 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
      - Spheres/conics, planar RD=0, signed thickness and infinity sentinels.
        Object distances with magnitude at least 1e8 lens units are infinite,
        independently of the conversion to millimeters.
+       Image-surface TH is a focus shift added to the preceding nominal gap
+       after solves and pickups. The physical detector position and final gap
+       retain that shift; native image thickness is zero. Focus shifts require
+       an interior surface; combining them with an image GC reference is not mapped.
        Fixed markers describe editing constraints and do not change the snapshot.
    * - ``AD`` through ``AG``; ``ASP ADO/ASR/ARA/ASX`` and ``ASn``
      - AD starts at r^4. ASR uses even radial powers, ARA all positive radial
@@ -151,6 +155,8 @@ on a single line. Use native JSON for those systems. Finite-object and floating-
 apertures export the actual axial beam radius at surface 1.
 The writer rejects finite object distances that OSLO would interpret as infinite
 and preserves thickness precision to avoid rounding across that boundary.
+It writes the physical final gap with zero image defocus, so exporting an imported
+focus shift does not apply it twice. Unused native image thickness is not defocus.
 Constant refractive indices retain their saved precision, including small
 differences from unity. Invalid object-NA launches are rejected before writing.
 Explicit surface aperture radii must be finite and positive: zero cannot retain

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -144,6 +144,8 @@ differs from a paraxial thin lens. Permissive import retains the existing thin-l
 approximation and warns; strict mode rejects it. ``PFM`` does not restore exact
 perfect imagery. Do not interpret successful imports of GRIN, non-sequential or
 user-surface examples as faithful optical models.
+Export of native thin-lens interactions is rejected because PFL would change
+their off-axis physics into OSLO's perfect-imaging model.
 
 Import coverage is broader than OSLO export coverage. Native Optiland JSON is the
 preferred way to retain imported general geometry, aperture composition and poses.

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -153,6 +153,8 @@ The writer rejects finite object distances that OSLO would interpret as infinite
 and preserves thickness precision to avoid rounding across that boundary.
 Constant refractive indices retain their saved precision, including small
 differences from unity. Invalid object-NA launches are rejected before writing.
+Explicit surface aperture radii must be finite and positive: zero cannot retain
+a native zero-radius clipping boundary, and infinity is not a finite OSLO radius.
 
 Specification and real-file validation
 --------------------------------------

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -72,7 +72,8 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
    * - ``DCX/Y/Z``, ``TLA/B/C``, ``DT``, ``TOX/Y/Z``, ``GC``, ``RCO``, ``BEN``
      - OSLO intrinsic Euler rotations, signed X/Y tilts, translation order,
        pivots, preceding global references and coordinate returns. BEN supports
-       single-axis local mirror bends; mixed-axis/global bends are rejected.
+       single-axis local RFL/RFH mirror bends; mixed-axis/global bends and bends
+       relying on unmapped TIR-controlled reflection are rejected.
    * - ``PK CV/CVM/TH/THM/LN/LNM/AP/GLA/TD/TDM``
      - Static preceding-surface pickups, relative references and chains.
        Curvature and length constants are additive. Forward/self references are
@@ -81,8 +82,11 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
        pickups involving global references, coordinate returns or bends are rejected.
    * - ``PY``, ``PYC``, ``PU``, ``PUC``, ``EC``
      - Targeted marginal/chief height, outgoing slope and edge-contact solves.
-       Targets are checked after solving. Unsupported or unsatisfiable solves
-       retain saved values with a warning in permissive mode; strict mode rejects.
+       Targets are rechecked after rebuilding dependent pickups, pupils and fields;
+       later solves must also preserve earlier accepted targets. Unsupported or
+       unsatisfied solves restore saved values with a warning in permissive mode;
+       strict mode rejects. General simultaneous constraint solving is not provided:
+       a coupled case can be rejected even if a joint solution exists in OSLO.
    * - ``GSP``, ``GOR``
      - Ruled gratings through the existing phase model, with grooves parallel
        to local X. Lens-unit spacing is converted to millimeters. Blaze efficiency
@@ -117,9 +121,10 @@ Import coverage is broader than OSLO export coverage. Native Optiland JSON is th
 preferred way to retain imported general geometry, aperture composition and poses.
 The OSLO writer supports its documented surface subset, direct spectral samples,
 correct even-asphere powers, explicit angular/object-height fields and radial
-aperture checking flags. Unsupported transformed surfaces, phase profiles and
-non-radial apertures raise before the destination file is opened, preventing
-silent loss of those features. Use native JSON for those systems.
+aperture checking flags, and object-space telecentricity. Unsupported field
+definitions, transformed surfaces, phase profiles and non-radial apertures raise
+before the destination file is opened, preventing silent loss of those features.
+Names and notes must fit on a single line. Use native JSON for those systems.
 
 Specification and real-file validation
 --------------------------------------
@@ -148,12 +153,15 @@ indices, poses, aperture clipping, grating directions and solve targets.
 
 The 2026-09-08 audit used archive SHA-256
 ``d5d43924d945a0ef5a200a0e5f12e459095b7504c59c946770fe75711814f8cc``.
-Both NumPy and Torch imported all 101 files in permissive mode (5 without
-warnings, 96 with warnings); 10 passed strict import. The on-axis smoke trace
-transmitted at least one finite ray in 80 files, transmitted none in 20, and
+Both NumPy and Torch imported 100 of 101 files in permissive mode (5 without
+warnings, 95 with warnings); 10 passed strict import. The on-axis smoke trace
+transmitted at least one finite ray in 79 files, transmitted none in 20, and
 raised an error in 1. None of the strict imports raised a trace error. These
 figures include deliberately unsupported examples and are compatibility results,
 not 101 validated optical designs. The audit JSON lists every filename and reason.
+The rejected import is ``demos/edu/prismirr.len``: its BEN bend relies on
+TIR-controlled reflection, which is not mapped. Earlier permissive imports
+accepted this file while tracing the affected surface with a refracting model.
 The remaining trace error is ``demos/edu/ebert.len``: its finite object-height
 field and off-axis entry combination is unsupported by Optiland's field launcher.
 Legacy ``RCO 0`` records in the demo archive are interpreted as the default undo

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -83,7 +83,9 @@ UTF-8 (including BOM) and legacy Windows-1252 text are accepted.
    * - ``AIR``, ``AIF``, ``RFL``, ``RFH``, ``GLA``, ``GLF``
      - Air, reflection, named catalog glass, constant index and sampled index
        data. Distinct saved indices use ``TabulatedMaterial``: exact at samples,
-       linear between samples, with extrapolation rejected. Two-parameter model
+       linear between samples, with extrapolation rejected. Wavelengths that
+       collapse together in the active backend precision cannot be interpolated;
+       use higher precision for those samples. Two-parameter model
        glass and historical fallback glasses use approximate Abbe dispersion.
    * - ``AP``, ``APF``, ``AP CHK/UNC``, ``APCK``, ``AST``
      - Ordinary AP retains drawing bounds; CHK enables clipping. APCK OFF

--- a/docs/oslo_import.rst
+++ b/docs/oslo_import.rst
@@ -164,8 +164,11 @@ notes must fit on a single line. Use native JSON for those systems. Finite-objec
 and floating-stop apertures export the actual axial beam radius at surface 1.
 The standard and even-asphere handlers also validate the concrete geometry;
 a surface label cannot authorize dropping or changing its actual sag terms.
-The writer rejects finite object distances that OSLO would interpret as infinite
-and preserves thickness precision to avoid rounding across that boundary.
+The writer derives spacings from the actual axial coordinates, including lenses
+built with absolute positions or edited coordinates. A common axial translation
+is removed by anchoring the first surface at zero. It rejects finite object or
+interior distances that import would interpret as infinite and preserves thickness
+precision to avoid rounding across those boundaries.
 It writes the physical final gap with zero image defocus, so exporting an imported
 focus shift does not apply it twice. Unused native image thickness is not defocus.
 Constant refractive indices retain their saved precision, including small

--- a/optiland/fileio/__init__.py
+++ b/optiland/fileio/__init__.py
@@ -46,16 +46,17 @@ def load_codev_file(source: str):
     return _CodeVTC({}).read(source)
 
 
-def load_oslo_file(source: str):
+def load_oslo_file(source: str, *, strict: bool = False):
     """Load an OSLO .len file and return an Optic object.
 
     Args:
         source: The path to a local .len file.
+        strict: Reject unsupported optical commands instead of warning.
 
     Returns:
         An Optic object created from the OSLO file data.
     """
-    return _OsloTC().read(source)
+    return _OsloTC(strict=strict).read(source)
 
 
 # ---------------------------------------------------------------------------

--- a/optiland/fileio/oslo/constants.py
+++ b/optiland/fileio/oslo/constants.py
@@ -1,0 +1,8 @@
+"""Documented defaults shared by the OSLO reader and writer."""
+
+from __future__ import annotations
+
+# OSLO Program Reference, printed p. 123, "Wavelength": initial values of the
+# Wavelength_default (wvld) preference, in micrometers (PDF page 137).
+# https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=137
+DEFAULT_WAVELENGTHS_UM = (0.58756, 0.48613, 0.65627)

--- a/optiland/fileio/oslo/constants.py
+++ b/optiland/fileio/oslo/constants.py
@@ -1,4 +1,4 @@
-"""Documented defaults shared by the OSLO reader and writer."""
+"""Documented conventions shared by the OSLO reader and writer."""
 
 from __future__ import annotations
 
@@ -6,3 +6,9 @@ from __future__ import annotations
 # Wavelength_default (wvld) preference, in micrometers (PDF page 137).
 # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=137
 DEFAULT_WAVELENGTHS_UM = (0.58756, 0.48613, 0.65627)
+
+# OSLO Optics Reference, printed p. 151, "Telecentric ray-aiming": object
+# distances at or above 1e8 lens units are treated as infinite. This threshold
+# differs from the large sentinel values commonly written in lens files.
+# https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf#page=151
+OBJECT_INFINITY_THRESHOLD = 1e8

--- a/optiland/fileio/oslo/constants.py
+++ b/optiland/fileio/oslo/constants.py
@@ -12,3 +12,8 @@ DEFAULT_WAVELENGTHS_UM = (0.58756, 0.48613, 0.65627)
 # differs from the large sentinel values commonly written in lens files.
 # https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf#page=151
 OBJECT_INFINITY_THRESHOLD = 1e8
+
+# Saved OSLO prescriptions use values near 1e10 for infinite non-object gaps
+# (including rounded values such as 9.9999999996e9). Keep import and export
+# consistent about which finite native spacings would become this sentinel.
+THICKNESS_INFINITY_THRESHOLD = 9.9e9

--- a/optiland/fileio/oslo/model.py
+++ b/optiland/fileio/oslo/model.py
@@ -1,7 +1,8 @@
 """OSLO Data Model
 
-Defines OsloDataModel, the shared intermediate representation used by both
-the OSLO reader (parser -> model) and writer (optic -> model) paths.
+Defines OsloDataModel, the shared parsed prescription. The reader fills it
+from .len commands before converting it to an Optic; the writer builds it
+from an Optic before formatting .len text.
 
 Kramer Harrison, 2026
 """
@@ -24,7 +25,7 @@ class OsloDiagnostic:
 
 @dataclass
 class OsloDataModel:
-    """Intermediate representation of an OSLO .len optical system.
+    """Parsed OSLO prescription shared by the reader and writer.
 
     Attributes:
         name: System name from the LEN NEW command.

--- a/optiland/fileio/oslo/model.py
+++ b/optiland/fileio/oslo/model.py
@@ -50,6 +50,7 @@ class OsloDataModel:
     units: float = 1.0
     notes: dict[str, str] = field(default_factory=dict)
     diagnostics: list[OsloDiagnostic] = field(default_factory=list)
+    settings: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Return the data model as a plain dictionary.

--- a/optiland/fileio/oslo/model.py
+++ b/optiland/fileio/oslo/model.py
@@ -12,6 +12,16 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+@dataclass(frozen=True)
+class OsloDiagnostic:
+    """A source-located record of an OSLO command that was not imported."""
+
+    command: str
+    line: int
+    surface: int
+    message: str
+
+
 @dataclass
 class OsloDataModel:
     """Intermediate representation of an OSLO .len optical system.
@@ -39,6 +49,7 @@ class OsloDataModel:
     surfaces: dict[int, dict[str, Any]] = field(default_factory=dict)
     units: float = 1.0
     notes: dict[str, str] = field(default_factory=dict)
+    diagnostics: list[OsloDiagnostic] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Return the data model as a plain dictionary.

--- a/optiland/fileio/oslo/model.py
+++ b/optiland/fileio/oslo/model.py
@@ -8,7 +8,7 @@ Kramer Harrison, 2026
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
@@ -59,14 +59,4 @@ class OsloDataModel:
             A plain dict representation suitable for use with
             ``OsloToOpticConverter``.
         """
-        return {
-            "name": self.name,
-            "scaling": self.scaling,
-            "num_surfaces": self.num_surfaces,
-            "aperture": self.aperture,
-            "fields": self.fields,
-            "wavelengths": self.wavelengths,
-            "surfaces": self.surfaces,
-            "units": self.units,
-            "notes": self.notes,
-        }
+        return asdict(self)

--- a/optiland/fileio/oslo/reader/apertures.py
+++ b/optiland/fileio/oslo/reader/apertures.py
@@ -50,7 +50,12 @@ def physical_aperture(
             else:
                 ap = RectangularAperture(x0, x1, y0, y1)
             if spec.get("AAN", 0.0):
-                ap = RotatedAperture(ap, math.radians(spec["AAN"]))
+                # AAN rotates around the aperture centroid, not the surface
+                # origin: OSLO Optics Reference, printed p. 105.
+                # https://lambdares.com/hubfs/Support/support/OSLOOpticsReference_Sep21.pdf#page=105
+                ap = RotatedAperture(
+                    ap, math.radians(spec["AAN"]), (x1 + x0) / 2, (y1 + y0) / 2
+                )
         elif kind in {3, 4}:
             ap = PolygonAperture(
                 [spec.get(f"AVX{i}", 0.0) * scale for i in range(1, kind + 1)],

--- a/optiland/fileio/oslo/reader/apertures.py
+++ b/optiland/fileio/oslo/reader/apertures.py
@@ -1,0 +1,65 @@
+"""OSLO special apertures and aperture-group Boolean rules (reference pp. 49–50)."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from optiland.physical_apertures import (
+    BaseAperture,
+    DifferenceAperture,
+    EllipticalAperture,
+    IntersectionAperture,
+    PolygonAperture,
+    RadialAperture,
+    RectangularAperture,
+    RotatedAperture,
+    UnionAperture,
+)
+
+
+def physical_aperture(data: dict[str, Any], scale: float) -> BaseAperture | None:
+    """Build a surface aperture from ordinary and special aperture data."""
+    radius = data.get("AP", 0.0)
+    outer = RadialAperture(r_max=radius * scale) if 0 < radius < 1e6 else None
+    groups: dict[int, list[tuple[BaseAperture, int]]] = {}
+    for spec in data.get("special_apertures", {}).values():
+        action = int(spec.get("AAC", 4))
+        if action not in {2, 4}:
+            continue  # The parser has already diagnosed hole/unknown actions.
+        kind = int(spec.get("ATP", 1))
+        if kind in {1, 2}:
+            x0, x1, y0, y1 = [spec[k] * scale for k in ("AX1", "AX2", "AY1", "AY2")]
+            if x0 >= x1 or y0 >= y1:
+                raise ValueError("OSLO special aperture requires increasing bounds")
+            if kind == 1:
+                ap = EllipticalAperture(
+                    (x1 - x0) / 2, (y1 - y0) / 2, (x1 + x0) / 2, (y1 + y0) / 2
+                )
+            else:
+                ap = RectangularAperture(x0, x1, y0, y1)
+            if spec.get("AAN", 0.0):
+                ap = RotatedAperture(ap, math.radians(spec["AAN"]))
+        elif kind in {3, 4}:
+            ap = PolygonAperture(
+                [spec[f"AVX{i}"] * scale for i in range(1, kind + 1)],
+                [spec[f"AVY{i}"] * scale for i in range(1, kind + 1)],
+            )
+        else:
+            raise ValueError(f"OSLO special aperture type {kind} is not supported")
+        groups.setdefault(int(spec.get("AGN", 0)), []).append((ap, action))
+    combined = None
+    for members in groups.values():
+        group = None
+        for ap, action in members:
+            if action == 4:
+                group = ap if group is None else IntersectionAperture(group, ap)
+        if group is None:
+            group = RadialAperture(r_max=math.inf)
+        for ap, action in members:
+            if action == 2:
+                group = DifferenceAperture(group, ap)
+        combined = group if combined is None else UnionAperture(combined, group)
+    if combined is None:
+        return outer
+    return combined if outer is None else IntersectionAperture(outer, combined)

--- a/optiland/fileio/oslo/reader/apertures.py
+++ b/optiland/fileio/oslo/reader/apertures.py
@@ -24,7 +24,13 @@ def physical_aperture(
 ) -> BaseAperture | None:
     """Build a surface aperture from ordinary and special aperture data."""
     radius = data.get("AP", 0.0)
-    outer = RadialAperture(r_max=radius * scale) if 0 < radius < 1e6 else None
+    # Omit huge unchecked drawing outlines (typically the object plane).
+    # A checked radius must retain its clipping boundary at any lens-unit scale.
+    outer = (
+        RadialAperture(r_max=radius * scale)
+        if radius > 0 and (data.get("aperture_checked") or radius < 1e6)
+        else None
+    )
     groups: dict[int, list[tuple[BaseAperture, int]]] = {}
     for spec in data.get("special_apertures", {}).values():
         action = int(spec.get("AAC", 4))

--- a/optiland/fileio/oslo/reader/apertures.py
+++ b/optiland/fileio/oslo/reader/apertures.py
@@ -14,11 +14,14 @@ from optiland.physical_apertures import (
     RadialAperture,
     RectangularAperture,
     RotatedAperture,
+    UnclippedAperture,
     UnionAperture,
 )
 
 
-def physical_aperture(data: dict[str, Any], scale: float) -> BaseAperture | None:
+def physical_aperture(
+    data: dict[str, Any], scale: float, check: bool = True
+) -> BaseAperture | None:
     """Build a surface aperture from ordinary and special aperture data."""
     radius = data.get("AP", 0.0)
     outer = RadialAperture(r_max=radius * scale) if 0 < radius < 1e6 else None
@@ -29,7 +32,9 @@ def physical_aperture(data: dict[str, Any], scale: float) -> BaseAperture | None
             continue  # The parser has already diagnosed hole/unknown actions.
         kind = int(spec.get("ATP", 1))
         if kind in {1, 2}:
-            x0, x1, y0, y1 = [spec[k] * scale for k in ("AX1", "AX2", "AY1", "AY2")]
+            x0, x1, y0, y1 = [
+                spec.get(k, 0.0) * scale for k in ("AX1", "AX2", "AY1", "AY2")
+            ]
             if x0 >= x1 or y0 >= y1:
                 raise ValueError("OSLO special aperture requires increasing bounds")
             if kind == 1:
@@ -42,8 +47,8 @@ def physical_aperture(data: dict[str, Any], scale: float) -> BaseAperture | None
                 ap = RotatedAperture(ap, math.radians(spec["AAN"]))
         elif kind in {3, 4}:
             ap = PolygonAperture(
-                [spec[f"AVX{i}"] * scale for i in range(1, kind + 1)],
-                [spec[f"AVY{i}"] * scale for i in range(1, kind + 1)],
+                [spec.get(f"AVX{i}", 0.0) * scale for i in range(1, kind + 1)],
+                [spec.get(f"AVY{i}", 0.0) * scale for i in range(1, kind + 1)],
             )
         else:
             raise ValueError(f"OSLO special aperture type {kind} is not supported")
@@ -61,5 +66,11 @@ def physical_aperture(data: dict[str, Any], scale: float) -> BaseAperture | None
                 group = DifferenceAperture(group, ap)
         combined = group if combined is None else UnionAperture(combined, group)
     if combined is None:
-        return outer
-    return combined if outer is None else IntersectionAperture(outer, combined)
+        return (
+            UnclippedAperture(outer)
+            if outer is not None and (not check or not data.get("aperture_checked"))
+            else outer
+        )
+    if outer is not None and data.get("aperture_checked"):
+        combined = IntersectionAperture(outer, combined)
+    return combined if check else UnclippedAperture(combined)

--- a/optiland/fileio/oslo/reader/apertures.py
+++ b/optiland/fileio/oslo/reader/apertures.py
@@ -57,9 +57,25 @@ def physical_aperture(
                     ap, math.radians(spec["AAN"]), (x1 + x0) / 2, (y1 + y0) / 2
                 )
         elif kind in {3, 4}:
+            vertices = [
+                (spec.get(f"AVX{i}", 0.0), spec.get(f"AVY{i}", 0.0))
+                for i in range(1, kind + 1)
+            ]
+            # OSLO requires nondegenerate triangles and strictly convex,
+            # cyclically ordered quadrangles (Program Reference pp. 49–50).
+            # Validate in lens units so unit conversion cannot collapse area.
+            # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=63
+            turns = []
+            for i, (ax, ay) in enumerate(vertices):
+                bx, by = vertices[(i + 1) % kind]
+                cx, cy = vertices[(i + 2) % kind]
+                turns.append((bx - ax) * (cy - by) - (by - ay) * (cx - bx))
+            if not (all(turn > 0 for turn in turns) or all(turn < 0 for turn in turns)):
+                raise ValueError(
+                    "OSLO polygon aperture must be nondegenerate and strictly convex"
+                )
             ap = PolygonAperture(
-                [spec.get(f"AVX{i}", 0.0) * scale for i in range(1, kind + 1)],
-                [spec.get(f"AVY{i}", 0.0) * scale for i in range(1, kind + 1)],
+                [x * scale for x, _ in vertices], [y * scale for _, y in vertices]
             )
         else:
             raise ValueError(f"OSLO special aperture type {kind} is not supported")

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
 from optiland.fileio.base import BaseOpticReader
+from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
@@ -278,7 +279,7 @@ class OsloToOpticConverter(BaseOpticReader):
                 return AbbeMaterial(*indices, model="buchdahl")
             if len(set(indices)) == 1:
                 return IdealMaterial(indices[0])
-            wavelengths = wavelengths or [0.58756, 0.48613, 0.65627]
+            wavelengths = wavelengths or list(DEFAULT_WAVELENGTHS_UM)
             if len(indices) != len(wavelengths):
                 raise ValueError(f"OSLO glass {name!r} index/wavelength counts differ")
             return TabulatedMaterial(wavelengths, indices, name=name)

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -220,7 +220,9 @@ class OsloToOpticConverter(BaseOpticReader):
             material_raw, data.get("glass_wavelengths")
         )
 
-        surface_params["aperture"] = physical_aperture(data, scale)
+        surface_params["aperture"] = physical_aperture(
+            data, scale, self.data.settings.get("aperture_check", True)
+        )
 
         if has_coord_transform:
             surface_params.pop("thickness")

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING, Any
 import optiland.backend as be
 from optiland.fields.field_types import ObjectHeightField
 from optiland.fileio.base import BaseOpticReader
-from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
+from optiland.fileio.oslo.constants import (
+    DEFAULT_WAVELENGTHS_UM,
+    OBJECT_INFINITY_THRESHOLD,
+)
 from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
@@ -227,9 +230,10 @@ class OsloToOpticConverter(BaseOpticReader):
         surface_params["is_stop"] = data.get("AST", False)
 
         th = data.get("TH", 0.0)
-        # OSLO uses 1e10 as "infinity"; allow for floating-point imprecision
-        # (e.g., 9.9999999996e+09 appears in practice).
-        if abs(th) >= 9.9e9:
+        # Object conjugates have a documented cutoff below the large sentinel
+        # used for other distances (sometimes saved as 9.9999999996e+09).
+        infinity_threshold = OBJECT_INFINITY_THRESHOLD if index == 0 else 9.9e9
+        if abs(th) >= infinity_threshold:
             th = be.inf if th > 0 else -be.inf
         surface_params["thickness"] = th * scale
 

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.fileio.base import BaseOpticReader
+from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
@@ -182,12 +183,7 @@ class OsloToOpticConverter(BaseOpticReader):
             material_raw, data.get("glass_wavelengths")
         )
 
-        # Handle aperture (AP is radius in OSLO).
-        # Skip sentinel values like AP 4e9 which mean "infinite aperture".
-        if "AP" in data and data["AP"] < 1e6:
-            from optiland.physical_apertures import RadialAperture
-
-            surface_params["aperture"] = RadialAperture(r_max=data["AP"] * scale)
+        surface_params["aperture"] = physical_aperture(data, scale)
 
         if has_coord_transform:
             # Resolve effective global position and orientation

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -8,6 +8,7 @@ Kramer Harrison, 2026
 from __future__ import annotations
 
 import warnings
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
@@ -17,6 +18,7 @@ from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
+from optiland.fileio.oslo.reader.pickups import resolve_pickups
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
 
@@ -127,6 +129,8 @@ class OsloToOpticConverter(BaseOpticReader):
         if self.data is None:
             raise ValueError("No OSLO data to convert.")
 
+        self.data = deepcopy(self.data)
+        self.data.surfaces = resolve_pickups(self.data.surfaces)
         self.optic = Optic(self.data.name)
         self.current_cs = CoordinateSystem()
         self._py_surface_indices = []

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -485,6 +485,13 @@ class OsloToOpticConverter(BaseOpticReader):
         else:
             y_coords = [y * self.data.units for y in y_coords]
 
+        # The reference field must stay below 90 degrees even in OSLO's
+        # separate WARM mode (Program Reference p. 215). Our ordinary field
+        # mapping uses tan/atan, which would fold 100 degrees onto -80 degrees.
+        # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=229
+        if field_type == "angle" and any(abs(y) >= 90 for y in y_coords):
+            raise ValueError("OSLO angular reference must be less than 90 degrees")
+
         self.optic.fields.set_type(field_type)
 
         if "points" in field_data:

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -416,9 +416,9 @@ class OsloToOpticConverter(BaseOpticReader):
             self.optic.set_aperture("imageFNO", aperture_data["FNO"])
             return
         if "EPD" in aperture_data:
-            # The intermediate model stores twice OSLO's EBR under its legacy
-            # EPD key. EBR is measured at surface 1 (Program Reference p. 120),
-            # which need not coincide with the entrance pupil for finite objects.
+            # The shared model's EPD is twice OSLO's EBR, the radius at surface 1
+            # (Program Reference p. 120). For finite objects, this plane need
+            # not coincide with the entrance pupil.
             diameter = aperture_data["EPD"] * self.data.units
             self.optic.set_aperture("EPD", 1.0)
             if not self.optic.object_surface.is_infinite:

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -18,6 +18,7 @@ from optiland.fileio.base import BaseOpticReader
 from optiland.fileio.oslo.constants import (
     DEFAULT_WAVELENGTHS_UM,
     OBJECT_INFINITY_THRESHOLD,
+    THICKNESS_INFINITY_THRESHOLD,
 )
 from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
@@ -283,7 +284,9 @@ class OsloToOpticConverter(BaseOpticReader):
         th = data.get("TH", 0.0)
         # Object conjugates have a documented cutoff below the large sentinel
         # used for other distances (sometimes saved as 9.9999999996e+09).
-        infinity_threshold = OBJECT_INFINITY_THRESHOLD if index == 0 else 9.9e9
+        infinity_threshold = (
+            OBJECT_INFINITY_THRESHOLD if index == 0 else THICKNESS_INFINITY_THRESHOLD
+        )
         if abs(th) >= infinity_threshold:
             th = be.inf if th > 0 else -be.inf
         surface_params["thickness"] = th * scale

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -129,14 +129,18 @@ class OsloToOpticConverter(BaseOpticReader):
 
         self.data = deepcopy(self.data)
         self.data.surfaces = resolve_pickups(self.data.surfaces)
+        self._build_optic()
+        self._apply_solves()
+        return self.optic
+
+    def _build_optic(self) -> None:
+        """Build from the current resolved prescription without applying solves."""
         self.optic = Optic(self.data.name)
         self.optic.obj_space_telecentric = self.data.settings.get("telecentric", False)
         self._configure_surfaces()
         self._configure_wavelengths()
         self._configure_aperture()
         self._configure_fields()
-        self._apply_solves()
-        return self.optic
 
     def _configure_surfaces(self) -> None:
         """Configure all surfaces on the optic."""
@@ -305,14 +309,14 @@ class OsloToOpticConverter(BaseOpticReader):
                 # Also check the fallback table for the base name.
                 if base.upper() in _OSLO_GLASS_FALLBACK:
                     nd, vd = _OSLO_GLASS_FALLBACK[base.upper()]
-                    return AbbeMaterial(nd, vd, model="buchdahl")
+                    return self._fallback_material(name, nd, vd)
                 break
 
         # Step 3 – built-in OSLO fallback table.
         entry = _OSLO_GLASS_FALLBACK.get(name.upper())
         if entry is not None:
             nd, vd = entry
-            return AbbeMaterial(nd, vd, model="buchdahl")
+            return self._fallback_material(name, nd, vd)
 
         # Step 4 – cannot resolve; warn and fall back to air.
         if self.strict:
@@ -325,6 +329,13 @@ class OsloToOpticConverter(BaseOpticReader):
             stacklevel=4,
         )
         return "air"
+
+    def _fallback_material(self, name: str, nd: float, vd: float) -> AbbeMaterial:
+        message = f"OSLO glass {name!r} uses approximate historical Abbe dispersion"
+        if self.strict:
+            raise ValueError(message)
+        warnings.warn(message, UserWarning, stacklevel=4)
+        return AbbeMaterial(nd, vd, model="buchdahl")
 
     def _configure_aperture(self) -> None:
         aperture_data = self.data.aperture
@@ -429,7 +440,8 @@ class OsloToOpticConverter(BaseOpticReader):
 
     def _apply_solves(self) -> None:
         """Apply surface-specific solves, retaining saved values on warned failures."""
-        for index, data in sorted(self.data.surfaces.items()):
+        for index in sorted(self.data.surfaces):
+            data = self.data.surfaces[index]
             for command in SOLVES:
                 if command not in data:
                     continue
@@ -438,6 +450,20 @@ class OsloToOpticConverter(BaseOpticReader):
                     apply_solve(
                         self.optic, index, command, data[command], self.data.units
                     )
+                    key = "TH" if command in {"PY", "PYC", "EC"} else "RD"
+                    surface = self.optic.surfaces[index]
+                    value = (
+                        surface.thickness if key == "TH" else surface.geometry.radius
+                    )
+                    data[key] = float(be.asarray(value).item()) / self.data.units
+                    if any(
+                        sd.get("pickups")
+                        for i, sd in self.data.surfaces.items()
+                        if i > index
+                    ):
+                        self.data.surfaces = resolve_pickups(self.data.surfaces)
+                        self._build_optic()
+                        data = self.data.surfaces[index]
                 except (ValueError, RuntimeError, ArithmeticError) as exc:
                     self.optic = Optic.from_dict(saved)
                     message = f"OSLO {command} at surface {index}: {exc}"

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -20,7 +20,7 @@ from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
-from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve
+from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve, check_solve
 from optiland.fileio.oslo.syntax import decode_text, tokenize
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
@@ -453,31 +453,40 @@ class OsloToOpticConverter(BaseOpticReader):
 
     def _apply_solves(self) -> None:
         """Apply surface-specific solves, retaining saved values on warned failures."""
+        applied = []
         for index in sorted(self.data.surfaces):
-            data = self.data.surfaces[index]
             for command in SOLVES:
+                data = self.data.surfaces[index]
                 if command not in data:
                     continue
                 saved = self.optic.to_dict()
+                saved_surfaces = deepcopy(self.data.surfaces)
+                target = data[command]
                 try:
-                    apply_solve(
-                        self.optic, index, command, data[command], self.data.units
-                    )
+                    apply_solve(self.optic, index, command, target, self.data.units)
                     key = "TH" if command in {"PY", "PYC", "EC"} else "RD"
                     surface = self.optic.surfaces[index]
                     value = (
                         surface.thickness if key == "TH" else surface.geometry.radius
                     )
                     data[key] = float(be.asarray(value).item()) / self.data.units
-                    if any(
-                        sd.get("pickups")
-                        for i, sd in self.data.surfaces.items()
-                        if i > index
-                    ):
-                        self.data.surfaces = resolve_pickups(self.data.surfaces)
-                        self._build_optic()
-                        data = self.data.surfaces[index]
+                    self.data.surfaces = resolve_pickups(self.data.surfaces)
+                    self._build_optic()
+                    # Recomputing dependent geometry, NAP/FNO/PUK or GIH may
+                    # change the rays used by this solve or an earlier one.
+                    # Accept only a prescription that still meets every target.
+                    pending = (index, command, target)
+                    for solve_index, solve_command, solve_target in [*applied, pending]:
+                        check_solve(
+                            self.optic,
+                            solve_index,
+                            solve_command,
+                            solve_target,
+                            self.data.units,
+                        )
+                    applied.append(pending)
                 except (ValueError, RuntimeError, ArithmeticError) as exc:
+                    self.data.surfaces = saved_surfaces
                     self.optic = Optic.from_dict(saved)
                     message = f"OSLO {command} at surface {index}: {exc}"
                     if self.strict:

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -21,6 +21,7 @@ from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
 from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve
+from optiland.fileio.oslo.syntax import decode_text, tokenize
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
 from optiland.phase import LinearGratingPhaseProfile
@@ -247,7 +248,7 @@ class OsloToOpticConverter(BaseOpticReader):
 
         if material_raw.startswith("GLA "):
             rest = material_raw[4:].strip()
-            parts = rest.split()
+            parts = tokenize(rest)
             if not parts:
                 return "air"
 
@@ -256,11 +257,15 @@ class OsloToOpticConverter(BaseOpticReader):
             modeled = parts[0].upper() == "MOD"
             if modeled:
                 parts = parts[1:]
+            if not parts:
+                raise ValueError("GLA MOD requires refractive-index data")
             try:
                 float(parts[0])
             except ValueError:
-                name, parts = parts[0].strip('"'), parts[1:]
+                name, parts = decode_text(parts[0]), parts[1:]
             if not parts:
+                if modeled:
+                    raise ValueError("GLA MOD requires refractive-index data")
                 # Catalog glass (e.g. GLA BK7).
                 return self._resolve_catalog_glass(name)
             # Direct indices (e.g. GLA 1.573 1.573 1.573), or index data

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -233,6 +233,8 @@ class OsloToOpticConverter(BaseOpticReader):
             surface_params.update(self._coordinates[index])
 
         self.optic.surfaces.add(**surface_params)
+        if has_coord_transform:
+            self.optic.surfaces[index].thickness = th * scale
 
     def _resolve_material(
         self, material_raw: str, wavelengths: list[float] | None = None
@@ -399,7 +401,7 @@ class OsloToOpticConverter(BaseOpticReader):
         # If object is at infinity, ObjectHeightField is invalid in Optiland.
         # OSLO often uses OBH even for infinite objects, encoding the angle.
         # OSLO OBH sign convention: negative means below axis - take abs().
-        if field_type == "object_height" and be.isinf(self.optic.surfaces[0].thickness):
+        if field_type == "object_height" and self.optic.object_surface.is_infinite:
             field_type = "angle"
             distance = self.data.surfaces[0].get("TH", 1e10)
             y_coords = [

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -227,6 +227,18 @@ class OsloToOpticConverter(BaseOpticReader):
     ) -> None:
         scale = self.data.units
         surface_params = surface_geometry(data, scale)
+        # Native scalar traces use the base radius only. Constant, linear and
+        # quadratic sag terms can change the vertex, normal or paraxial power.
+        low_order = {"ASR": (1,), "ARA": (1, 2), "ASX": tuple(range(6))}
+        if any(data.get(f"AS{i}", 0) for i in low_order.get(data.get("ASP"), ())):
+            message = (
+                f"OSLO asphere at surface {index} has low-order sag terms ignored "
+                "by native paraxial analysis; real-ray geometry is retained, but "
+                "paraxial pupils, fields and solves may be inaccurate"
+            )
+            if self.strict:
+                raise ValueError(message)
+            warnings.warn(message, UserWarning, stacklevel=3)
         surface_params["index"] = index
         surface_params["is_stop"] = data.get("AST", False)
 

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -14,6 +14,7 @@ import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.fileio.base import BaseOpticReader
 from optiland.fileio.oslo.reader.apertures import physical_aperture
+from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
@@ -141,12 +142,33 @@ class OsloToOpticConverter(BaseOpticReader):
         """Configure all surfaces on the optic."""
         # Check if any surface has decenters or tilts
         has_coord_transform = any(
-            any(k in sd for k in ["DCX", "DCY", "DCZ", "TLA", "TLB", "TLC"])
+            any(
+                k in sd
+                for k in [
+                    "DCX",
+                    "DCY",
+                    "DCZ",
+                    "TLA",
+                    "TLB",
+                    "TLC",
+                    "GC",
+                    "RCO",
+                    "BEN",
+                    "TOX",
+                    "TOY",
+                    "TOZ",
+                ]
+            )
             for sd in self.data.surfaces.values()
         )
 
         # Determine if any surface is explicitly marked as the stop
         has_stop = any(sd.get("AST", False) for sd in self.data.surfaces.values())
+        self._coordinates = (
+            surface_coordinates(self.data.surfaces, self.data.units)
+            if has_coord_transform
+            else {}
+        )
 
         for idx in sorted(self.data.surfaces.keys()):
             surf_data = self.data.surfaces[idx]
@@ -186,43 +208,8 @@ class OsloToOpticConverter(BaseOpticReader):
         surface_params["aperture"] = physical_aperture(data, scale)
 
         if has_coord_transform:
-            # Resolve effective global position and orientation
-            # OSLO decenters/tilts are applied to the surface.
-            dx = data.get("DCX", 0.0) * scale
-            dy = data.get("DCY", 0.0) * scale
-            dz = data.get("DCZ", 0.0) * scale
-            rx = be.deg2rad(data.get("TLA", 0.0))
-            ry = be.deg2rad(data.get("TLB", 0.0))
-            rz = be.deg2rad(data.get("TLC", 0.0))
-
-            if dx != 0 or dy != 0 or dz != 0 or rx != 0 or ry != 0 or rz != 0:
-                # Apply transform to current CS
-                self.current_cs = CoordinateSystem(
-                    x=dx, y=dy, z=dz, rx=rx, ry=ry, rz=rz, reference_cs=self.current_cs
-                )
-
-            translation, _ = self.current_cs.get_effective_transform()
-            rx_, ry_, rz_ = self.current_cs.get_effective_rotation_euler()
-
-            surface_params.update(
-                {
-                    "x": float(translation[0]),
-                    "y": float(translation[1]),
-                    "z": float(translation[2]),
-                    "rx": float(rx_),
-                    "ry": float(ry_),
-                    "rz": float(rz_),
-                }
-            )
-
-            # Advance CS by thickness for next surface
-            if not be.isinf(th):
-                self.current_cs = CoordinateSystem(
-                    z=th * scale, reference_cs=self.current_cs
-                )
-        else:
-            # Standard sequential path, thickness handled by Optiland automatically
-            pass
+            surface_params.pop("thickness")
+            surface_params.update(self._coordinates[index])
 
         self.optic.surfaces.add(**surface_params)
 

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -22,6 +22,7 @@ from optiland.fileio.oslo.reader.pickups import resolve_pickups
 from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
+from optiland.phase import LinearGratingPhaseProfile
 
 # ---------------------------------------------------------------------------
 # Fallback glass catalog for OSLO glass names not in the refractiveindex.info
@@ -195,8 +196,23 @@ class OsloToOpticConverter(BaseOpticReader):
 
         # Is paraxial?
         if "PFL" in data:
+            message = "OSLO PFL perfect imagery is approximated by a paraxial thin lens"
+            if self.strict:
+                raise ValueError(message)
+            warnings.warn(message, UserWarning, stacklevel=3)
             surface_params["surface_type"] = "paraxial"
             surface_params["f"] = data["PFL"] * scale
+
+        if "GSP" in data or "GOR" in data:
+            spacing, order = data.get("GSP", 0.0), data.get("GOR", 1)
+            if int(order) != order or spacing < 0 or (spacing == 0 and order != 0):
+                raise ValueError(
+                    "OSLO GSP requires positive spacing and GOR an integer order"
+                )
+            if spacing and order:
+                surface_params["phase_profile"] = LinearGratingPhaseProfile(
+                    spacing * scale, angle=math.pi / 2, order=int(order)
+                )
 
         # Handle material
         material_raw = data.get("material", "AIR")

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -146,26 +146,22 @@ class OsloToOpticConverter(BaseOpticReader):
 
     def _configure_surfaces(self) -> None:
         """Configure all surfaces on the optic."""
-        # Check if any surface has decenters or tilts
+        coordinate_commands = {
+            "DCX",
+            "DCY",
+            "DCZ",
+            "TLA",
+            "TLB",
+            "TLC",
+            "GC",
+            "RCO",
+            "BEN",
+            "TOX",
+            "TOY",
+            "TOZ",
+        }
         has_coord_transform = any(
-            any(
-                k in sd
-                for k in [
-                    "DCX",
-                    "DCY",
-                    "DCZ",
-                    "TLA",
-                    "TLB",
-                    "TLC",
-                    "GC",
-                    "RCO",
-                    "BEN",
-                    "TOX",
-                    "TOY",
-                    "TOZ",
-                ]
-            )
-            for sd in self.data.surfaces.values()
+            coordinate_commands.intersection(sd) for sd in self.data.surfaces.values()
         )
 
         # Determine if any surface is explicitly marked as the stop

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING, Any
 import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.fileio.base import BaseOpticReader
+from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
-from optiland.fileio.oslo.surfaces import get_handler
 from optiland.materials import AbbeMaterial, IdealMaterial, Material
 from optiland.optic import Optic
 
@@ -159,16 +159,8 @@ class OsloToOpticConverter(BaseOpticReader):
     def _configure_surface(
         self, index: int, data: dict[str, Any], has_coord_transform: bool
     ) -> None:
-        # Determine surface type
-        # Default is standard. If AD, AE, AF, or AG are present, it's even_asphere.
-        oslo_type = "standard"
-        if any(k in data for k in ["AD", "AE", "AF", "AG"]):
-            oslo_type = "even_asphere"
-
-        handler = get_handler(oslo_type)
-        surface_params = handler.parse(data)
         scale = self.data.units
-        surface_params["radius"] *= scale
+        surface_params = surface_geometry(data, scale)
         surface_params["index"] = index
         surface_params["is_stop"] = data.get("AST", False)
 

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -138,7 +138,45 @@ class OsloToOpticConverter(BaseOpticReader):
         self.data.surfaces = resolve_pickups(self.data.surfaces)
         self._build_optic()
         self._apply_solves()
+        self._apply_image_focus()
         return self.optic
+
+    def _apply_image_focus(self) -> None:
+        """Move the detector by OSLO's defocus after nominal solves and pickups."""
+        image_index = max(self.data.surfaces)
+        shift = self.data.surfaces[image_index].get("TH", 0.0)
+        image = self.optic.surfaces[image_index]
+        image.thickness = 0.0
+        if not shift:
+            return
+        if image_index < 2:
+            raise ValueError("OSLO image focus shift requires an interior surface")
+        if "GC" in self.data.surfaces[image_index]:
+            raise ValueError(
+                "OSLO image focus shift with a global reference is not mapped"
+            )
+
+        # Image TH adds to the preceding nominal gap; it does not advance a
+        # nonexistent next surface. Apply it after solves so PY=0 may retain
+        # deliberate defocus. Program Reference pp. 46 and 122:
+        # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=60
+        if self._coordinates:
+            # Reuse the coordinate convention, including bends and returns,
+            # rather than moving a tilted image leg along global z.
+            surfaces = deepcopy(self.data.surfaces)
+            previous = surfaces[image_index - 1]
+            previous["TH"] = previous.get("TH", 0.0) + shift
+            position = surface_coordinates(surfaces, self.data.units)[image_index]
+            for axis in ("x", "y", "z"):
+                setattr(image.geometry.cs, axis, be.array(position[axis]))
+        else:
+            image.geometry.cs.z = image.geometry.cs.z + shift * self.data.units
+        self.optic.surfaces[image_index - 1].thickness += shift * self.data.units
+        if image.is_stop:
+            # Moving the stop moves its entrance pupil. Preserve OSLO's beam
+            # specification with the new pupil while keeping nominal GIH fields.
+            self._configure_aperture()
+            self._configure_telecentric_launch()
 
     def _build_optic(self) -> None:
         """Build from the current resolved prescription without applying solves."""

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
+from optiland.fields.field_types import ObjectHeightField
 from optiland.fileio.base import BaseOpticReader
 from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.reader.apertures import physical_aperture
@@ -139,10 +140,46 @@ class OsloToOpticConverter(BaseOpticReader):
         """Build from the current resolved prescription without applying solves."""
         self.optic = Optic(self.data.name)
         self.optic.obj_space_telecentric = self.data.settings.get("telecentric", False)
+        self.optic.fields.set_telecentric(self.optic.obj_space_telecentric)
         self._configure_surfaces()
         self._configure_wavelengths()
         self._configure_aperture()
         self._configure_fields()
+        self._configure_telecentric_launch()
+
+    def _configure_telecentric_launch(self) -> None:
+        """Adapt supported TELE prescriptions to the native real-ray launcher."""
+        if not self.optic.obj_space_telecentric:
+            return
+        if (
+            self.optic.object_surface.is_infinite
+            or not isinstance(self.optic.fields.field_definition, ObjectHeightField)
+            or float(
+                self.optic.object_surface.material_post.n(
+                    self.optic.primary_wavelength
+                ).item()
+            )
+            != 1
+            or not self.optic.surfaces.build_paraxial_path().entry_is_positive_z
+        ):
+            message = (
+                "OSLO TELE real-ray launch currently requires finite object-height "
+                "fields in air and entry along +z"
+            )
+            if self.strict:
+                raise ValueError(message)
+            warnings.warn(message, UserWarning, stacklevel=3)
+            return
+        if self.optic.aperture.ap_type != "objectNA":
+            # Keep the axial cone fixed while allowing every field point's
+            # chief ray to launch parallel to the axis. The native TELE aimer
+            # expects the cone's sine as an object-NA aperture in air.
+            slope = abs(float(self.optic.paraxial.marginal_ray()[1][0].item()))
+            self.optic.set_aperture("objectNA", math.sin(math.atan(slope)))
+        if not 0 < self.optic.aperture.value < 1:
+            raise ValueError(
+                "OSLO TELE launch requires object NA strictly between 0 and 1"
+            )
 
     def _configure_surfaces(self) -> None:
         """Configure all surfaces on the optic."""

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -95,8 +95,9 @@ class OsloToOpticConverter(BaseOpticReader):
         oslo_data: OsloDataModel containing the OSLO optical system data.
     """
 
-    def __init__(self, oslo_data: OsloDataModel | None = None):
+    def __init__(self, oslo_data: OsloDataModel | None = None, *, strict: bool = False):
         self.data = oslo_data
+        self.strict = strict
         self.optic: Optic | None = None
         self.current_cs = CoordinateSystem()
         self._py_surface_indices: list[int] = []
@@ -110,7 +111,7 @@ class OsloToOpticConverter(BaseOpticReader):
         Returns:
             A configured Optic instance.
         """
-        self.data = OsloDataParser(source).parse()
+        self.data = OsloDataParser(source, strict=self.strict).parse()
         self.current_cs = CoordinateSystem()
         self._py_surface_indices = []
         return self.convert()

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -26,6 +26,7 @@ from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
 from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve, check_solve
 from optiland.fileio.oslo.syntax import decode_text, tokenize
+from optiland.fileio.oslo.validation import validate_object_na
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
 from optiland.phase import LinearGratingPhaseProfile
@@ -416,7 +417,9 @@ class OsloToOpticConverter(BaseOpticReader):
             self.optic.set_aperture("EPD", diameter)
 
         if "NAO" in aperture_data:
-            self.optic.set_aperture("objectNA", aperture_data["NAO"])
+            value = aperture_data["NAO"]
+            validate_object_na(self.optic, value)
+            self.optic.set_aperture("objectNA", value)
         if any(key in aperture_data for key in ("NAP", "FNO", "PUK")):
             # OSLO's image NA is an aplanatic paraxial specification. Scale a
             # unit pupil using its image-space reduced slope (n * u).

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -15,7 +15,7 @@ from optiland.coordinate_system import CoordinateSystem
 from optiland.fileio.base import BaseOpticReader
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
-from optiland.materials import AbbeMaterial, IdealMaterial, Material
+from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
 
 # ---------------------------------------------------------------------------
@@ -178,7 +178,9 @@ class OsloToOpticConverter(BaseOpticReader):
 
         # Handle material
         material_raw = data.get("material", "AIR")
-        surface_params["material"] = self._resolve_material(material_raw)
+        surface_params["material"] = self._resolve_material(
+            material_raw, data.get("glass_wavelengths")
+        )
 
         # Handle aperture (AP is radius in OSLO).
         # Skip sentinel values like AP 4e9 which mean "infinite aperture".
@@ -233,7 +235,9 @@ class OsloToOpticConverter(BaseOpticReader):
         if "PY" in data:
             self._py_surface_indices.append(index)
 
-    def _resolve_material(self, material_raw: str) -> Any:
+    def _resolve_material(
+        self, material_raw: str, wavelengths: list[float] | None = None
+    ) -> Any:
         if material_raw == "AIR":
             return "air"
         if material_raw == "RFL":
@@ -245,31 +249,38 @@ class OsloToOpticConverter(BaseOpticReader):
             if not parts:
                 return "air"
 
-            # Case 1: Catalog Glass (e.g. GLA BK7)
-            if len(parts) == 1:
-                return self._resolve_catalog_glass(parts[0])
-
-            # Case 2: Direct Indices (e.g. GLA 1.573 1.573 1.573)
-            # Case 3: Modeled Glass (e.g. GLA MOD G1 1.6489 1.662...)
+            name = ""
+            modeled = parts[0].upper() == "MOD"
+            if modeled:
+                parts = parts[1:]
             try:
-                if parts[0].upper() == "MOD":
-                    # MOD <name> <nd> <n1> <n2>
-                    nd = float(parts[2])
-                    if len(parts) >= 5:
-                        n1 = float(parts[3])
-                        n2 = float(parts[4])
-                        return self._create_abbe_material(nd, n1, n2)
-                    return IdealMaterial(nd)
-                else:
-                    # <nd> <n1> <n2>
-                    nd = float(parts[0])
-                    if len(parts) >= 3:
-                        n1 = float(parts[1])
-                        n2 = float(parts[2])
-                        return self._create_abbe_material(nd, n1, n2)
-                    return IdealMaterial(nd)
-            except (ValueError, IndexError):
-                return "air"
+                float(parts[0])
+            except ValueError:
+                name, parts = parts[0].strip('"'), parts[1:]
+            if not parts:
+                return self._resolve_catalog_glass(name)
+            indices = [float(value) for value in parts]
+            if any(value <= 0 for value in indices):
+                raise ValueError(
+                    f"OSLO glass {name!r} requires positive refractive indices"
+                )
+            if modeled and len(indices) == 2:
+                # Interactive model-glass form specifies index and Abbe number.
+                # Saved legacy MOD records instead contain explicit index samples.
+                if self.strict:
+                    raise ValueError("GLA MOD index/Abbe dispersion is approximate")
+                warnings.warn(
+                    "OSLO GLA MOD index/Abbe uses Optiland's Buchdahl model",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return AbbeMaterial(*indices, model="buchdahl")
+            if len(set(indices)) == 1:
+                return IdealMaterial(indices[0])
+            wavelengths = wavelengths or [0.58756, 0.48613, 0.65627]
+            if len(indices) != len(wavelengths):
+                raise ValueError(f"OSLO glass {name!r} index/wavelength counts differ")
+            return TabulatedMaterial(wavelengths, indices, name=name)
 
         return "air"
 
@@ -309,6 +320,8 @@ class OsloToOpticConverter(BaseOpticReader):
             return AbbeMaterial(nd, vd, model="buchdahl")
 
         # Step 4 – cannot resolve; warn and fall back to air.
+        if self.strict:
+            raise ValueError(f"OSLO glass '{name}' could not be resolved")
         warnings.warn(
             f"OSLO glass '{name}' could not be resolved and will be treated as "
             "air.  Add it to _OSLO_GLASS_FALLBACK in oslo/reader/converter.py "
@@ -317,15 +330,6 @@ class OsloToOpticConverter(BaseOpticReader):
             stacklevel=4,
         )
         return "air"
-
-    def _create_abbe_material(self, nd: float, n1: float, n2: float) -> Any:
-        # n1 = nF (F line 0.48613 µm), n2 = nC (C line 0.65627 µm)
-        # Abbe V = (nd - 1) / (nF - nC)
-        if n1 != n2:
-            vd = (nd - 1.0) / (n1 - n2)
-            if vd > 0:
-                return AbbeMaterial(nd, vd, model="buchdahl")
-        return IdealMaterial(nd)
 
     def _configure_aperture(self) -> None:
         aperture_data = self.data.aperture

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -12,13 +12,13 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
-from optiland.coordinate_system import CoordinateSystem
 from optiland.fileio.base import BaseOpticReader
 from optiland.fileio.oslo.reader.apertures import physical_aperture
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.geometry import surface_geometry
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
+from optiland.fileio.oslo.reader.solves import SOLVES, apply_solve
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.optic import Optic
 
@@ -103,8 +103,6 @@ class OsloToOpticConverter(BaseOpticReader):
         self.data = oslo_data
         self.strict = strict
         self.optic: Optic | None = None
-        self.current_cs = CoordinateSystem()
-        self._py_surface_indices: list[int] = []
 
     def read(self, source: str) -> Optic:
         """Read an OSLO file and return a fully-configured Optic.
@@ -116,8 +114,6 @@ class OsloToOpticConverter(BaseOpticReader):
             A configured Optic instance.
         """
         self.data = OsloDataParser(source, strict=self.strict).parse()
-        self.current_cs = CoordinateSystem()
-        self._py_surface_indices = []
         return self.convert()
 
     def convert(self) -> Optic:
@@ -132,14 +128,12 @@ class OsloToOpticConverter(BaseOpticReader):
         self.data = deepcopy(self.data)
         self.data.surfaces = resolve_pickups(self.data.surfaces)
         self.optic = Optic(self.data.name)
-        self.current_cs = CoordinateSystem()
-        self._py_surface_indices = []
         self.optic.obj_space_telecentric = self.data.settings.get("telecentric", False)
         self._configure_surfaces()
         self._configure_wavelengths()
         self._configure_aperture()
         self._configure_fields()
-        self._apply_py_solves()
+        self._apply_solves()
         return self.optic
 
     def _configure_surfaces(self) -> None:
@@ -216,11 +210,6 @@ class OsloToOpticConverter(BaseOpticReader):
             surface_params.update(self._coordinates[index])
 
         self.optic.surfaces.add(**surface_params)
-
-        # Track surfaces with a PY (paraxial thickness) solve.
-        # Actual solve is applied in _apply_py_solves() after full configuration.
-        if "PY" in data:
-            self._py_surface_indices.append(index)
 
     def _resolve_material(
         self, material_raw: str, wavelengths: list[float] | None = None
@@ -373,20 +362,27 @@ class OsloToOpticConverter(BaseOpticReader):
         for y in fields_to_add:
             self.optic.fields.add(y=y, x=0.0)
 
-    def _apply_py_solves(self) -> None:
-        """Apply paraxial thickness (PY) solves.
-
-        PY 0.0 in an OSLO file means "set this surface's thickness so that
-        the paraxial marginal ray focuses at the image plane."  We implement
-        this via image_solve(), which drives F2() to zero by correctly setting
-        the image distance.
-        """
-        if not self._py_surface_indices:
-            return
-        import contextlib
-
-        with contextlib.suppress(Exception):
-            self.optic.updater.image_solve()
+    def _apply_solves(self) -> None:
+        """Apply surface-specific solves, retaining saved values on warned failures."""
+        for index, data in sorted(self.data.surfaces.items()):
+            for command in SOLVES:
+                if command not in data:
+                    continue
+                saved = self.optic.to_dict()
+                try:
+                    apply_solve(
+                        self.optic, index, command, data[command], self.data.units
+                    )
+                except (ValueError, RuntimeError, ArithmeticError) as exc:
+                    self.optic = Optic.from_dict(saved)
+                    message = f"OSLO {command} at surface {index}: {exc}"
+                    if self.strict:
+                        raise ValueError(message) from exc
+                    warnings.warn(
+                        message + "; retained saved prescription",
+                        UserWarning,
+                        stacklevel=3,
+                    )
 
     def _configure_wavelengths(self) -> None:
         wl_data = self.data.wavelengths

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -347,7 +347,7 @@ class OsloToOpticConverter(BaseOpticReader):
         return AbbeMaterial(nd, vd, model="buchdahl")
 
     def _configure_aperture(self) -> None:
-        aperture_data = self.data.aperture
+        aperture_data = self.data.aperture or {"EPD": 2.0}
         if (
             "FNO" in aperture_data
             and self.optic.object_surface.is_infinite
@@ -357,11 +357,22 @@ class OsloToOpticConverter(BaseOpticReader):
                 .item()
             )
             == 1.0
+            and 0 < float(self.optic.paraxial.f2()) < math.inf
         ):
             self.optic.set_aperture("imageFNO", aperture_data["FNO"])
             return
         if "EPD" in aperture_data:
-            self.optic.set_aperture("EPD", aperture_data["EPD"] * self.data.units)
+            # The intermediate model stores twice OSLO's EBR under its legacy
+            # EPD key. EBR is measured at surface 1 (Program Reference p. 120),
+            # which need not coincide with the entrance pupil for finite objects.
+            diameter = aperture_data["EPD"] * self.data.units
+            self.optic.set_aperture("EPD", 1.0)
+            if not self.optic.object_surface.is_infinite:
+                height = abs(float(self.optic.paraxial.marginal_ray()[0][1].item()))
+                if not math.isfinite(height) or height == 0:
+                    raise ValueError("EBR requires a finite nonzero beam at surface 1")
+                diameter /= 2 * height
+            self.optic.set_aperture("EPD", diameter)
 
         if "NAO" in aperture_data:
             self.optic.set_aperture("objectNA", aperture_data["NAO"])
@@ -382,8 +393,6 @@ class OsloToOpticConverter(BaseOpticReader):
             if reduced_slope == 0:
                 raise ValueError("NAP cannot define an aperture for an afocal system")
             self.optic.set_aperture("EPD", target / reduced_slope)
-        if not aperture_data:
-            self.optic.set_aperture("EPD", 2.0 * self.data.units)
 
     def _configure_fields(self) -> None:
         field_data = self.data.fields

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -7,6 +7,7 @@ Kramer Harrison, 2026
 
 from __future__ import annotations
 
+import math
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
@@ -309,15 +310,24 @@ class OsloToOpticConverter(BaseOpticReader):
 
     def _configure_aperture(self) -> None:
         aperture_data = self.data.aperture
+        if (
+            "FNO" in aperture_data
+            and self.optic.object_surface.is_infinite
+            and float(
+                self.optic.surfaces[-1]
+                .material_pre.n(self.optic.primary_wavelength)
+                .item()
+            )
+            == 1.0
+        ):
+            self.optic.set_aperture("imageFNO", aperture_data["FNO"])
+            return
         if "EPD" in aperture_data:
             self.optic.set_aperture("EPD", aperture_data["EPD"] * self.data.units)
 
-        if "FNO" in aperture_data:
-            self.optic.set_aperture("imageFNO", aperture_data["FNO"])
-
         if "NAO" in aperture_data:
             self.optic.set_aperture("objectNA", aperture_data["NAO"])
-        if "NAP" in aperture_data:
+        if any(key in aperture_data for key in ("NAP", "FNO", "PUK")):
             # OSLO's image NA is an aplanatic paraxial specification. Scale a
             # unit pupil using its image-space reduced slope (n * u).
             self.optic.set_aperture("EPD", 1.0)
@@ -326,9 +336,14 @@ class OsloToOpticConverter(BaseOpticReader):
                 self.optic.primary_wavelength
             )
             reduced_slope = abs(float((n_image * slopes[-2]).item()))
+            target = aperture_data.get("NAP")
+            if "FNO" in aperture_data:
+                target = 1 / (2 * aperture_data["FNO"])
+            elif "PUK" in aperture_data:
+                target = aperture_data["PUK"] * float(n_image.item())
             if reduced_slope == 0:
                 raise ValueError("NAP cannot define an aperture for an afocal system")
-            self.optic.set_aperture("EPD", aperture_data["NAP"] / reduced_slope)
+            self.optic.set_aperture("EPD", target / reduced_slope)
         if not aperture_data:
             self.optic.set_aperture("EPD", 2.0 * self.data.units)
 
@@ -336,6 +351,21 @@ class OsloToOpticConverter(BaseOpticReader):
         field_data = self.data.fields
         field_type = field_data.get("type", "angle")
         y_coords = field_data.get("y", [0.0])
+
+        if field_type == "gaussian_image_height":
+            height = y_coords[0] * self.data.units
+            if self.optic.object_surface.is_infinite:
+                field_type = "angle"
+                y_coords = [
+                    math.degrees(math.atan(height / float(self.optic.paraxial.f2())))
+                ]
+            else:
+                field_type = "object_height"
+                y_coords = [
+                    height
+                    / float(self.optic.paraxial.magnification())
+                    / self.data.units
+                ]
 
         # If object is at infinity, ObjectHeightField is invalid in Optiland.
         # OSLO often uses OBH even for infinite objects, encoding the angle.
@@ -353,6 +383,23 @@ class OsloToOpticConverter(BaseOpticReader):
             y_coords = [y * self.data.units for y in y_coords]
 
         self.optic.fields.set_type(field_type)
+
+        if "points" in field_data:
+            maximum = y_coords[0]
+            for point in field_data["points"].values():
+                coords = dict(point)
+                for axis in ("x", "y"):
+                    fraction = point[axis]
+                    coords[axis] = (
+                        math.degrees(
+                            math.atan(fraction * math.tan(math.radians(maximum)))
+                        )
+                        if field_type == "angle"
+                        else fraction * maximum
+                    )
+                self.optic.fields.add(**coords)
+            if self.optic.fields.num_fields:
+                return
 
         # OSLO stores only the maximum field value.  Expand to three standard
         # field points (on-axis, 0.7×max, full field) for usable analysis.

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -252,6 +252,7 @@ class OsloToOpticConverter(BaseOpticReader):
                 return "air"
 
             name = ""
+            # Modeled glass (e.g. GLA MOD G1 1.6489 1.662...).
             modeled = parts[0].upper() == "MOD"
             if modeled:
                 parts = parts[1:]
@@ -260,14 +261,18 @@ class OsloToOpticConverter(BaseOpticReader):
             except ValueError:
                 name, parts = parts[0].strip('"'), parts[1:]
             if not parts:
+                # Catalog glass (e.g. GLA BK7).
                 return self._resolve_catalog_glass(name)
+            # Direct indices (e.g. GLA 1.573 1.573 1.573), or index data
+            # remaining after a named/model-glass prefix.
             indices = [float(value) for value in parts]
             if any(value <= 0 for value in indices):
                 raise ValueError(
                     f"OSLO glass {name!r} requires positive refractive indices"
                 )
             if modeled and len(indices) == 2:
-                # Interactive model-glass form specifies index and Abbe number.
+                # Interactive model glass (e.g. GLA MOD 1.6 50) specifies
+                # refractive index and Abbe number.
                 # Saved legacy MOD records instead contain explicit index samples.
                 if self.strict:
                     raise ValueError("GLA MOD index/Abbe dispersion is approximate")

--- a/optiland/fileio/oslo/reader/converter.py
+++ b/optiland/fileio/oslo/reader/converter.py
@@ -126,10 +126,13 @@ class OsloToOpticConverter(BaseOpticReader):
             raise ValueError("No OSLO data to convert.")
 
         self.optic = Optic(self.data.name)
+        self.current_cs = CoordinateSystem()
+        self._py_surface_indices = []
+        self.optic.obj_space_telecentric = self.data.settings.get("telecentric", False)
         self._configure_surfaces()
+        self._configure_wavelengths()
         self._configure_aperture()
         self._configure_fields()
-        self._configure_wavelengths()
         self._apply_py_solves()
         return self.optic
 
@@ -164,20 +167,22 @@ class OsloToOpticConverter(BaseOpticReader):
 
         handler = get_handler(oslo_type)
         surface_params = handler.parse(data)
+        scale = self.data.units
+        surface_params["radius"] *= scale
         surface_params["index"] = index
         surface_params["is_stop"] = data.get("AST", False)
 
         th = data.get("TH", 0.0)
         # OSLO uses 1e10 as "infinity"; allow for floating-point imprecision
         # (e.g., 9.9999999996e+09 appears in practice).
-        if th >= 9.9e9:
-            th = be.inf
-        surface_params["thickness"] = th
+        if abs(th) >= 9.9e9:
+            th = be.inf if th > 0 else -be.inf
+        surface_params["thickness"] = th * scale
 
         # Is paraxial?
         if "PFL" in data:
             surface_params["surface_type"] = "paraxial"
-            surface_params["f"] = data["PFL"]
+            surface_params["f"] = data["PFL"] * scale
 
         # Handle material
         material_raw = data.get("material", "AIR")
@@ -188,14 +193,14 @@ class OsloToOpticConverter(BaseOpticReader):
         if "AP" in data and data["AP"] < 1e6:
             from optiland.physical_apertures import RadialAperture
 
-            surface_params["aperture"] = RadialAperture(r_max=data["AP"])
+            surface_params["aperture"] = RadialAperture(r_max=data["AP"] * scale)
 
         if has_coord_transform:
             # Resolve effective global position and orientation
             # OSLO decenters/tilts are applied to the surface.
-            dx = data.get("DCX", 0.0)
-            dy = data.get("DCY", 0.0)
-            dz = data.get("DCZ", 0.0)
+            dx = data.get("DCX", 0.0) * scale
+            dy = data.get("DCY", 0.0) * scale
+            dz = data.get("DCZ", 0.0) * scale
             rx = be.deg2rad(data.get("TLA", 0.0))
             ry = be.deg2rad(data.get("TLB", 0.0))
             rz = be.deg2rad(data.get("TLC", 0.0))
@@ -221,9 +226,10 @@ class OsloToOpticConverter(BaseOpticReader):
             )
 
             # Advance CS by thickness for next surface
-            th = data.get("TH", 0.0)
             if not be.isinf(th):
-                self.current_cs = CoordinateSystem(z=th, reference_cs=self.current_cs)
+                self.current_cs = CoordinateSystem(
+                    z=th * scale, reference_cs=self.current_cs
+                )
         else:
             # Standard sequential path, thickness handled by Optiland automatically
             pass
@@ -332,19 +338,30 @@ class OsloToOpticConverter(BaseOpticReader):
     def _configure_aperture(self) -> None:
         aperture_data = self.data.aperture
         if "EPD" in aperture_data:
-            self.optic.set_aperture("EPD", aperture_data["EPD"])
+            self.optic.set_aperture("EPD", aperture_data["EPD"] * self.data.units)
 
         if "FNO" in aperture_data:
             self.optic.set_aperture("imageFNO", aperture_data["FNO"])
 
         if "NAO" in aperture_data:
             self.optic.set_aperture("objectNA", aperture_data["NAO"])
+        if "NAP" in aperture_data:
+            # OSLO's image NA is an aplanatic paraxial specification. Scale a
+            # unit pupil using its image-space reduced slope (n * u).
+            self.optic.set_aperture("EPD", 1.0)
+            _, slopes = self.optic.paraxial.marginal_ray()
+            n_image = self.optic.surfaces[-1].material_pre.n(
+                self.optic.primary_wavelength
+            )
+            reduced_slope = abs(float((n_image * slopes[-2]).item()))
+            if reduced_slope == 0:
+                raise ValueError("NAP cannot define an aperture for an afocal system")
+            self.optic.set_aperture("EPD", aperture_data["NAP"] / reduced_slope)
+        if not aperture_data:
+            self.optic.set_aperture("EPD", 2.0 * self.data.units)
 
     def _configure_fields(self) -> None:
         field_data = self.data.fields
-        if not field_data:
-            return
-
         field_type = field_data.get("type", "angle")
         y_coords = field_data.get("y", [0.0])
 
@@ -353,10 +370,15 @@ class OsloToOpticConverter(BaseOpticReader):
         # OSLO OBH sign convention: negative means below axis - take abs().
         if field_type == "object_height" and be.isinf(self.optic.surfaces[0].thickness):
             field_type = "angle"
-            y_coords = [abs(float(be.degrees(be.arctan(y / 1e10)))) for y in y_coords]
+            distance = self.data.surfaces[0].get("TH", 1e10)
+            y_coords = [
+                abs(float(be.degrees(be.arctan(y / distance)))) for y in y_coords
+            ]
         elif field_type == "angle":
             # ANG is always positive in OSLO for the max half-angle.
             y_coords = [abs(y) for y in y_coords]
+        else:
+            y_coords = [y * self.data.units for y in y_coords]
 
         self.optic.fields.set_type(field_type)
 

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -84,6 +84,8 @@ def surface_coordinates(
                 raise ValueError(
                     "OSLO BEN currently supports single-axis local mirror tilts"
                 )
+            if data.get("material") != "RFL":
+                raise ValueError("OSLO BEN requires a reflecting surface")
             extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
             next_rotation = rotation @ extra
         distance = data.get("TH", 0.0)

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -45,6 +45,8 @@ def surface_coordinates(
                     f"OSLO GC at surface {index} requires a preceding surface"
                 )
             base_position, base_rotation = (v.copy() for v in frames[ref])
+        if index > 0 and not np.all(np.isfinite(base_position)):
+            raise ValueError("OSLO coordinate reference must have a finite position")
         bases[index] = (base_position, base_rotation)
         order = data.get("DT", 1)
         if order not in {1, -1}:
@@ -85,6 +87,10 @@ def surface_coordinates(
             extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
             next_rotation = rotation @ extra
         distance = data.get("TH", 0.0)
+        if 0 < index < max(surfaces) and abs(distance) >= 9.9e9:
+            raise ValueError(
+                "OSLO infinite thickness with coordinate transforms is not mapped"
+            )
         if index != 0 and abs(distance) < 9.9e9:
             next_position = next_position + next_rotation[:, 2] * distance * scale
     return result

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -8,6 +8,8 @@ from typing import Any
 import numpy as np
 from scipy.spatial.transform import Rotation
 
+from optiland.fileio.oslo.constants import OBJECT_INFINITY_THRESHOLD
+
 
 def reference_index(value: int, current: int) -> int:
     """Resolve an OSLO negative relative or nonnegative absolute surface index."""
@@ -34,7 +36,7 @@ def surface_coordinates(
             distance = data.get("TH", 0.0)
             base_position[2] = (
                 -distance * scale
-                if abs(distance) < 9.9e9
+                if abs(distance) < OBJECT_INFINITY_THRESHOLD
                 else -math.copysign(math.inf, distance)
             )
         elif index == 1:

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -8,7 +8,10 @@ from typing import Any
 import numpy as np
 from scipy.spatial.transform import Rotation
 
-from optiland.fileio.oslo.constants import OBJECT_INFINITY_THRESHOLD
+from optiland.fileio.oslo.constants import (
+    OBJECT_INFINITY_THRESHOLD,
+    THICKNESS_INFINITY_THRESHOLD,
+)
 
 
 def reference_index(value: int, current: int) -> int:
@@ -94,10 +97,10 @@ def surface_coordinates(
             extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
             next_rotation = rotation @ extra
         distance = data.get("TH", 0.0)
-        if 0 < index < last_index and abs(distance) >= 9.9e9:
+        if 0 < index < last_index and abs(distance) >= THICKNESS_INFINITY_THRESHOLD:
             raise ValueError(
                 "OSLO infinite thickness with coordinate transforms is not mapped"
             )
-        if index != 0 and abs(distance) < 9.9e9:
+        if index != 0 and abs(distance) < THICKNESS_INFINITY_THRESHOLD:
             next_position = next_position + next_rotation[:, 2] * distance * scale
     return result

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -1,0 +1,90 @@
+"""OSLO intrinsic rotations and local/global coordinate references."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+
+def reference_index(value: int, current: int) -> int:
+    """Resolve an OSLO negative relative or nonnegative absolute surface index."""
+    return current + value if value < 0 else value
+
+
+def surface_coordinates(
+    surfaces: dict[int, dict[str, Any]], scale: float
+) -> dict[int, dict[str, float]]:
+    """Build absolute poses without passing incompatible thickness/z arguments.
+
+    OSLO rotations are intrinsic, about -x, -y and +z. DT=1 translates then
+    rotates XYZ; DT=-1 rotates ZYX then translates. See Optics Reference pp.
+    142–145 and Program Reference pp. 65–68.
+    """
+    frames = {}
+    bases = {}
+    result = {}
+    next_position, next_rotation = np.zeros(3), np.eye(3)
+    for index, data in sorted(surfaces.items()):
+        base_position, base_rotation = next_position.copy(), next_rotation.copy()
+        if index == 0:
+            distance = data.get("TH", 0.0)
+            base_position[2] = (
+                -distance * scale
+                if abs(distance) < 9.9e9
+                else -math.copysign(math.inf, distance)
+            )
+        elif index == 1:
+            base_position, base_rotation = np.zeros(3), np.eye(3)
+        if "GC" in data:
+            ref = reference_index(int(data["GC"]), index)
+            if ref not in frames:
+                raise ValueError(
+                    f"OSLO GC at surface {index} requires a preceding surface"
+                )
+            base_position, base_rotation = (v.copy() for v in frames[ref])
+        bases[index] = (base_position, base_rotation)
+        order = data.get("DT", 1)
+        if order not in {1, -1}:
+            raise ValueError("OSLO DT must be 1 (decenter/tilt) or -1 (tilt/decenter)")
+        angles = [-data.get("TLA", 0.0), -data.get("TLB", 0.0), data.get("TLC", 0.0)]
+        rotation = Rotation.from_euler(
+            "XYZ" if order == 1 else "ZYX",
+            angles if order == 1 else angles[::-1],
+            degrees=True,
+        ).as_matrix()
+        shift = np.array([data.get(k, 0.0) for k in ("DCX", "DCY", "DCZ")]) * scale
+        pivot = np.array([data.get(k, 0.0) for k in ("TOX", "TOY", "TOZ")]) * scale
+        shift = (shift if order == 1 else rotation @ shift) + pivot - rotation @ pivot
+        position = base_position + base_rotation @ shift
+        rotation = base_rotation @ rotation
+        frames[index] = (position, rotation)
+        result[index] = dict(zip(("x", "y", "z"), position.tolist(), strict=True))
+        result[index].update(
+            zip(
+                ("rx", "ry", "rz"),
+                Rotation.from_matrix(rotation).as_euler("xyz").tolist(),
+                strict=True,
+            )
+        )
+        next_position, next_rotation = position, rotation
+        if "RCO" in data:
+            ref = reference_index(int(data["RCO"]), index)
+            if ref not in frames:
+                raise ValueError(
+                    f"OSLO RCO at surface {index} references an unavailable surface"
+                )
+            next_position, next_rotation = bases[index] if ref == index else frames[ref]
+        if data.get("BEN"):
+            if "GC" in data or "RCO" in data or (angles[0] and angles[1]) or angles[2]:
+                raise ValueError(
+                    "OSLO BEN currently supports single-axis local mirror tilts"
+                )
+            extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
+            next_rotation = rotation @ extra
+        distance = data.get("TH", 0.0)
+        if index != 0 and abs(distance) < 9.9e9:
+            next_position = next_position + next_rotation[:, 2] * distance * scale
+    return result

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -26,6 +26,7 @@ def surface_coordinates(
     frames = {}
     bases = {}
     result = {}
+    last_index = max(surfaces, default=0)
     next_position, next_rotation = np.zeros(3), np.eye(3)
     for index, data in sorted(surfaces.items()):
         base_position, base_rotation = next_position.copy(), next_rotation.copy()
@@ -89,7 +90,7 @@ def surface_coordinates(
             extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
             next_rotation = rotation @ extra
         distance = data.get("TH", 0.0)
-        if 0 < index < max(surfaces) and abs(distance) >= 9.9e9:
+        if 0 < index < last_index and abs(distance) >= 9.9e9:
             raise ValueError(
                 "OSLO infinite thickness with coordinate transforms is not mapped"
             )

--- a/optiland/fileio/oslo/reader/coordinates.py
+++ b/optiland/fileio/oslo/reader/coordinates.py
@@ -86,7 +86,9 @@ def surface_coordinates(
                     "OSLO BEN currently supports single-axis local mirror tilts"
                 )
             if data.get("material") != "RFL":
-                raise ValueError("OSLO BEN requires a reflecting surface")
+                raise ValueError(
+                    "OSLO BEN requires a mapped reflecting surface (RFL/RFH)"
+                )
             extra = Rotation.from_euler("XYZ", angles, degrees=True).as_matrix()
             next_rotation = rotation @ extra
         distance = data.get("TH", 0.0)

--- a/optiland/fileio/oslo/reader/geometry.py
+++ b/optiland/fileio/oslo/reader/geometry.py
@@ -1,0 +1,58 @@
+"""Documented OSLO surface equations mapped to existing Optiland geometries."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+
+def surface_geometry(data: dict[str, Any], scale: float) -> dict[str, Any]:
+    """Return surface kwargs in millimeters (Program Reference pp. 70–74)."""
+    radius = data.get("RD", math.inf) or math.inf
+    params = {
+        "surface_type": "standard",
+        "radius": radius * scale,
+        "conic": data.get("CC", 0.0),
+    }
+    kind = data.get("ASP", "ADO")
+    general = {int(k[2:]): v for k, v in data.items() if re.fullmatch(r"AS\d+", k)}
+    if general and max(general) > 256:
+        raise ValueError("OSLO asphere coefficient index exceeds supported limit 256")
+    if kind == "ASX":
+        order = int((math.sqrt(8 * max(general, default=0) + 1) - 1) // 2)
+        coefficients = [[0.0] * (order + 1) for _ in range(order + 1)]
+        for i, value in general.items():
+            degree = int((math.sqrt(8 * i + 1) - 1) // 2)
+            y_power = i - degree * (degree + 1) // 2
+            coefficients[degree - y_power][y_power] = value * scale ** (1 - degree)
+        params.update(surface_type="polynomial", coefficients=coefficients)
+    elif kind in {"ASR", "ARA"}:
+        if general.get(0, 0.0):
+            raise ValueError(f"OSLO {kind} with nonzero AS0 requires an offset sag")
+        step = 2 if kind == "ASR" else 1
+        coefficients = [
+            general.get(i, 0.0) * scale ** (1 - step * i)
+            for i in range(1, max(general, default=1) + 1)
+        ]
+        params.update(
+            surface_type="even_asphere" if step == 2 else "odd_asphere",
+            coefficients=coefficients,
+        )
+    elif any(k in data for k in ("AD", "AE", "AF", "AG")):
+        coefficients = [0.0] + [
+            data.get(k, 0.0) * scale ** (1 - power)
+            for k, power in zip(("AD", "AE", "AF", "AG"), (4, 6, 8, 10), strict=True)
+        ]
+        params.update(surface_type="even_asphere", coefficients=coefficients)
+    if "CVX" in data:
+        if kind not in {"ADO", "ASR"}:
+            raise ValueError("OSLO toric requires an even YZ asphere profile")
+        cvx = data["CVX"]
+        params.update(
+            surface_type="toroidal",
+            radius_y=radius * scale,
+            radius_x=scale / cvx if cvx else math.inf,
+            toroidal_coeffs_poly_y=params.pop("coefficients", []),
+        )
+    return params

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -13,6 +13,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.model import OsloDataModel, OsloDiagnostic
 
 
@@ -201,7 +202,7 @@ class OsloDataParser:
                 self._current_surf_idx = index
                 self._unsupported("ASn", "general coefficients require ASP ASR/ARA/ASX")
 
-        values = self._wavelength_values or [0.58756, 0.48613, 0.65627]
+        values = self._wavelength_values or list(DEFAULT_WAVELENGTHS_UM)
         weights = self._wavelength_weights + [1.0] * len(values)
         self.data_model.wavelengths["values"] = values
         self.data_model.wavelengths["weights"] = weights[: len(values)]
@@ -445,7 +446,7 @@ class OsloDataParser:
         self._clear_constraint("GLA")
         self._current_surf_data["material"] = "GLA " + " ".join(tokens[1:])
         self._current_surf_data["glass_wavelengths"] = list(
-            self._wavelength_values or [0.58756, 0.48613, 0.65627]
+            self._wavelength_values or DEFAULT_WAVELENGTHS_UM
         )
 
     def _read_paraxial(self, tokens: list[str]) -> None:
@@ -621,7 +622,7 @@ class OsloDataParser:
         if index > 1000 or len(values) != 1:
             raise ValueError(f"{cmd} requires one value and a bounded wavelength index")
         target = getattr(self, attr)
-        defaults = [0.58756, 0.48613, 0.65627] if wavelength else [1.0] * (index + 1)
+        defaults = DEFAULT_WAVELENGTHS_UM if wavelength else [1.0] * (index + 1)
         while len(target) <= index:
             if len(target) >= len(defaults):
                 if len(target) != index:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -382,7 +382,8 @@ class OsloDataParser:
         """The latest aperture specification replaces the previous one."""
         command, value = tokens[0], float(tokens[1])
         if command == "EBR":
-            command, value = "EPD", 2 * value  # Legacy model key for beam diameter.
+            # The shared model represents OSLO's beam radius as a diameter.
+            command, value = "EPD", 2 * value
         elif command == "PUK":
             value = abs(value)
         self.data_model.aperture = {command: value}

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -17,6 +17,21 @@ from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.model import OsloDataModel, OsloDiagnostic
 from optiland.fileio.oslo.syntax import decode_text, tokenize
 
+# Pickup variants constrain the same underlying surface property. Use one
+# definition for validation, replacement by literal values/solves, and deletion.
+_PICKUP_FAMILIES = {
+    "CV": "CV",
+    "CVM": "CV",
+    "TH": "TH",
+    "THM": "TH",
+    "LN": "TH",
+    "LNM": "TH",
+    "AP": "AP",
+    "GLA": "GLA",
+    "TD": "TD",
+    "TDM": "TD",
+}
+
 
 class OsloDataParser:
     """Parses an OSLO .len file into an OsloDataModel.
@@ -511,20 +526,14 @@ class OsloDataParser:
                 "RCO",
                 "BEN",
             ],
-            "CSD": ["PU", "PUC"],
-            "TSD": ["PY", "PYC", "EC"],
+            "CSD": [],  # Solves and pickups are cleared together below.
+            "TSD": [],
         }[tokens[0]]
         for key in keys:
             data.pop(key, None)
-        kinds = {
-            "CSD": {"CV", "CVM"},
-            "TSD": {"TH", "THM", "LN", "LNM"},
-            "TDD": {"TD", "TDM"},
-        }.get(tokens[0], set())
-        if kinds:
-            data["pickups"] = [
-                p for p in data.get("pickups", []) if p[0].upper() not in kinds
-            ]
+        family = {"CSD": "CV", "TSD": "TH", "TDD": "TD"}.get(tokens[0])
+        if family:
+            self._clear_constraint(family)
 
     def _read_rd(self, tokens: list[str]) -> None:
         self._clear_constraint("CV")
@@ -668,35 +677,22 @@ class OsloDataParser:
         self._current_surf_data[tokens[0]] = float(tokens[1])
 
     def _clear_constraint(self, kind: str) -> None:
-        kinds = {
-            "CV": {"CV", "CVM"},
-            "TH": {"TH", "THM", "LN", "LNM"},
-            "TD": {"TD", "TDM"},
-        }.get(kind, {kind})
+        family = _PICKUP_FAMILIES[kind]
         data = self._current_surf_data
         if "pickups" in data:
-            data["pickups"] = [p for p in data["pickups"] if p[0].upper() not in kinds]
-        for key in {"CV": ("PU", "PUC"), "TH": ("PY", "PYC", "EC")}.get(kind, ()):
+            data["pickups"] = [
+                p for p in data["pickups"] if _PICKUP_FAMILIES[p[0].upper()] != family
+            ]
+        for key in {"CV": ("PU", "PUC"), "TH": ("PY", "PYC", "EC")}.get(family, ()):
             data.pop(key, None)
 
     def _read_pickup(self, tokens: list[str]) -> None:
         if len(tokens) < 3:
             raise ValueError("PK requires a pickup type and preceding source")
-        if tokens[1].upper() not in {
-            "CV",
-            "CVM",
-            "TH",
-            "THM",
-            "LN",
-            "LNM",
-            "AP",
-            "GLA",
-            "TD",
-            "TDM",
-        }:
+        kind = tokens[1].upper()
+        if kind not in _PICKUP_FAMILIES:
             self._unsupported("PK", f"pickup type {tokens[1]} is not mapped")
             return
-        kind = tokens[1].upper()
         expected = {
             "LN": {4, 5},
             "LNM": {4, 5},
@@ -710,10 +706,7 @@ class OsloDataParser:
         int(tokens[2])
         if kind in {"LN", "LNM"}:
             int(tokens[3])
-        family = {"CVM": "CV", "THM": "TH", "LN": "TH", "LNM": "TH", "TDM": "TD"}.get(
-            kind, kind
-        )
-        self._clear_constraint(family)
+        self._clear_constraint(kind)
         self._current_surf_data.setdefault("pickups", []).append(tokens[1:])
 
     def _read_aperture_pickup(self, tokens: list[str]) -> None:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -7,7 +7,6 @@ Kramer Harrison, 2026
 
 from __future__ import annotations
 
-import contextlib
 import math
 import re
 import warnings
@@ -71,6 +70,8 @@ class OsloDataParser:
             "PK": self._read_pickup,
             "FNO": self._read_fno,
             "NAO": self._read_nao,
+            "NAP": self._read_nap,
+            "TELE": self._read_tele,
             "DES": self._read_des,
             "PFL": self._read_paraxial,
         }
@@ -101,6 +102,9 @@ class OsloDataParser:
                     tokens[0] = cmd
                     if re.fullmatch(r"SNO\d+", cmd):
                         self._read_sno(tokens)
+                    elif re.fullmatch(r"W[VW][1-9]\d*", cmd):
+                        self._validate_numbers(tokens)
+                        self._read_spectrum(tokens)
                     elif cmd in self._dispatch_table:
                         self._validate_numbers(tokens)
                         self._dispatch_table[cmd](tokens)
@@ -113,20 +117,10 @@ class OsloDataParser:
         if not self._ended:
             self._read_end(["END"])
 
-        # Finalize wavelengths - deduplicate (inline WV before each GLA block
-        # causes duplicates; the final WV+WW block defines system wavelengths
-        # but shares the same values).
-        seen: set[float] = set()
-        unique_vals: list[float] = []
-        for v in self._wavelength_values:
-            if v not in seen:
-                seen.add(v)
-                unique_vals.append(v)
-        weights = list(self._wavelength_weights)
-        if weights and len(weights) < len(unique_vals):
-            weights = weights + [1.0] * (len(unique_vals) - len(weights))
-        self.data_model.wavelengths["values"] = unique_vals
-        self.data_model.wavelengths["weights"] = weights[: len(unique_vals)]
+        values = self._wavelength_values or [0.58756, 0.48613, 0.65627]
+        weights = self._wavelength_weights + [1.0] * len(values)
+        self.data_model.wavelengths["values"] = values
+        self.data_model.wavelengths["weights"] = weights[: len(values)]
 
         return self.data_model
 
@@ -193,32 +187,36 @@ class OsloDataParser:
 
     def _read_ebr(self, tokens: list[str]) -> None:
         # EBR <float> (Entrance Beam Radius)
-        self.data_model.aperture["EPD"] = 2.0 * float(tokens[1])
+        self.data_model.aperture = {"EPD": 2.0 * float(tokens[1])}
 
     def _read_fno(self, tokens: list[str]) -> None:
         # FNO <float> (F-Number)
-        self.data_model.aperture["FNO"] = float(tokens[1])
+        self.data_model.aperture = {"FNO": float(tokens[1])}
 
     def _read_nao(self, tokens: list[str]) -> None:
         # NAO <float> (Object NA)
-        self.data_model.aperture["NAO"] = float(tokens[1])
+        self.data_model.aperture = {"NAO": float(tokens[1])}
+
+    def _read_nap(self, tokens: list[str]) -> None:
+        self.data_model.aperture = {"NAP": float(tokens[1])}
+
+    def _read_tele(self, tokens: list[str]) -> None:
+        if tokens[1].upper() not in {"ON", "OFF", "0", "1"}:
+            raise ValueError("TELE expects ON or OFF")
+        self.data_model.settings["telecentric"] = tokens[1].upper() in {"ON", "1"}
 
     def _read_obh(self, tokens: list[str]) -> None:
         # OBH <float> (Object Height)
-        self.data_model.fields["type"] = "object_height"
-        if "y" not in self.data_model.fields:
-            self.data_model.fields["y"] = []
-        self.data_model.fields["y"].append(float(tokens[1]))
+        self.data_model.fields = {"type": "object_height", "y": [float(tokens[1])]}
 
     def _read_ang(self, tokens: list[str]) -> None:
         # ANG <float> (Field Angle)
-        self.data_model.fields["type"] = "angle"
-        if "y" not in self.data_model.fields:
-            self.data_model.fields["y"] = []
-        self.data_model.fields["y"].append(float(tokens[1]))
+        self.data_model.fields = {"type": "angle", "y": [float(tokens[1])]}
 
     def _read_uni(self, tokens: list[str]) -> None:
         self.data_model.units = float(tokens[1])
+        if self.data_model.units <= 0:
+            raise ValueError("UNI must be positive (millimeters per lens unit)")
 
     def _read_des(self, tokens: list[str]) -> None:
         self.data_model.notes["DES"] = " ".join(tokens[1:]).strip('"')
@@ -270,18 +268,34 @@ class OsloDataParser:
         self._current_surf_data[cmd] = float(tokens[1])
 
     def _read_wv(self, tokens: list[str]) -> None:
-        # WV <w1> [<w2> <w3>]
-        # WV2 <w2>
-        # WV3 <w3>
-        for t in tokens[1:]:
-            with contextlib.suppress(ValueError):
-                self._wavelength_values.append(float(t))
+        self._read_spectrum(tokens)
 
     def _read_ww(self, tokens: list[str]) -> None:
-        # WW <wt1> [<wt2> <wt3>]
-        for t in tokens[1:]:
-            with contextlib.suppress(ValueError):
-                self._wavelength_weights.append(float(t))
+        self._read_spectrum(tokens)
+
+    def _read_spectrum(self, tokens: list[str]) -> None:
+        cmd = tokens[0]
+        values = [float(t) for t in tokens[1:]]
+        wavelength = cmd.startswith("WV")
+        if not values or any(v <= 0 if wavelength else v < 0 for v in values):
+            raise ValueError(f"{cmd} requires positive wavelengths/nonnegative weights")
+        attr = "_wavelength_values" if wavelength else "_wavelength_weights"
+        if len(cmd) == 2:
+            setattr(self, attr, values)
+            return
+        index = int(cmd[2:]) - 1
+        if index > 1000 or len(values) != 1:
+            raise ValueError(f"{cmd} requires one value and a bounded wavelength index")
+        target = getattr(self, attr)
+        defaults = [0.58756, 0.48613, 0.65627] if wavelength else [1.0] * (index + 1)
+        while len(target) <= index:
+            if len(target) >= len(defaults):
+                if len(target) != index:
+                    raise ValueError(f"{cmd} leaves undefined wavelength slots")
+                target.append(values[0])
+            else:
+                target.append(defaults[len(target)])
+        target[index] = values[0]
 
     def _read_nxt(self, tokens: list[str]) -> None:
         # Save current surface and increment index

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -43,10 +43,10 @@ class OsloDataParser:
         # Command dispatch table
         self._dispatch_table = {
             "LEN": self._read_len,
-            "EBR": self._read_ebr,
-            "OBH": self._read_obh,
-            "ANG": self._read_ang,
-            "GIH": self._read_gih,
+            "EBR": self._read_system_aperture,
+            "OBH": self._read_field,
+            "ANG": self._read_field,
+            "GIH": self._read_field,
             "UNI": self._read_uni,
             "AIR": self._read_medium,
             "RFL": self._read_medium,
@@ -77,7 +77,7 @@ class OsloDataParser:
             "AY2": self._read_special_aperture,
             "ASP": self._read_asp,
             "AST": self._read_ast,
-            "CC": self._read_cc,
+            "CC": self._read_coeff,
             "AD": self._read_coeff,
             "AE": self._read_coeff,
             "AF": self._read_coeff,
@@ -106,12 +106,12 @@ class OsloDataParser:
             "PUC": self._read_solve,
             "EC": self._read_solve,
             "PK": self._read_pickup,
-            "FNO": self._read_fno,
-            "NAO": self._read_nao,
-            "NAP": self._read_nap,
-            "PUK": self._read_puk,
+            "FNO": self._read_system_aperture,
+            "NAO": self._read_system_aperture,
+            "NAP": self._read_system_aperture,
+            "PUK": self._read_system_aperture,
             "TELE": self._read_tele,
-            "DES": self._read_des,
+            "DES": self._read_sno,
             "PFL": self._read_paraxial,
             "PFM": self._read_coeff,
             "GSP": self._read_coeff,
@@ -374,27 +374,23 @@ class OsloDataParser:
         if not 1 <= self.data_model.num_surfaces <= 10000:
             raise ValueError("LEN surface count must be between 1 and 10000")
 
-    def _read_ebr(self, tokens: list[str]) -> None:
-        # EBR <float> (Entrance Beam Radius)
-        self.data_model.aperture = {"EPD": 2.0 * float(tokens[1])}
+    def _read_system_aperture(self, tokens: list[str]) -> None:
+        """The latest aperture specification replaces the previous one."""
+        command, value = tokens[0], float(tokens[1])
+        if command == "EBR":
+            command, value = "EPD", 2 * value  # Legacy model key for beam diameter.
+        elif command == "PUK":
+            value = abs(value)
+        self.data_model.aperture = {command: value}
 
-    def _read_fno(self, tokens: list[str]) -> None:
-        # FNO <float> (F-Number)
-        self.data_model.aperture = {"FNO": float(tokens[1])}
-
-    def _read_nao(self, tokens: list[str]) -> None:
-        # NAO <float> (Object NA)
-        self.data_model.aperture = {"NAO": float(tokens[1])}
-
-    def _read_nap(self, tokens: list[str]) -> None:
-        self.data_model.aperture = {"NAP": float(tokens[1])}
-
-    def _read_puk(self, tokens: list[str]) -> None:
-        self.data_model.aperture = {"PUK": abs(float(tokens[1]))}
-
-    def _read_gih(self, tokens: list[str]) -> None:
+    def _read_field(self, tokens: list[str]) -> None:
+        """Read ANG half-angle, OBH object height or GIH Gaussian image height."""
         self.data_model.fields = {
-            "type": "gaussian_image_height",
+            "type": {
+                "ANG": "angle",
+                "OBH": "object_height",
+                "GIH": "gaussian_image_height",
+            }[tokens[0]],
             "y": [float(tokens[1])],
         }
 
@@ -445,21 +441,10 @@ class OsloDataParser:
             raise ValueError("TELE expects ON or OFF")
         self.data_model.settings["telecentric"] = tokens[1].upper() in {"ON", "1"}
 
-    def _read_obh(self, tokens: list[str]) -> None:
-        # OBH <float> (Object Height)
-        self.data_model.fields = {"type": "object_height", "y": [float(tokens[1])]}
-
-    def _read_ang(self, tokens: list[str]) -> None:
-        # ANG <float> (Field Angle)
-        self.data_model.fields = {"type": "angle", "y": [float(tokens[1])]}
-
     def _read_uni(self, tokens: list[str]) -> None:
         self.data_model.units = float(tokens[1])
         if self.data_model.units <= 0:
             raise ValueError("UNI must be positive (millimeters per lens unit)")
-
-    def _read_des(self, tokens: list[str]) -> None:
-        self.data_model.notes["DES"] = decode_text(" ".join(tokens[1:]))
 
     def _read_sno(self, tokens: list[str]) -> None:
         cmd = tokens[0].upper()
@@ -584,6 +569,7 @@ class OsloDataParser:
             raise ValueError("APN count must be between 0 and 256")
         self._current_surf_data["APN"] = count
         self._current_surf_data["special_apertures"] = {}
+        self._current_surf_data.pop("aperture_pickups", None)
 
     def _read_special_aperture(self, tokens: list[str]) -> None:
         if len(tokens) != 3:
@@ -608,9 +594,6 @@ class OsloDataParser:
         for data in self.data_model.surfaces.values():
             data.pop("AST", None)
         self._current_surf_data["AST"] = True
-
-    def _read_cc(self, tokens: list[str]) -> None:
-        self._current_surf_data["CC"] = float(tokens[1])
 
     def _read_coeff(self, tokens: list[str]) -> None:
         if len(tokens) != 2:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -58,6 +58,7 @@ class OsloDataParser:
             "AP": self._read_ap,
             "APF": self._read_ap,
             "APN": self._read_apn,
+            "APK": self._read_aperture_pickup,
             "ATP": self._read_special_aperture,
             "AAC": self._read_special_aperture,
             "AAN": self._read_special_aperture,
@@ -407,6 +408,25 @@ class OsloDataParser:
             self._current_surf_data["PY"] = float(tokens[1])
 
     def _read_pickup(self, tokens: list[str]) -> None:
-        # TODO: Support standard pickups
-        # PK <surf> <cmd>
-        self._current_surf_data["PK"] = tokens[1:]
+        if tokens[1].upper() not in {
+            "CV",
+            "CVM",
+            "TH",
+            "THM",
+            "LN",
+            "LNM",
+            "AP",
+            "GLA",
+            "TD",
+            "TDM",
+        }:
+            self._unsupported("PK", f"pickup type {tokens[1]} is not mapped")
+            return
+        self._current_surf_data.setdefault("pickups", []).append(tokens[1:])
+
+    def _read_aperture_pickup(self, tokens: list[str]) -> None:
+        if len(tokens) != 4:
+            raise ValueError(
+                "APK expects target aperture, source surface and source aperture"
+            )
+        self._current_surf_data.setdefault("aperture_pickups", []).append(tokens[1:])

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -33,6 +33,7 @@ class OsloDataParser:
         self._wavelength_weights: list[float] = []
         self._line = 0
         self._ended = False
+        self._field_table = False
 
         # Command dispatch table
         self._dispatch_table = {
@@ -40,6 +41,7 @@ class OsloDataParser:
             "EBR": self._read_ebr,
             "OBH": self._read_obh,
             "ANG": self._read_ang,
+            "GIH": self._read_gih,
             "UNI": self._read_uni,
             "AIR": self._read_medium,
             "RFL": self._read_medium,
@@ -103,6 +105,7 @@ class OsloDataParser:
             "FNO": self._read_fno,
             "NAO": self._read_nao,
             "NAP": self._read_nap,
+            "PUK": self._read_puk,
             "TELE": self._read_tele,
             "DES": self._read_des,
             "PFL": self._read_paraxial,
@@ -121,18 +124,16 @@ class OsloDataParser:
         except UnicodeDecodeError:
             source = raw.decode("cp1252")
         for self._line, line in enumerate(source.splitlines(), 1):
-            if self._ended:
-                break  # Analysis/variable/CCL blocks are not lens prescriptions.
             try:
                 for statement in self._statements(line):
-                    if self._ended:
-                        break
                     tokens = self._tokenize(statement)
                     if not tokens:
                         continue
                     cmd = tokens[0].upper()
                     tokens[0] = cmd
-                    if re.fullmatch(r"SNO\d+", cmd):
+                    if self._ended:
+                        self._read_footer(tokens)
+                    elif re.fullmatch(r"SNO\d+", cmd):
                         self._read_sno(tokens)
                     elif re.fullmatch(r"W[VW][1-9]\d*", cmd):
                         self._validate_numbers(tokens)
@@ -237,6 +238,54 @@ class OsloDataParser:
 
     def _read_nap(self, tokens: list[str]) -> None:
         self.data_model.aperture = {"NAP": float(tokens[1])}
+
+    def _read_puk(self, tokens: list[str]) -> None:
+        self.data_model.aperture = {"PUK": abs(float(tokens[1]))}
+
+    def _read_gih(self, tokens: list[str]) -> None:
+        self.data_model.fields = {
+            "type": "gaussian_image_height",
+            "y": [float(tokens[1])],
+        }
+
+    def _read_footer(self, tokens: list[str]) -> None:
+        """Read declarative field data without executing analysis or CCL blocks."""
+        cmd = tokens[0]
+        if cmd in {"CFG", "LEN"}:
+            self._unsupported(cmd, "additional configurations are not imported")
+        elif cmd == "RST":
+            self._field_table = len(tokens) == 2 and tokens[1].upper() == "NEW"
+            if self._field_table:
+                self.data_model.fields["points"] = {}
+        elif cmd == "END":
+            self._field_table = False
+        elif cmd == "F" and self._field_table:
+            self._validate_numbers(tokens)
+            if len(tokens) not in {12, 14}:
+                raise ValueError("F requires an index and ten field-table values")
+            index = int(tokens[1])
+            values = [float(v) for v in tokens[2:]]
+            if index < 1 or values[9] < 0:
+                raise ValueError("F requires a positive index and nonnegative weight")
+            if any(values[2:5]) or any(values[10:]):
+                self._unsupported(
+                    "F",
+                    "field depth, reference-ray aiming or extended flags "
+                    "are not mapped",
+                )
+            ymin, ymax, xmin, xmax = values[5:9]
+            if not (ymin < ymax and xmin < xmax):
+                raise ValueError("F pupil bounds must be increasing")
+            if ymin != -ymax or xmin != -xmax:
+                self._unsupported("F", "asymmetric field pupil bounds are not mapped")
+                ymin, ymax, xmin, xmax = -1, 1, -1, 1
+            self.data_model.fields["points"][index] = {
+                "y": values[0],
+                "x": values[1],
+                "weight": values[9],
+                "vy": 1 - ymax,
+                "vx": 1 - xmax,
+            }
 
     def _read_tele(self, tokens: list[str]) -> None:
         if tokens[1].upper() not in {"ON", "OFF", "0", "1"}:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -76,6 +76,13 @@ class OsloDataParser:
             "DCX": self._read_decenter,
             "DCY": self._read_decenter,
             "DCZ": self._read_decenter,
+            "DT": self._read_coeff,
+            "GC": self._read_coeff,
+            "RCO": self._read_return,
+            "BEN": self._read_flag,
+            "TOX": self._read_coeff,
+            "TOY": self._read_coeff,
+            "TOZ": self._read_coeff,
             "TLA": self._read_tilt,
             "TLB": self._read_tilt,
             "TLC": self._read_tilt,
@@ -335,6 +342,14 @@ class OsloDataParser:
     def _read_tilt(self, tokens: list[str]) -> None:
         cmd = tokens[0].upper()
         self._current_surf_data[cmd] = float(tokens[1])
+
+    def _read_return(self, tokens: list[str]) -> None:
+        self._current_surf_data["RCO"] = (
+            int(tokens[1]) if len(tokens) > 1 else self._current_surf_idx
+        )
+
+    def _read_flag(self, tokens: list[str]) -> None:
+        self._current_surf_data[tokens[0]] = True
 
     def _read_wv(self, tokens: list[str]) -> None:
         self._read_spectrum(tokens)

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.model import OsloDataModel, OsloDiagnostic
+from optiland.fileio.oslo.syntax import decode_text, tokenize
 
 
 class OsloDataParser:
@@ -35,6 +36,7 @@ class OsloDataParser:
         self._line = 0
         self._ended = False
         self._field_table = False
+        self._ignore_footer = False
         self._seen_len = False
 
         # Command dispatch table
@@ -79,9 +81,9 @@ class OsloDataParser:
             "AE": self._read_coeff,
             "AF": self._read_coeff,
             "AG": self._read_coeff,
-            "DCX": self._read_decenter,
-            "DCY": self._read_decenter,
-            "DCZ": self._read_decenter,
+            "DCX": self._read_coeff,
+            "DCY": self._read_coeff,
+            "DCZ": self._read_coeff,
             "DT": self._read_coeff,
             "GC": self._read_coeff,
             "RCO": self._read_return,
@@ -89,13 +91,11 @@ class OsloDataParser:
             "TOX": self._read_coeff,
             "TOY": self._read_coeff,
             "TOZ": self._read_coeff,
-            "TLA": self._read_tilt,
-            "TLB": self._read_tilt,
-            "TLC": self._read_tilt,
-            "WV": self._read_wv,
-            "WV2": self._read_wv,
-            "WV3": self._read_wv,
-            "WW": self._read_ww,
+            "TLA": self._read_coeff,
+            "TLB": self._read_coeff,
+            "TLC": self._read_coeff,
+            "WV": self._read_spectrum,
+            "WW": self._read_spectrum,
             "NXT": self._read_nxt,
             "GTO": self._read_gto,
             "END": self._read_end,
@@ -147,7 +147,7 @@ class OsloDataParser:
         for self._line, line in enumerate(source.splitlines(), 1):
             try:
                 for statement in self._statements(line):
-                    tokens = self._tokenize(statement)
+                    tokens = tokenize(statement)
                     if not tokens:
                         continue
                     cmd = tokens[0].upper()
@@ -286,6 +286,37 @@ class OsloDataParser:
         }
         if cmd in scalar and len(tokens) != 2:
             raise ValueError(f"{cmd} requires exactly one argument")
+        if (
+            cmd
+            in {
+                "AIR",
+                "AIF",
+                "RFL",
+                "RFH",
+                "AST",
+                "BEN",
+                "NXT",
+                "ATD",
+                "CXD",
+                "APD",
+                "GCD",
+                "RCD",
+                "BED",
+                "PFD",
+                "TDD",
+                "CSD",
+                "TSD",
+            }
+            and len(tokens) != 1
+        ):
+            raise ValueError(f"{cmd} does not take arguments")
+        if cmd == "RCO" and len(tokens) not in {1, 2}:
+            raise ValueError("RCO takes at most one surface reference")
+        if cmd == "ASP":
+            if len(tokens) not in {2, 3}:
+                raise ValueError("ASP expects a type and optional coefficient count")
+            if len(tokens) == 3 and not 0 <= int(tokens[2]) <= 256:
+                raise ValueError("ASP coefficient count must be between 0 and 256")
         if cmd in {"EBR", "FNO", "NAO", "NAP"} and float(tokens[1]) <= 0:
             raise ValueError(f"{cmd} must be positive")
         if cmd == "DT" and float(tokens[1]) not in {-1, 1}:
@@ -323,21 +354,12 @@ class OsloDataParser:
         statements.append(line[start:])
         return statements
 
-    def _tokenize(self, line: str) -> list[str]:
-        """Tokenize a line, respecting double quotes."""
-        # This regex finds either strings in quotes or non-whitespace sequences
-        return re.findall(r'"(?:\\.|[^"\\])*"|[^\s,]+', line)
-
-    @staticmethod
-    def _decode_text(value: str) -> str:
-        return re.sub(r'\\(["\\])', r"\1", value.strip('"'))
-
     def _read_len(self, tokens: list[str]) -> None:
         # LEN NEW "lens_name" <scaling> <total_surfaces>
         if self._seen_len or len(tokens) != 5 or tokens[1].upper() != "NEW":
             raise ValueError('LEN expects NEW "name" scaling surface-count')
         self._seen_len = True
-        self.data_model.name = self._decode_text(tokens[2])
+        self.data_model.name = decode_text(tokens[2])
         self.data_model.scaling = float(tokens[3])
         self.data_model.num_surfaces = int(tokens[4])
         if not 1 <= self.data_model.num_surfaces <= 10000:
@@ -370,7 +392,10 @@ class OsloDataParser:
     def _read_footer(self, tokens: list[str]) -> None:
         """Read declarative field data without executing analysis or CCL blocks."""
         cmd = tokens[0]
+        if self._ignore_footer:
+            return
         if cmd in {"CFG", "LEN"}:
+            self._ignore_footer = True
             self._unsupported(cmd, "additional configurations are not imported")
         elif cmd == "RST":
             self._field_table = len(tokens) == 2 and tokens[1].upper() == "NEW"
@@ -425,11 +450,11 @@ class OsloDataParser:
             raise ValueError("UNI must be positive (millimeters per lens unit)")
 
     def _read_des(self, tokens: list[str]) -> None:
-        self.data_model.notes["DES"] = self._decode_text(" ".join(tokens[1:]))
+        self.data_model.notes["DES"] = decode_text(" ".join(tokens[1:]))
 
     def _read_sno(self, tokens: list[str]) -> None:
         cmd = tokens[0].upper()
-        content = self._decode_text(" ".join(tokens[1:]))
+        content = decode_text(" ".join(tokens[1:]))
         self.data_model.notes[cmd] = content
 
     def _read_medium(self, tokens: list[str]) -> None:
@@ -453,7 +478,7 @@ class OsloDataParser:
         self._current_surf_data["PFL"] = float(tokens[1])
 
     def _read_note(self, tokens: list[str]) -> None:
-        self._current_surf_data["note"] = self._decode_text(" ".join(tokens[1:]))
+        self._current_surf_data["note"] = decode_text(" ".join(tokens[1:]))
 
     def _read_group(self, tokens: list[str]) -> None:
         if tokens[1].upper() not in {"EGR", "ELE"}:
@@ -530,6 +555,8 @@ class OsloDataParser:
     def _read_ap(self, tokens: list[str]) -> None:
         self._clear_constraint("AP")
         index = 2 if tokens[1].upper() in {"CHK", "UNC"} else 1
+        if len(tokens) != index + 1:
+            raise ValueError("AP expects an optional CHK/UNC flag and one radius")
         value = float(tokens[index])
         if value < 0:
             raise ValueError("AP radius must be nonnegative")
@@ -582,14 +609,6 @@ class OsloDataParser:
         cmd = tokens[0].upper()
         self._current_surf_data[cmd] = float(tokens[1])
 
-    def _read_decenter(self, tokens: list[str]) -> None:
-        cmd = tokens[0].upper()
-        self._current_surf_data[cmd] = float(tokens[1])
-
-    def _read_tilt(self, tokens: list[str]) -> None:
-        cmd = tokens[0].upper()
-        self._current_surf_data[cmd] = float(tokens[1])
-
     def _read_return(self, tokens: list[str]) -> None:
         # Legacy saved prescriptions encode the default local undo as RCO 0
         # (e.g. Lambda Research EyeModel_LB.len and io61ac.len).
@@ -601,12 +620,6 @@ class OsloDataParser:
 
     def _read_flag(self, tokens: list[str]) -> None:
         self._current_surf_data[tokens[0]] = True
-
-    def _read_wv(self, tokens: list[str]) -> None:
-        self._read_spectrum(tokens)
-
-    def _read_ww(self, tokens: list[str]) -> None:
-        self._read_spectrum(tokens)
 
     def _read_spectrum(self, tokens: list[str]) -> None:
         cmd = tokens[0]

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -31,6 +31,7 @@ class OsloDataParser:
         self.data_model = OsloDataModel()
         self._current_surf_idx = 0
         self._current_surf_data: dict[str, Any] = {}
+        self._coefficient_lines: dict[tuple[int, str], int] = {}
         self._wavelength_values: list[float] = []
         self._wavelength_weights: list[float] = []
         self._line = 0
@@ -196,11 +197,14 @@ class OsloDataParser:
         ):
             raise ValueError(f"{self.filename}: surface records do not match LEN count")
         for index, data in self.data_model.surfaces.items():
-            if data.get("ASP", "ADO") == "ADO" and any(
-                re.fullmatch(r"AS\d+", k) for k in data
-            ):
+            coefficient = next((k for k in data if re.fullmatch(r"AS\d+", k)), None)
+            if data.get("ASP", "ADO") == "ADO" and coefficient is not None:
                 self._current_surf_idx = index
-                self._unsupported("ASn", "general coefficients require ASP ASR/ARA/ASX")
+                self._unsupported(
+                    "ASn",
+                    "general coefficients require ASP ASR/ARA/ASX",
+                    line=self._coefficient_lines[index, coefficient],
+                )
 
         values = self._wavelength_values or list(DEFAULT_WAVELENGTHS_UM)
         weights = self._wavelength_weights + [1.0] * len(values)
@@ -211,13 +215,18 @@ class OsloDataParser:
 
         return self.data_model
 
-    def _unsupported(self, command: str, message: str = "unsupported command") -> None:
-        diagnostic = OsloDiagnostic(
-            command, self._line, self._current_surf_idx, message
-        )
+    def _unsupported(
+        self,
+        command: str,
+        message: str = "unsupported command",
+        *,
+        line: int | None = None,
+    ) -> None:
+        line = self._line if line is None else line
+        diagnostic = OsloDiagnostic(command, line, self._current_surf_idx, message)
         self.data_model.diagnostics.append(diagnostic)
         detail = (
-            f"{self.filename}:{self._line}: OSLO {command} at surface "
+            f"{self.filename}:{line}: OSLO {command} at surface "
             f"{self._current_surf_idx}: {message}; import may be incomplete"
         )
         if self.strict:
@@ -608,6 +617,8 @@ class OsloDataParser:
             raise ValueError(f"{tokens[0]} expects one coefficient")
         cmd = tokens[0].upper()
         self._current_surf_data[cmd] = float(tokens[1])
+        if re.fullmatch(r"AS\d+", cmd):
+            self._coefficient_lines[self._current_surf_idx, cmd] = self._line
 
     def _read_return(self, tokens: list[str]) -> None:
         # Legacy saved prescriptions encode the default local undo as RCO 0

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -32,7 +32,7 @@ class OsloDataParser:
         self._current_surf_idx = 0
         self._current_surf_data: dict[str, Any] = {}
         self._coefficient_lines: dict[tuple[int, str], int] = {}
-        self._wavelength_values: list[float] = []
+        self._wavelength_values = list(DEFAULT_WAVELENGTHS_UM)
         self._wavelength_weights: list[float] = []
         self._line = 0
         self._ended = False
@@ -206,7 +206,7 @@ class OsloDataParser:
                     line=self._coefficient_lines[index, coefficient],
                 )
 
-        values = self._wavelength_values or list(DEFAULT_WAVELENGTHS_UM)
+        values = self._wavelength_values
         weights = self._wavelength_weights + [1.0] * len(values)
         self.data_model.wavelengths["values"] = values
         self.data_model.wavelengths["weights"] = weights[: len(values)]
@@ -464,9 +464,7 @@ class OsloDataParser:
         # GLA MOD G1 1.6489 1.662...
         self._clear_constraint("GLA")
         self._current_surf_data["material"] = "GLA " + " ".join(tokens[1:])
-        self._current_surf_data["glass_wavelengths"] = list(
-            self._wavelength_values or DEFAULT_WAVELENGTHS_UM
-        )
+        self._current_surf_data["glass_wavelengths"] = list(self._wavelength_values)
 
     def _read_paraxial(self, tokens: list[str]) -> None:
         self._current_surf_data["PFL"] = float(tokens[1])
@@ -629,14 +627,9 @@ class OsloDataParser:
         if index > 1000 or len(values) != 1:
             raise ValueError(f"{cmd} requires one value and a bounded wavelength index")
         target = getattr(self, attr)
-        defaults = DEFAULT_WAVELENGTHS_UM if wavelength else [1.0] * (index + 1)
-        while len(target) <= index:
-            if len(target) >= len(defaults):
-                if len(target) != index:
-                    raise ValueError(f"{cmd} leaves undefined wavelength slots")
-                target.append(values[0])
-            else:
-                target.append(defaults[len(target)])
+        if wavelength and index > len(target):
+            raise ValueError(f"{cmd} leaves undefined wavelength slots")
+        target.extend([1.0] * max(0, index + 1 - len(target)))
         target[index] = values[0]
 
     def _read_nxt(self, tokens: list[str]) -> None:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -251,6 +251,9 @@ class OsloDataParser:
         # GLA 1.573 1.573 1.573
         # GLA MOD G1 1.6489 1.662...
         self._current_surf_data["material"] = "GLA " + " ".join(tokens[1:])
+        self._current_surf_data["glass_wavelengths"] = list(
+            self._wavelength_values or [0.58756, 0.48613, 0.65627]
+        )
 
     def _read_paraxial(self, tokens: list[str]) -> None:
         self._current_surf_data["PFL"] = float(tokens[1])

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -95,6 +95,10 @@ class OsloDataParser:
             "GTO": self._read_gto,
             "END": self._read_end,
             "PY": self._read_solve,
+            "PYC": self._read_solve,
+            "PU": self._read_solve,
+            "PUC": self._read_solve,
+            "EC": self._read_solve,
             "PK": self._read_pickup,
             "FNO": self._read_fno,
             "NAO": self._read_nao,
@@ -403,9 +407,7 @@ class OsloDataParser:
         self._ended = True
 
     def _read_solve(self, tokens: list[str]) -> None:
-        # TODO: Support more solves
-        if tokens[0].upper() == "PY":
-            self._current_surf_data["PY"] = float(tokens[1])
+        self._current_surf_data[tokens[0]] = float(tokens[1])
 
     def _read_pickup(self, tokens: list[str]) -> None:
         if tokens[1].upper() not in {

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -8,10 +8,13 @@ Kramer Harrison, 2026
 from __future__ import annotations
 
 import contextlib
+import math
 import re
+import warnings
+from pathlib import Path
 from typing import Any
 
-from optiland.fileio.oslo.model import OsloDataModel
+from optiland.fileio.oslo.model import OsloDataModel, OsloDiagnostic
 
 
 class OsloDataParser:
@@ -21,13 +24,16 @@ class OsloDataParser:
         filename: Path to the .len file to parse.
     """
 
-    def __init__(self, filename: str) -> None:
+    def __init__(self, filename: str, *, strict: bool = False) -> None:
         self.filename = filename
+        self.strict = strict
         self.data_model = OsloDataModel()
         self._current_surf_idx = 0
         self._current_surf_data: dict[str, Any] = {}
         self._wavelength_values: list[float] = []
         self._wavelength_weights: list[float] = []
+        self._line = 0
+        self._ended = False
 
         # Command dispatch table
         self._dispatch_table = {
@@ -59,6 +65,7 @@ class OsloDataParser:
             "WV3": self._read_wv,
             "WW": self._read_ww,
             "NXT": self._read_nxt,
+            "GTO": self._read_gto,
             "END": self._read_end,
             "PY": self._read_solve,
             "PK": self._read_pickup,
@@ -74,26 +81,37 @@ class OsloDataParser:
         Returns:
             A populated OsloDataModel.
         """
-        with open(self.filename, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("//"):
-                    continue
-
-                # Handle quoted strings correctly
-                tokens = self._tokenize(line)
-                if not tokens:
-                    continue
-
-                cmd = tokens[0].upper()
-
-                # Handle SNO1, SNO2, etc.
-                if cmd.startswith("SNO"):
-                    self._read_sno(tokens)
-                    continue
-
-                if cmd in self._dispatch_table:
-                    self._dispatch_table[cmd](tokens)
+        self.__init__(self.filename, strict=self.strict)
+        raw = Path(self.filename).read_bytes()
+        try:
+            source = raw.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            source = raw.decode("cp1252")
+        for self._line, line in enumerate(source.splitlines(), 1):
+            if self._ended:
+                break  # Analysis/variable/CCL blocks are not lens prescriptions.
+            try:
+                for statement in self._statements(line):
+                    if self._ended:
+                        break
+                    tokens = self._tokenize(statement)
+                    if not tokens:
+                        continue
+                    cmd = tokens[0].upper()
+                    tokens[0] = cmd
+                    if re.fullmatch(r"SNO\d+", cmd):
+                        self._read_sno(tokens)
+                    elif cmd in self._dispatch_table:
+                        self._validate_numbers(tokens)
+                        self._dispatch_table[cmd](tokens)
+                    elif cmd in {"DRW", "LDP", "CBK", "ELMDF1", "ELMDF2"}:
+                        continue  # Drawing-only data, without optical effects.
+                    else:
+                        self._unsupported(cmd)
+            except (ValueError, IndexError) as exc:
+                raise ValueError(f"{self.filename}:{self._line}: {exc}") from exc
+        if not self._ended:
+            self._read_end(["END"])
 
         # Finalize wavelengths - deduplicate (inline WV before each GLA block
         # causes duplicates; the final WV+WW block defines system wavelengths
@@ -112,10 +130,59 @@ class OsloDataParser:
 
         return self.data_model
 
+    def _unsupported(self, command: str, message: str = "unsupported command") -> None:
+        diagnostic = OsloDiagnostic(
+            command, self._line, self._current_surf_idx, message
+        )
+        self.data_model.diagnostics.append(diagnostic)
+        detail = (
+            f"{self.filename}:{self._line}: OSLO {command} at surface "
+            f"{self._current_surf_idx}: {message}; import may be incomplete"
+        )
+        if self.strict:
+            raise ValueError(detail)
+        warnings.warn(detail, UserWarning, stacklevel=3)
+
+    @staticmethod
+    def _validate_numbers(tokens: list[str]) -> None:
+        for token in tokens[1:]:
+            try:
+                value = float(token)
+            except ValueError:
+                continue
+            if not math.isfinite(value):
+                raise ValueError(f"{tokens[0]} requires finite numeric input")
+
+    @staticmethod
+    def _statements(line: str) -> list[str]:
+        """Split commands and comments outside quoted, backslash-escaped text."""
+        statements = []
+        start = 0
+        quoted = escaped = False
+        for i, char in enumerate(line):
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\" and quoted:
+                escaped = True
+            elif char == '"':
+                quoted = not quoted
+            elif not quoted:
+                if line[i : i + 2] == "//":
+                    line = line[:i]
+                    break
+                if char == ";":
+                    statements.append(line[start:i])
+                    start = i + 1
+        if quoted:
+            raise ValueError("unterminated quoted string")
+        statements.append(line[start:])
+        return statements
+
     def _tokenize(self, line: str) -> list[str]:
         """Tokenize a line, respecting double quotes."""
         # This regex finds either strings in quotes or non-whitespace sequences
-        return re.findall(r'"[^"]*"|\S+', line)
+        return re.findall(r'"(?:\\.|[^"\\])*"|[^\s,]+', line)
 
     def _read_len(self, tokens: list[str]) -> None:
         # LEN NEW "lens_name" <scaling> <total_surfaces>
@@ -220,13 +287,21 @@ class OsloDataParser:
         # Save current surface and increment index
         self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
         self._current_surf_idx += 1
-        self._current_surf_data = {}
+        self._current_surf_data = self.data_model.surfaces.get(
+            self._current_surf_idx, {}
+        )
+
+    def _read_gto(self, tokens: list[str]) -> None:
+        self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
+        index = int(tokens[1])
+        if not 0 <= index <= self.data_model.num_surfaces:
+            raise ValueError("GTO surface is outside the declared lens")
+        self._current_surf_idx = index
+        self._current_surf_data = self.data_model.surfaces.get(index, {})
 
     def _read_end(self, tokens: list[str]) -> None:
-        if self._current_surf_data:
-            self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
-            self._current_surf_idx += 1
-            self._current_surf_data = {}
+        self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
+        self._ended = True
 
     def _read_solve(self, tokens: list[str]) -> None:
         # TODO: Support more solves

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -43,10 +43,21 @@ class OsloDataParser:
             "UNI": self._read_uni,
             "AIR": self._read_medium,
             "RFL": self._read_medium,
+            "RFH": self._read_medium,
+            "AIF": self._read_medium,
             "GLA": self._read_glass,
+            "GLF": self._read_glass,
             "RD": self._read_rd,
+            "RDF": self._read_rd,
+            "CV": self._read_cv,
+            "CVF": self._read_cv,
+            "CVX": self._read_coeff,
+            "RDX": self._read_rdx,
             "TH": self._read_th,
+            "THF": self._read_th,
             "AP": self._read_ap,
+            "APF": self._read_ap,
+            "ASP": self._read_asp,
             "AST": self._read_ast,
             "CC": self._read_cc,
             "AD": self._read_coeff,
@@ -105,6 +116,9 @@ class OsloDataParser:
                     elif re.fullmatch(r"W[VW][1-9]\d*", cmd):
                         self._validate_numbers(tokens)
                         self._read_spectrum(tokens)
+                    elif re.fullmatch(r"AS\d+", cmd):
+                        self._validate_numbers(tokens)
+                        self._read_coeff(tokens)
                     elif cmd in self._dispatch_table:
                         self._validate_numbers(tokens)
                         self._dispatch_table[cmd](tokens)
@@ -228,7 +242,8 @@ class OsloDataParser:
 
     def _read_medium(self, tokens: list[str]) -> None:
         # AIR or RFL
-        self._current_surf_data["material"] = tokens[0].upper()
+        cmd = tokens[0].upper()
+        self._current_surf_data["material"] = {"AIF": "AIR", "RFH": "RFL"}.get(cmd, cmd)
 
     def _read_glass(self, tokens: list[str]) -> None:
         # GLA <glass_def>
@@ -241,7 +256,21 @@ class OsloDataParser:
         self._current_surf_data["PFL"] = float(tokens[1])
 
     def _read_rd(self, tokens: list[str]) -> None:
-        self._current_surf_data["RD"] = float(tokens[1])
+        self._current_surf_data["RD"] = float(tokens[1]) or math.inf
+
+    def _read_cv(self, tokens: list[str]) -> None:
+        curvature = float(tokens[1])
+        self._current_surf_data["RD"] = 1 / curvature if curvature else math.inf
+
+    def _read_rdx(self, tokens: list[str]) -> None:
+        radius = float(tokens[1])
+        self._current_surf_data["CVX"] = 1 / radius if radius else 0.0
+
+    def _read_asp(self, tokens: list[str]) -> None:
+        kind = {"0": "ADO", "1": "ASR", "2": "ASX"}.get(tokens[1], tokens[1].upper())
+        self._current_surf_data["ASP"] = kind
+        if kind not in {"ADO", "ASR", "ASX", "ARA"}:
+            self._unsupported("ASP", f"asphere type {kind} is not mapped")
 
     def _read_th(self, tokens: list[str]) -> None:
         self._current_surf_data["TH"] = float(tokens[1])

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -34,6 +34,7 @@ class OsloDataParser:
         self._line = 0
         self._ended = False
         self._field_table = False
+        self._seen_len = False
 
         # Command dispatch table
         self._dispatch_table = {
@@ -165,6 +166,7 @@ class OsloDataParser:
                         self._read_special_aperture(tokens)
                     elif cmd in self._dispatch_table:
                         self._validate_numbers(tokens)
+                        self._validate_command(tokens)
                         self._dispatch_table[cmd](tokens)
                     elif cmd in {
                         "DRW",
@@ -186,11 +188,25 @@ class OsloDataParser:
                 raise ValueError(f"{self.filename}:{self._line}: {exc}") from exc
         if not self._ended:
             self._read_end(["END"])
+        if not self._seen_len:
+            raise ValueError(f"{self.filename}: missing LEN NEW prescription")
+        if set(self.data_model.surfaces) != set(
+            range(self.data_model.num_surfaces + 1)
+        ):
+            raise ValueError(f"{self.filename}: surface records do not match LEN count")
+        for index, data in self.data_model.surfaces.items():
+            if data.get("ASP", "ADO") == "ADO" and any(
+                re.fullmatch(r"AS\d+", k) for k in data
+            ):
+                self._current_surf_idx = index
+                self._unsupported("ASn", "general coefficients require ASP ASR/ARA/ASX")
 
         values = self._wavelength_values or [0.58756, 0.48613, 0.65627]
         weights = self._wavelength_weights + [1.0] * len(values)
         self.data_model.wavelengths["values"] = values
         self.data_model.wavelengths["weights"] = weights[: len(values)]
+        if not any(self.data_model.wavelengths["weights"]):
+            raise ValueError(f"{self.filename}: wavelength weights cannot all be zero")
 
         return self.data_model
 
@@ -216,6 +232,69 @@ class OsloDataParser:
                 continue
             if not math.isfinite(value):
                 raise ValueError(f"{tokens[0]} requires finite numeric input")
+
+    def _validate_command(self, tokens: list[str]) -> None:
+        cmd = tokens[0]
+        scalar = {
+            "EBR",
+            "FNO",
+            "NAO",
+            "NAP",
+            "PUK",
+            "UNI",
+            "ANG",
+            "OBH",
+            "GIH",
+            "RD",
+            "RDF",
+            "CV",
+            "CVF",
+            "TH",
+            "THF",
+            "CC",
+            "CVX",
+            "RDX",
+            "AD",
+            "AE",
+            "AF",
+            "AG",
+            "DCX",
+            "DCY",
+            "DCZ",
+            "TLA",
+            "TLB",
+            "TLC",
+            "DT",
+            "GC",
+            "TOX",
+            "TOY",
+            "TOZ",
+            "APN",
+            "PFL",
+            "PFM",
+            "GSP",
+            "GOR",
+            "PY",
+            "PYC",
+            "PU",
+            "PUC",
+            "EC",
+            "GTO",
+            "TELE",
+            "APCK",
+        }
+        if cmd in scalar and len(tokens) != 2:
+            raise ValueError(f"{cmd} requires exactly one argument")
+        if cmd in {"EBR", "FNO", "NAO", "NAP"} and float(tokens[1]) <= 0:
+            raise ValueError(f"{cmd} must be positive")
+        if cmd == "DT" and float(tokens[1]) not in {-1, 1}:
+            raise ValueError("DT must be -1 or 1")
+        if cmd in {"GC", "GOR"} and not float(tokens[1]).is_integer():
+            raise ValueError(f"{cmd} requires an integer")
+        if cmd in {"GLA", "GLF"} and (
+            len(tokens) < 2 or (tokens[1].upper() == "MOD" and len(tokens) < 3)
+        ):
+            raise ValueError("GLA requires a glass name or index data")
 
     @staticmethod
     def _statements(line: str) -> list[str]:
@@ -248,12 +327,20 @@ class OsloDataParser:
         # This regex finds either strings in quotes or non-whitespace sequences
         return re.findall(r'"(?:\\.|[^"\\])*"|[^\s,]+', line)
 
+    @staticmethod
+    def _decode_text(value: str) -> str:
+        return re.sub(r'\\(["\\])', r"\1", value.strip('"'))
+
     def _read_len(self, tokens: list[str]) -> None:
         # LEN NEW "lens_name" <scaling> <total_surfaces>
-        if len(tokens) >= 5 and tokens[1].upper() == "NEW":
-            self.data_model.name = tokens[2].strip('"')
-            self.data_model.scaling = float(tokens[3])
-            self.data_model.num_surfaces = int(tokens[4])
+        if self._seen_len or len(tokens) != 5 or tokens[1].upper() != "NEW":
+            raise ValueError('LEN expects NEW "name" scaling surface-count')
+        self._seen_len = True
+        self.data_model.name = self._decode_text(tokens[2])
+        self.data_model.scaling = float(tokens[3])
+        self.data_model.num_surfaces = int(tokens[4])
+        if not 1 <= self.data_model.num_surfaces <= 10000:
+            raise ValueError("LEN surface count must be between 1 and 10000")
 
     def _read_ebr(self, tokens: list[str]) -> None:
         # EBR <float> (Entrance Beam Radius)
@@ -337,11 +424,11 @@ class OsloDataParser:
             raise ValueError("UNI must be positive (millimeters per lens unit)")
 
     def _read_des(self, tokens: list[str]) -> None:
-        self.data_model.notes["DES"] = " ".join(tokens[1:]).strip('"')
+        self.data_model.notes["DES"] = self._decode_text(" ".join(tokens[1:]))
 
     def _read_sno(self, tokens: list[str]) -> None:
         cmd = tokens[0].upper()
-        content = " ".join(tokens[1:]).strip('"')
+        content = self._decode_text(" ".join(tokens[1:]))
         self.data_model.notes[cmd] = content
 
     def _read_medium(self, tokens: list[str]) -> None:
@@ -365,7 +452,7 @@ class OsloDataParser:
         self._current_surf_data["PFL"] = float(tokens[1])
 
     def _read_note(self, tokens: list[str]) -> None:
-        self._current_surf_data["note"] = " ".join(tokens[1:]).strip('"')
+        self._current_surf_data["note"] = self._decode_text(" ".join(tokens[1:]))
 
     def _read_group(self, tokens: list[str]) -> None:
         if tokens[1].upper() not in {"EGR", "ELE"}:
@@ -462,8 +549,13 @@ class OsloDataParser:
         self._current_surf_data["special_apertures"] = {}
 
     def _read_special_aperture(self, tokens: list[str]) -> None:
+        if len(tokens) != 3:
+            raise ValueError(f"{tokens[0]} expects an aperture identifier and value")
         cmd, identifier = tokens[:2]
+        identifier = identifier.upper()
         value = float(tokens[2])
+        if cmd in {"ATP", "AAC", "AGN"} and not value.is_integer():
+            raise ValueError(f"{cmd} requires an integer")
         if cmd == "AAC" and value not in {2, 4}:
             self._unsupported(
                 cmd,
@@ -476,12 +568,16 @@ class OsloDataParser:
         )[cmd] = value
 
     def _read_ast(self, tokens: list[str]) -> None:
+        for data in self.data_model.surfaces.values():
+            data.pop("AST", None)
         self._current_surf_data["AST"] = True
 
     def _read_cc(self, tokens: list[str]) -> None:
         self._current_surf_data["CC"] = float(tokens[1])
 
     def _read_coeff(self, tokens: list[str]) -> None:
+        if len(tokens) != 2:
+            raise ValueError(f"{tokens[0]} expects one coefficient")
         cmd = tokens[0].upper()
         self._current_surf_data[cmd] = float(tokens[1])
 
@@ -494,8 +590,12 @@ class OsloDataParser:
         self._current_surf_data[cmd] = float(tokens[1])
 
     def _read_return(self, tokens: list[str]) -> None:
+        # Legacy saved prescriptions encode the default local undo as RCO 0
+        # (e.g. Lambda Research EyeModel_LB.len and io61ac.len).
         self._current_surf_data["RCO"] = (
-            int(tokens[1]) if len(tokens) > 1 else self._current_surf_idx
+            (int(tokens[1]) or self._current_surf_idx)
+            if len(tokens) > 1
+            else self._current_surf_idx
         )
 
     def _read_flag(self, tokens: list[str]) -> None:
@@ -535,6 +635,8 @@ class OsloDataParser:
         # Save current surface and increment index
         self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
         self._current_surf_idx += 1
+        if self._current_surf_idx > self.data_model.num_surfaces:
+            raise ValueError("NXT exceeds LEN surface count")
         self._current_surf_data = self.data_model.surfaces.get(
             self._current_surf_idx, {}
         )
@@ -548,6 +650,10 @@ class OsloDataParser:
         self._current_surf_data = self.data_model.surfaces.get(index, {})
 
     def _read_end(self, tokens: list[str]) -> None:
+        if len(tokens) > 2 or (
+            len(tokens) == 2 and int(tokens[1]) != self.data_model.num_surfaces
+        ):
+            raise ValueError("END surface count differs from LEN")
         self.data_model.surfaces[self._current_surf_idx] = self._current_surf_data
         self._ended = True
 
@@ -568,6 +674,8 @@ class OsloDataParser:
             data.pop(key, None)
 
     def _read_pickup(self, tokens: list[str]) -> None:
+        if len(tokens) < 3:
+            raise ValueError("PK requires a pickup type and preceding source")
         if tokens[1].upper() not in {
             "CV",
             "CVM",
@@ -583,6 +691,19 @@ class OsloDataParser:
             self._unsupported("PK", f"pickup type {tokens[1]} is not mapped")
             return
         kind = tokens[1].upper()
+        expected = {
+            "LN": {4, 5},
+            "LNM": {4, 5},
+            "CV": {3, 4},
+            "CVM": {3, 4},
+            "TH": {3, 4},
+            "THM": {3, 4},
+        }.get(kind, {3})
+        if len(tokens) not in expected:
+            raise ValueError(f"PK {kind} has an invalid number of arguments")
+        int(tokens[2])
+        if kind in {"LN", "LNM"}:
+            int(tokens[3])
         family = {"CVM": "CV", "THM": "TH", "LN": "TH", "LNM": "TH", "TDM": "TD"}.get(
             kind, kind
         )
@@ -594,4 +715,6 @@ class OsloDataParser:
             raise ValueError(
                 "APK expects target aperture, source surface and source aperture"
             )
-        self._current_surf_data.setdefault("aperture_pickups", []).append(tokens[1:])
+        self._current_surf_data.setdefault("aperture_pickups", []).append(
+            [tokens[1].upper(), tokens[2], tokens[3].upper()]
+        )

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -109,7 +109,25 @@ class OsloDataParser:
             "TELE": self._read_tele,
             "DES": self._read_des,
             "PFL": self._read_paraxial,
+            "PFM": self._read_coeff,
+            "GSP": self._read_coeff,
+            "GOR": self._read_coeff,
+            "NOT": self._read_note,
+            "LMO": self._read_group,
         }
+        for cmd in (
+            "ATD",
+            "CXD",
+            "APD",
+            "GCD",
+            "RCD",
+            "BED",
+            "PFD",
+            "TDD",
+            "CSD",
+            "TSD",
+        ):
+            self._dispatch_table[cmd] = self._read_delete
 
     def parse(self) -> OsloDataModel:
         """Parse the OSLO file.
@@ -147,7 +165,19 @@ class OsloDataParser:
                     elif cmd in self._dispatch_table:
                         self._validate_numbers(tokens)
                         self._dispatch_table[cmd](tokens)
-                    elif cmd in {"DRW", "LDP", "CBK", "ELMDF1", "ELMDF2"}:
+                    elif cmd in {
+                        "DRW",
+                        "LDP",
+                        "CBK",
+                        "ELMDF1",
+                        "ELMDF2",
+                        "BDI",
+                        "BDD",
+                        "VX",
+                        "PF",
+                        "LMN",
+                        "LME",
+                    }:
                         continue  # Drawing-only data, without optical effects.
                     else:
                         self._unsupported(cmd)
@@ -330,6 +360,58 @@ class OsloDataParser:
 
     def _read_paraxial(self, tokens: list[str]) -> None:
         self._current_surf_data["PFL"] = float(tokens[1])
+
+    def _read_note(self, tokens: list[str]) -> None:
+        self._current_surf_data["note"] = " ".join(tokens[1:]).strip('"')
+
+    def _read_group(self, tokens: list[str]) -> None:
+        if tokens[1].upper() not in {"EGR", "ELE"}:
+            self._unsupported("LMO", "non-sequential groups are not mapped")
+
+    def _read_delete(self, tokens: list[str]) -> None:
+        data = self._current_surf_data
+        keys = {
+            "ATD": [
+                k
+                for k in data
+                if k in {"CC", "AD", "AE", "AF", "AG", "ASP"}
+                or re.fullmatch(r"AS\d+", k)
+            ],
+            "CXD": ["CVX"],
+            "APD": ["APN", "special_apertures", "aperture_pickups"],
+            "GCD": ["GC"],
+            "RCD": ["RCO"],
+            "BED": ["BEN"],
+            "PFD": ["PFL", "PFM"],
+            "TDD": [
+                "DCX",
+                "DCY",
+                "DCZ",
+                "TLA",
+                "TLB",
+                "TLC",
+                "DT",
+                "TOX",
+                "TOY",
+                "TOZ",
+                "GC",
+                "RCO",
+                "BEN",
+            ],
+            "CSD": ["PU", "PUC"],
+            "TSD": ["PY", "PYC", "EC"],
+        }[tokens[0]]
+        for key in keys:
+            data.pop(key, None)
+        kinds = {
+            "CSD": {"CV", "CVM"},
+            "TSD": {"TH", "THM", "LN", "LNM"},
+            "TDD": {"TD", "TDM"},
+        }.get(tokens[0], set())
+        if kinds:
+            data["pickups"] = [
+                p for p in data.get("pickups", []) if p[0].upper() not in kinds
+            ]
 
     def _read_rd(self, tokens: list[str]) -> None:
         self._current_surf_data["RD"] = float(tokens[1]) or math.inf

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -60,6 +60,7 @@ class OsloDataParser:
             "AP": self._read_ap,
             "APF": self._read_ap,
             "APN": self._read_apn,
+            "APCK": self._read_apck,
             "APK": self._read_aperture_pickup,
             "ATP": self._read_special_aperture,
             "AAC": self._read_special_aperture,
@@ -439,6 +440,13 @@ class OsloDataParser:
         if value < 0:
             raise ValueError("AP radius must be nonnegative")
         self._current_surf_data["AP"] = value
+        self._current_surf_data["aperture_checked"] = tokens[1].upper() == "CHK"
+
+    def _read_apck(self, tokens: list[str]) -> None:
+        flag = tokens[1].upper()
+        if flag not in {"ON", "OFF", "1", "0"}:
+            raise ValueError("APCK expects ON or OFF")
+        self.data_model.settings["aperture_check"] = flag in {"ON", "1"}
 
     def _read_apn(self, tokens: list[str]) -> None:
         count = int(tokens[1])

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -347,6 +347,7 @@ class OsloDataParser:
     def _read_medium(self, tokens: list[str]) -> None:
         # AIR or RFL
         cmd = tokens[0].upper()
+        self._clear_constraint("GLA")
         self._current_surf_data["material"] = {"AIF": "AIR", "RFH": "RFL"}.get(cmd, cmd)
 
     def _read_glass(self, tokens: list[str]) -> None:
@@ -354,6 +355,7 @@ class OsloDataParser:
         # GLA BK7
         # GLA 1.573 1.573 1.573
         # GLA MOD G1 1.6489 1.662...
+        self._clear_constraint("GLA")
         self._current_surf_data["material"] = "GLA " + " ".join(tokens[1:])
         self._current_surf_data["glass_wavelengths"] = list(
             self._wavelength_values or [0.58756, 0.48613, 0.65627]
@@ -415,9 +417,11 @@ class OsloDataParser:
             ]
 
     def _read_rd(self, tokens: list[str]) -> None:
+        self._clear_constraint("CV")
         self._current_surf_data["RD"] = float(tokens[1]) or math.inf
 
     def _read_cv(self, tokens: list[str]) -> None:
+        self._clear_constraint("CV")
         curvature = float(tokens[1])
         self._current_surf_data["RD"] = 1 / curvature if curvature else math.inf
 
@@ -432,9 +436,11 @@ class OsloDataParser:
             self._unsupported("ASP", f"asphere type {kind} is not mapped")
 
     def _read_th(self, tokens: list[str]) -> None:
+        self._clear_constraint("TH")
         self._current_surf_data["TH"] = float(tokens[1])
 
     def _read_ap(self, tokens: list[str]) -> None:
+        self._clear_constraint("AP")
         index = 2 if tokens[1].upper() in {"CHK", "UNC"} else 1
         value = float(tokens[index])
         if value < 0:
@@ -546,7 +552,20 @@ class OsloDataParser:
         self._ended = True
 
     def _read_solve(self, tokens: list[str]) -> None:
+        self._clear_constraint("CV" if tokens[0] in {"PU", "PUC"} else "TH")
         self._current_surf_data[tokens[0]] = float(tokens[1])
+
+    def _clear_constraint(self, kind: str) -> None:
+        kinds = {
+            "CV": {"CV", "CVM"},
+            "TH": {"TH", "THM", "LN", "LNM"},
+            "TD": {"TD", "TDM"},
+        }.get(kind, {kind})
+        data = self._current_surf_data
+        if "pickups" in data:
+            data["pickups"] = [p for p in data["pickups"] if p[0].upper() not in kinds]
+        for key in {"CV": ("PU", "PUC"), "TH": ("PY", "PYC", "EC")}.get(kind, ()):
+            data.pop(key, None)
 
     def _read_pickup(self, tokens: list[str]) -> None:
         if tokens[1].upper() not in {
@@ -563,6 +582,11 @@ class OsloDataParser:
         }:
             self._unsupported("PK", f"pickup type {tokens[1]} is not mapped")
             return
+        kind = tokens[1].upper()
+        family = {"CVM": "CV", "THM": "TH", "LN": "TH", "LNM": "TH", "TDM": "TD"}.get(
+            kind, kind
+        )
+        self._clear_constraint(family)
         self._current_surf_data.setdefault("pickups", []).append(tokens[1:])
 
     def _read_aperture_pickup(self, tokens: list[str]) -> None:

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -57,6 +57,15 @@ class OsloDataParser:
             "THF": self._read_th,
             "AP": self._read_ap,
             "APF": self._read_ap,
+            "APN": self._read_apn,
+            "ATP": self._read_special_aperture,
+            "AAC": self._read_special_aperture,
+            "AAN": self._read_special_aperture,
+            "AGN": self._read_special_aperture,
+            "AX1": self._read_special_aperture,
+            "AX2": self._read_special_aperture,
+            "AY1": self._read_special_aperture,
+            "AY2": self._read_special_aperture,
             "ASP": self._read_asp,
             "AST": self._read_ast,
             "CC": self._read_cc,
@@ -119,6 +128,9 @@ class OsloDataParser:
                     elif re.fullmatch(r"AS\d+", cmd):
                         self._validate_numbers(tokens)
                         self._read_coeff(tokens)
+                    elif re.fullmatch(r"AV[XY][1-4]", cmd):
+                        self._validate_numbers(tokens)
+                        self._read_special_aperture(tokens)
                     elif cmd in self._dispatch_table:
                         self._validate_numbers(tokens)
                         self._dispatch_table[cmd](tokens)
@@ -279,7 +291,32 @@ class OsloDataParser:
         self._current_surf_data["TH"] = float(tokens[1])
 
     def _read_ap(self, tokens: list[str]) -> None:
-        self._current_surf_data["AP"] = float(tokens[1])
+        index = 2 if tokens[1].upper() in {"CHK", "UNC"} else 1
+        value = float(tokens[index])
+        if value < 0:
+            raise ValueError("AP radius must be nonnegative")
+        self._current_surf_data["AP"] = value
+
+    def _read_apn(self, tokens: list[str]) -> None:
+        count = int(tokens[1])
+        if not 0 <= count <= 256:
+            raise ValueError("APN count must be between 0 and 256")
+        self._current_surf_data["APN"] = count
+        self._current_surf_data["special_apertures"] = {}
+
+    def _read_special_aperture(self, tokens: list[str]) -> None:
+        cmd, identifier = tokens[:2]
+        value = float(tokens[2])
+        if cmd == "AAC" and value not in {2, 4}:
+            self._unsupported(
+                cmd,
+                "undeviated hole action is not mapped"
+                if value == 1
+                else f"aperture action {value} is not mapped",
+            )
+        self._current_surf_data.setdefault("special_apertures", {}).setdefault(
+            identifier, {}
+        )[cmd] = value
 
     def _read_ast(self, tokens: list[str]) -> None:
         self._current_surf_data["AST"] = True

--- a/optiland/fileio/oslo/reader/parser.py
+++ b/optiland/fileio/oslo/reader/parser.py
@@ -212,6 +212,10 @@ class OsloDataParser:
         self.data_model.wavelengths["weights"] = weights[: len(values)]
         if not any(self.data_model.wavelengths["weights"]):
             raise ValueError(f"{self.filename}: wavelength weights cannot all be zero")
+        if weights[0] == 0:
+            raise ValueError(
+                f"{self.filename}: OSLO primary wavelength weight must be positive"
+            )
 
         return self.data_model
 

--- a/optiland/fileio/oslo/reader/pickups.py
+++ b/optiland/fileio/oslo/reader/pickups.py
@@ -78,8 +78,14 @@ def resolve_pickups(surfaces: dict[int, dict[str, Any]]) -> dict[int, dict[str, 
                 if "glass_wavelengths" in original:
                     data["glass_wavelengths"] = list(original["glass_wavelengths"])
             elif kind in {"TD", "TDM"}:
+                if any(key in original for key in ("GC", "RCO", "BEN")):
+                    raise ValueError(
+                        "OSLO PK TD/TDM with global/return/bend data is not mapped"
+                    )
                 for key in ("DCX", "DCY", "DCZ", "TLA", "TLB", "TLC"):
                     data[key] = sign * original.get(key, 0.0)
+                for key in ("TOX", "TOY", "TOZ"):
+                    data[key] = original.get(key, 0.0)
                 data["DT"] = sign * original.get("DT", 1)
             else:
                 raise ValueError(f"OSLO PK {kind} is unsupported")

--- a/optiland/fileio/oslo/reader/pickups.py
+++ b/optiland/fileio/oslo/reader/pickups.py
@@ -1,0 +1,98 @@
+"""Resolve static OSLO prescription pickups in surface order."""
+
+from __future__ import annotations
+
+import math
+import re
+from copy import deepcopy
+from typing import Any
+
+from optiland.fileio.oslo.reader.coordinates import reference_index
+
+
+def resolve_pickups(surfaces: dict[int, dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    """Resolve documented preceding-surface pickups without mutating the input.
+
+    PK CV/CVM copy the full profile with an additive curvature offset. TH/THM
+    and LN/LNM have additive length offsets (never multiplicative factors).
+    Forward and cyclic references are invalid OSLO static pickups.
+    """
+    resolved = deepcopy(surfaces)
+    for index, data in sorted(resolved.items()):
+        for pickup in data.get("pickups", []):
+            kind = pickup[0].upper()
+            source = reference_index(int(pickup[1]), index)
+            if source not in resolved or not 0 <= source < index:
+                raise ValueError(
+                    f"OSLO PK at surface {index} requires a preceding source"
+                )
+            original = resolved[source]
+            negative = kind in {"CVM", "THM", "LNM", "TDM"}
+            sign = -1 if negative else 1
+            offset = (
+                float(pickup[2])
+                if len(pickup) > 2 and kind not in {"LN", "LNM"}
+                else 0.0
+            )
+            if kind in {"CV", "CVM"}:
+                for key in list(data):
+                    if key in {
+                        "CC",
+                        "CVX",
+                        "ASP",
+                        "AD",
+                        "AE",
+                        "AF",
+                        "AG",
+                    } or re.fullmatch(r"AS\d+", key):
+                        del data[key]
+                for key, value in original.items():
+                    if key in {"CC", "ASP"}:
+                        data[key] = value
+                    elif key in {"CVX", "AD", "AE", "AF", "AG"} or re.fullmatch(
+                        r"AS\d+", key
+                    ):
+                        data[key] = sign * value
+                radius = original.get("RD", math.inf)
+                curvature = (sign / radius if radius else 0.0) + offset
+                data["RD"] = 1 / curvature if curvature else math.inf
+            elif kind in {"TH", "THM"}:
+                data["TH"] = sign * original.get("TH", 0.0) + offset
+            elif kind in {"LN", "LNM"}:
+                end = (
+                    reference_index(int(pickup[2]), index) if int(pickup[2]) else index
+                )
+                if not source < end <= index:
+                    raise ValueError(f"OSLO PK {kind} has an invalid length range")
+                offset = float(pickup[3]) if len(pickup) > 3 else 0.0
+                data["TH"] = (
+                    sign * sum(resolved[i].get("TH", 0.0) for i in range(source, end))
+                    + offset
+                )
+            elif kind == "AP":
+                data["AP"] = original.get("AP", 0.0)
+            elif kind == "GLA":
+                data["material"] = original.get("material", "AIR")
+                if data["material"] == "RFL":
+                    raise ValueError("OSLO PK GLA cannot pick up a reflector")
+                if "glass_wavelengths" in original:
+                    data["glass_wavelengths"] = list(original["glass_wavelengths"])
+            elif kind in {"TD", "TDM"}:
+                for key in ("DCX", "DCY", "DCZ", "TLA", "TLB", "TLC"):
+                    data[key] = sign * original.get(key, 0.0)
+                data["DT"] = sign * original.get("DT", 1)
+            else:
+                raise ValueError(f"OSLO PK {kind} is unsupported")
+        for target, source_value, source_id in data.get("aperture_pickups", []):
+            source = reference_index(int(source_value), index)
+            if source not in resolved or source >= index or source < 0:
+                raise ValueError(
+                    f"OSLO APK at surface {index} requires a preceding source"
+                )
+            apertures = resolved[source].get("special_apertures", {})
+            if source_id not in apertures:
+                raise ValueError(f"OSLO APK source aperture {source_id} is undefined")
+            data.setdefault("special_apertures", {})[target] = deepcopy(
+                apertures[source_id]
+            )
+    return resolved

--- a/optiland/fileio/oslo/reader/pickups.py
+++ b/optiland/fileio/oslo/reader/pickups.py
@@ -78,7 +78,7 @@ def resolve_pickups(surfaces: dict[int, dict[str, Any]]) -> dict[int, dict[str, 
                 if "glass_wavelengths" in original:
                     data["glass_wavelengths"] = list(original["glass_wavelengths"])
             elif kind in {"TD", "TDM"}:
-                if any(key in original for key in ("GC", "RCO", "BEN")):
+                if any(key in original or key in data for key in ("GC", "RCO", "BEN")):
                     raise ValueError(
                         "OSLO PK TD/TDM with global/return/bend data is not mapped"
                     )

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -11,10 +11,10 @@ from optiland.paraxial_path import require_global_z_geometry
 from optiland.solves.factory import SolveFactory
 
 SOLVES = {
-    "PY": "marginal_ray_height_thickness",
-    "PYC": "chief_ray_height_thickness",
     "PU": "marginal_ray_angle_curvature",
     "PUC": "chief_ray_angle_curvature",
+    "PY": "marginal_ray_height_thickness",
+    "PYC": "chief_ray_height_thickness",
     "EC": None,
 }
 
@@ -71,4 +71,13 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
     ):
         raise ValueError(
             f"{command} target {target:g} could not be reached (got {actual:g})"
+        )
+    if is_height:
+        # Native height solves move coordinates directly. Keep the prescription
+        # thickness consistent for downstream pickups, updater calls and export.
+        optic.surfaces[index].thickness = float(
+            (
+                optic.surfaces[index + 1].geometry.cs.z
+                - optic.surfaces[index].geometry.cs.z
+            ).item()
         )

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -86,6 +86,7 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
 
 def check_solve(optic, index: int, command: str, value: float, scale: float) -> None:
     """Verify a solve target against the current, fully rebuilt prescription."""
+    absolute_tolerance = 1e-9
     if command == "EC":
         x, y = be.array([0.0]), be.array([value * scale])
         first = optic.surfaces[index].geometry
@@ -103,6 +104,16 @@ def check_solve(optic, index: int, command: str, value: float, scale: float) -> 
         actual = float(
             (local_edge[2] - second.sag(local_edge[0], local_edge[1])).item()
         )
+        # Transforming and subtracting positioned points incurs roundoff in
+        # the active precision. Allow a small error budget at that coordinate
+        # scale, including cancellation away from the global origin.
+        epsilon = be.finfo(be.to_numpy(local_edge).dtype).eps
+        magnitude = max(
+            abs(float(component.item()))
+            for vector in (origin1, origin2, edge)
+            for component in vector
+        )
+        absolute_tolerance = max(absolute_tolerance, 8 * epsilon * magnitude)
     else:
         is_height = command in {"PY", "PYC"}
         ray = (
@@ -115,7 +126,7 @@ def check_solve(optic, index: int, command: str, value: float, scale: float) -> 
             ray()[0 if is_height else 1][index + 1 if is_height else index].item()
         )
     if not math.isfinite(actual) or not math.isclose(
-        actual, target, rel_tol=1e-7, abs_tol=1e-9
+        actual, target, rel_tol=1e-7, abs_tol=absolute_tolerance
     ):
         raise ValueError(
             f"{command} at surface {index}: target {target:g} could not be reached "

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -23,6 +23,10 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
     """Solve one surface, checking that native no-op cases did not hide failure."""
     if not 1 <= index < len(optic.surfaces) - 1:
         raise ValueError(f"{command} requires an interior optical surface")
+    if optic.obj_space_telecentric and command in {"PYC", "PUC"}:
+        # Native paraxial chief rays target the stop center, whereas TELE's
+        # real chief rays launch parallel to the object-space axis.
+        raise ValueError("OSLO telecentric chief-ray solves are not mapped")
     require_global_z_geometry(optic.surfaces, f"OSLO {command}")
     if command == "EC":
         height = value * scale

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -65,13 +65,7 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
             if not result.converged:
                 raise ValueError("PUC curvature refinement did not converge")
             residual(result.root)
-    actual = float(ray()[0 if is_height else 1][target_index].item())
-    if not math.isfinite(actual) or not math.isclose(
-        actual, target, rel_tol=1e-7, abs_tol=1e-9
-    ):
-        raise ValueError(
-            f"{command} target {target:g} could not be reached (got {actual:g})"
-        )
+    check_solve(optic, index, command, value, scale)
     if is_height:
         # Native height solves move coordinates directly. Keep the prescription
         # thickness consistent for downstream pickups, updater calls and export.
@@ -80,4 +74,35 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
                 optic.surfaces[index + 1].geometry.cs.z
                 - optic.surfaces[index].geometry.cs.z
             ).item()
+        )
+
+
+def check_solve(optic, index: int, command: str, value: float, scale: float) -> None:
+    """Verify a solve target against the current, fully rebuilt prescription."""
+    if command == "EC":
+        x, y = be.array([0.0]), be.array([value * scale])
+        target = float(
+            (
+                optic.surfaces[index].geometry.sag(x, y)
+                - optic.surfaces[index + 1].geometry.sag(x, y)
+            ).item()
+        )
+        actual = float(optic.surfaces[index].thickness)
+    else:
+        is_height = command in {"PY", "PYC"}
+        ray = (
+            optic.paraxial.chief_ray
+            if command.endswith("C")
+            else optic.paraxial.marginal_ray
+        )
+        target = value * scale if is_height else value
+        actual = float(
+            ray()[0 if is_height else 1][index + 1 if is_height else index].item()
+        )
+    if not math.isfinite(actual) or not math.isclose(
+        actual, target, rel_tol=1e-7, abs_tol=1e-9
+    ):
+        raise ValueError(
+            f"{command} at surface {index}: target {target:g} could not be reached "
+            f"(got {actual:g})"
         )

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -40,6 +40,9 @@ def apply_solve(optic, index: int, command: str, value: float, scale: float) -> 
             raise ValueError("EC edge is outside the surface's sag domain")
         optic.updater.set_thickness(thickness, index)
         return
+    # OSLO paraxial analysis deliberately ignores tilts/decenters (Program
+    # Reference p. 251), as native scalar traces do on straight paths.
+    # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=265
     is_height = command in {"PY", "PYC"}
     target_index = index + 1 if is_height else index
     target = value * scale if is_height else value
@@ -85,13 +88,21 @@ def check_solve(optic, index: int, command: str, value: float, scale: float) -> 
     """Verify a solve target against the current, fully rebuilt prescription."""
     if command == "EC":
         x, y = be.array([0.0]), be.array([value * scale])
-        target = float(
-            (
-                optic.surfaces[index].geometry.sag(x, y)
-                - optic.surfaces[index + 1].geometry.sag(x, y)
-            ).item()
+        first = optic.surfaces[index].geometry
+        second = optic.surfaces[index + 1].geometry
+        # EC requires physical contact (Program Reference p. 45), not just
+        # a TH equal to the difference of two unpositioned local sags. Express
+        # the first surface's edge point in the second surface's coordinates
+        # and check that it lies on that surface after all pickups/transforms.
+        # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=59
+        edge = be.array([0.0, value * scale, float(first.sag(x, y).item())])
+        origin1, rotation1 = first.cs.get_effective_transform()
+        origin2, rotation2 = second.cs.get_effective_transform()
+        local_edge = rotation2.T @ (origin1 + rotation1 @ edge - origin2)
+        target = 0.0
+        actual = float(
+            (local_edge[2] - second.sag(local_edge[0], local_edge[1])).item()
         )
-        actual = float(optic.surfaces[index].thickness)
     else:
         is_height = command in {"PY", "PYC"}
         ray = (

--- a/optiland/fileio/oslo/reader/solves.py
+++ b/optiland/fileio/oslo/reader/solves.py
@@ -1,0 +1,74 @@
+"""Apply OSLO's static sequential solves through Optiland's solve APIs."""
+
+from __future__ import annotations
+
+import math
+
+from scipy.optimize import root_scalar
+
+import optiland.backend as be
+from optiland.paraxial_path import require_global_z_geometry
+from optiland.solves.factory import SolveFactory
+
+SOLVES = {
+    "PY": "marginal_ray_height_thickness",
+    "PYC": "chief_ray_height_thickness",
+    "PU": "marginal_ray_angle_curvature",
+    "PUC": "chief_ray_angle_curvature",
+    "EC": None,
+}
+
+
+def apply_solve(optic, index: int, command: str, value: float, scale: float) -> None:
+    """Solve one surface, checking that native no-op cases did not hide failure."""
+    if not 1 <= index < len(optic.surfaces) - 1:
+        raise ValueError(f"{command} requires an interior optical surface")
+    require_global_z_geometry(optic.surfaces, f"OSLO {command}")
+    if command == "EC":
+        height = value * scale
+        if height < 0:
+            raise ValueError("EC requires a nonnegative edge height")
+        x, y = be.array([0.0]), be.array([height])
+        sag1 = optic.surfaces[index].geometry.sag(x, y)
+        sag2 = optic.surfaces[index + 1].geometry.sag(x, y)
+        thickness = float((sag1 - sag2).item())
+        if not math.isfinite(thickness):
+            raise ValueError("EC edge is outside the surface's sag domain")
+        optic.updater.set_thickness(thickness, index)
+        return
+    is_height = command in {"PY", "PYC"}
+    target_index = index + 1 if is_height else index
+    target = value * scale if is_height else value
+    solve = SolveFactory.create_solve(optic, SOLVES[command], target_index, target)
+    solve.apply()
+    ray = (
+        optic.paraxial.chief_ray
+        if command.endswith("C")
+        else optic.paraxial.marginal_ray
+    )
+    if command == "PUC":
+        # The native chief-angle solve stops at 1e-5. Refine its solution to
+        # preserve the precision of saved OSLO targets without changing that API.
+        curvature = 1 / float(optic.surfaces[index].geometry.radius)
+
+        def residual(c):
+            optic.updater.set_radius(1 / c if c else math.inf, index)
+            return float(ray()[1][index].item()) - target
+
+        if abs(residual(curvature)) > 1e-9:
+            result = root_scalar(
+                residual,
+                x0=curvature,
+                x1=curvature + max(abs(curvature) * 1e-4, 1e-8),
+                xtol=1e-12,
+            )
+            if not result.converged:
+                raise ValueError("PUC curvature refinement did not converge")
+            residual(result.root)
+    actual = float(ray()[0 if is_height else 1][target_index].item())
+    if not math.isfinite(actual) or not math.isclose(
+        actual, target, rel_tol=1e-7, abs_tol=1e-9
+    ):
+        raise ValueError(
+            f"{command} target {target:g} could not be reached (got {actual:g})"
+        )

--- a/optiland/fileio/oslo/surfaces.py
+++ b/optiland/fileio/oslo/surfaces.py
@@ -107,6 +107,7 @@ class EvenAsphereSurfaceHandler(BaseSurfaceHandler):
     def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
         # OSLO ad=4th, ae=6th, af=8th, ag=10th
         coeffs = [
+            0.0,  # Optiland starts at r^2; OSLO AD starts at r^4.
             raw.get("AD", 0.0),
             raw.get("AE", 0.0),
             raw.get("AF", 0.0),
@@ -122,13 +123,20 @@ class EvenAsphereSurfaceHandler(BaseSurfaceHandler):
     def format(self, surface: Surface) -> dict[str, Any]:
         geom = surface.geometry
         coeffs = list(geom.coefficients) if geom.coefficients else []
-        while len(coeffs) < 4:
+        while len(coeffs) < 5:
             coeffs.append(0.0)
+        if coeffs[0] != 0 or any(c != 0 for c in coeffs[5:]):
+            return {
+                "RD": float(geom.radius),
+                "CC": float(getattr(geom, "k", 0.0)),
+                "ASP": "ASR",
+                **{f"AS{i + 1}": float(c) for i, c in enumerate(coeffs)},
+            }
         return {
             "RD": float(geom.radius),
             "CC": float(getattr(geom, "k", 0.0)),
-            "AD": float(coeffs[0]),
-            "AE": float(coeffs[1]),
-            "AF": float(coeffs[2]),
-            "AG": float(coeffs[3]),
+            "AD": float(coeffs[1]),
+            "AE": float(coeffs[2]),
+            "AF": float(coeffs[3]),
+            "AG": float(coeffs[4]),
         }

--- a/optiland/fileio/oslo/surfaces.py
+++ b/optiland/fileio/oslo/surfaces.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import optiland.backend as be
+from optiland.geometries import EvenAsphere, Plane, StandardGeometry
 
 if TYPE_CHECKING:
     from optiland.surfaces.standard_surface import Surface
@@ -91,6 +92,11 @@ class StandardSurfaceHandler(BaseSurfaceHandler):
 
     def format(self, surface: Surface) -> dict[str, Any]:
         geom = surface.geometry
+        # surface_type is mutable metadata, not proof of the actual sag model.
+        if type(geom) not in {StandardGeometry, Plane}:
+            raise NotImplementedError(
+                "OSLO writer cannot export this geometry as a standard surface"
+            )
         return {
             "RD": float(geom.radius),
             "CC": float(getattr(geom, "k", 0.0)),
@@ -122,6 +128,10 @@ class EvenAsphereSurfaceHandler(BaseSurfaceHandler):
 
     def format(self, surface: Surface) -> dict[str, Any]:
         geom = surface.geometry
+        if type(geom) is not EvenAsphere:
+            raise NotImplementedError(
+                "OSLO writer cannot export this geometry as an even asphere"
+            )
         coeffs = list(geom.coefficients) if geom.coefficients else []
         while len(coeffs) < 5:
             coeffs.append(0.0)

--- a/optiland/fileio/oslo/syntax.py
+++ b/optiland/fileio/oslo/syntax.py
@@ -1,0 +1,17 @@
+"""Shared token and quoted-string handling for OSLO prescription data."""
+
+from __future__ import annotations
+
+import re
+
+
+def tokenize(statement: str) -> list[str]:
+    """Split whitespace/comma-separated tokens, preserving quoted strings."""
+    return re.findall(r'"(?:\\.|[^"\\])*"|[^\s,]+', statement)
+
+
+def decode_text(value: str) -> str:
+    """Remove one pair of delimiters and decode escaped quotes/backslashes."""
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        value = value[1:-1]
+    return re.sub(r'\\(["\\])', r"\1", value)

--- a/optiland/fileio/oslo/validation.py
+++ b/optiland/fileio/oslo/validation.py
@@ -1,0 +1,24 @@
+"""Physical constraints shared by OSLO import and export."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
+
+if TYPE_CHECKING:
+    from optiland.optic import Optic
+
+
+def validate_object_na(optic: Optic, value: float) -> None:
+    """Require a finite object and a forward cone smaller than a hemisphere."""
+    if optic.object_surface.is_infinite:
+        raise ValueError("OSLO NAO requires a finite object distance")
+    wavelength = (
+        optic.primary_wavelength if optic.wavelengths else DEFAULT_WAVELENGTHS_UM[0]
+    )
+    n_object = float(optic.object_surface.material_post.n(wavelength).item())
+    # NA = n*sin(theta) (OSLO Program Reference p. 120). Equality needs
+    # extended ray aiming, which is outside the supported launch mapping.
+    if not 0 < value < n_object:
+        raise ValueError("OSLO NAO requires 0 < NA < the object refractive index")

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -15,7 +15,7 @@ import optiland.backend as be
 from optiland.fileio.common import FIELD_CLASS_TO_TYPE
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
-from optiland.materials import AbbeMaterial, IdealMaterial, Material
+from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.physical_apertures import RadialAperture
 
 if TYPE_CHECKING:
@@ -130,6 +130,8 @@ class OpticToOsloEncoder:
             is_mirror = bool(getattr(im, "is_reflective", False))
             is_paraxial = bool(im.interaction_type == "thin_lens")
             material_to_encode = "mirror" if is_mirror else surface.material_post
+            if isinstance(material_to_encode, TabulatedMaterial):
+                surf_data["glass_wavelengths"] = material_to_encode.wavelengths
             surf_data["material"] = self._encode_material(material_to_encode)
 
             # Aperture
@@ -172,6 +174,9 @@ class OpticToOsloEncoder:
 
         if isinstance(material, Material):
             return f"  GLA {material.name}"
+
+        if isinstance(material, TabulatedMaterial):
+            return "  GLA " + " ".join(f"{n:.12g}" for n in material.indices)
 
         if isinstance(material, IdealMaterial):
             n = float(material.index.item())

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
 from optiland.fileio.common import FIELD_CLASS_TO_TYPE
-from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
+from optiland.fileio.oslo.constants import (
+    DEFAULT_WAVELENGTHS_UM,
+    OBJECT_INFINITY_THRESHOLD,
+)
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
@@ -175,6 +178,10 @@ class OpticToOsloEncoder:
 
             # Common properties
             th = float(surface.thickness)
+            if idx == 0 and math.isfinite(th) and abs(th) >= OBJECT_INFINITY_THRESHOLD:
+                raise NotImplementedError(
+                    "OSLO cannot represent this finite object distance; use native JSON"
+                )
             if be.isinf(th):
                 th = math.copysign(1e10, th)
             surf_data["TH"] = th
@@ -198,7 +205,6 @@ class OpticToOsloEncoder:
             surf_data["material"] = self._encode_material(material_to_encode)
 
             # Aperture
-            # th >= 9.9e9 covers both be.inf (converted to 1e10) and 1e10 as-stored
             aperture = surface.aperture
             checked = not isinstance(aperture, UnclippedAperture)
             if not checked:
@@ -209,7 +215,7 @@ class OpticToOsloEncoder:
                 raise NotImplementedError(
                     "OSLO writer cannot export this aperture shape; use native JSON"
                 )
-            if idx == 0 and th >= 9.9e9:
+            if idx == 0 and surface.is_infinite:
                 # Object surface with infinite conjugate: emit a large AP sentinel
                 # matching OSLO EDU convention: AP = tan(max_field_angle) * 1e10
                 max_y = max((abs(f.y) for f in self.optic.fields), default=0.0)

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -79,11 +79,36 @@ class OpticToOsloEncoder:
                 FIELD_CLASS_TO_TYPE.get(type(fd).__name__, "angle") if fd else "angle"
             )
             self.data_model.fields["type"] = f_type
+            if f_type not in {"angle", "object_height"}:
+                raise NotImplementedError(
+                    "OSLO writer cannot export this field definition; use native JSON"
+                )
             # OSLO convention: store only the maximum absolute field value.
             # The reader expands this to [0, 0.7*max, max] on load.
-            y_values = [f.y for f in self.optic.fields]
+            y_values = [v for f in self.optic.fields for v in (f.x, f.y)]
             max_y = max((abs(y) for y in y_values), default=0.0)
             self.data_model.fields["y"] = [max_y]
+            if f_type == "angle" and max_y >= 90:
+                raise NotImplementedError(
+                    "OSLO writer cannot export wide-angle field tables"
+                )
+            points = {}
+            for index, field in enumerate(self.optic.fields, 1):
+                point = {"weight": field.weight, "vx": field.vx, "vy": field.vy}
+                for axis in ("x", "y"):
+                    value = getattr(field, axis)
+                    point[axis] = (
+                        (
+                            math.tan(math.radians(value))
+                            / math.tan(math.radians(max_y))
+                            if f_type == "angle"
+                            else value / max_y
+                        )
+                        if max_y
+                        else 0.0
+                    )
+                points[index] = point
+            self.data_model.fields["points"] = points
 
     def _encode_wavelengths(self) -> None:
         if self.optic.wavelengths:
@@ -110,6 +135,19 @@ class OpticToOsloEncoder:
 
     def _encode_surfaces(self) -> None:
         for idx, surface in enumerate(self.optic.surfaces):
+            position, rotation = surface.geometry.cs.get_effective_transform()
+            if (
+                abs(float(position[0])) > 1e-12
+                or abs(float(position[1])) > 1e-12
+                or not be.allclose(rotation, be.eye(3))
+            ):
+                raise NotImplementedError(
+                    "OSLO writer cannot export transformed surfaces; use native JSON"
+                )
+            if getattr(surface.interaction_model, "phase_profile", None) is not None:
+                raise NotImplementedError(
+                    "OSLO writer cannot export phase profiles; use native JSON"
+                )
             s_type = getattr(surface, "surface_type", "standard") or "standard"
             handler = get_handler_for_optiland_type(s_type)
             surf_data = handler.format(surface)
@@ -117,7 +155,7 @@ class OpticToOsloEncoder:
             # Common properties
             th = float(surface.thickness)
             if be.isinf(th):
-                th = 1e10
+                th = math.copysign(1e10, th)
             surf_data["TH"] = th
 
             # OSLO assumes surface 1 is the stop if no stop is explicitly marked.
@@ -132,6 +170,10 @@ class OpticToOsloEncoder:
             material_to_encode = "mirror" if is_mirror else surface.material_post
             if isinstance(material_to_encode, TabulatedMaterial):
                 surf_data["glass_wavelengths"] = material_to_encode.wavelengths
+            elif isinstance(material_to_encode, AbbeMaterial):
+                surf_data["glass_wavelengths"] = self.data_model.wavelengths.get(
+                    "values"
+                ) or [0.58756, 0.48613, 0.65627]
             surf_data["material"] = self._encode_material(material_to_encode)
 
             # Aperture
@@ -140,6 +182,12 @@ class OpticToOsloEncoder:
             checked = not isinstance(aperture, UnclippedAperture)
             if not checked:
                 aperture = aperture.aperture
+            if aperture is not None and (
+                not isinstance(aperture, RadialAperture) or aperture.r_min != 0
+            ):
+                raise NotImplementedError(
+                    "OSLO writer cannot export this aperture shape; use native JSON"
+                )
             if idx == 0 and th >= 9.9e9:
                 # Object surface with infinite conjugate: emit a large AP sentinel
                 # matching OSLO EDU convention: AP = tan(max_field_angle) * 1e10
@@ -192,17 +240,14 @@ class OpticToOsloEncoder:
             return f"  GLA {ns} {ns} {ns}"
 
         if isinstance(material, AbbeMaterial):
-            nd = float(material.index.item())
-            # OSLO direct index format: GLA <n_d> <n_F> <n_C>
-            try:
-                w_d, w_F, w_C = 0.58756, 0.48613, 0.65627
-                n_d = f"{float(material.n(w_d).item()):.7g}"
-                n_F = f"{float(material.n(w_F).item()):.7g}"
-                n_C = f"{float(material.n(w_C).item()):.7g}"
-                return f"  GLA {n_d} {n_F} {n_C}"
-            except Exception:
-                ns = f"{nd:.7g}"
-                return f"  GLA {ns} {ns} {ns}"
+            wavelengths = self.data_model.wavelengths.get("values") or [
+                0.58756,
+                0.48613,
+                0.65627,
+            ]
+            return "  GLA " + " ".join(
+                f"{float(material.n(w).item()):.12g}" for w in wavelengths
+            )
 
         # Fallback
         try:

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -20,6 +20,7 @@ from optiland.fileio.oslo.constants import (
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
 from optiland.fileio.oslo.validation import validate_object_na
+from optiland.interactions import RefractiveReflectiveModel, ThinLensInteractionModel
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.propagation import HomogeneousPropagation
@@ -158,6 +159,7 @@ class OpticToOsloEncoder:
 
     def _encode_surfaces(self) -> None:
         for idx, surface in enumerate(self.optic.surfaces):
+            interaction = surface.interaction_model
             position, rotation = surface.geometry.cs.get_effective_transform()
             if (
                 abs(float(position[0])) > 1e-12
@@ -167,16 +169,22 @@ class OpticToOsloEncoder:
                 raise NotImplementedError(
                     "OSLO writer cannot export transformed surfaces; use native JSON"
                 )
-            if getattr(surface.interaction_model, "phase_profile", None) is not None:
+            if getattr(interaction, "phase_profile", None) is not None:
                 raise NotImplementedError(
                     "OSLO writer cannot export phase profiles; use native JSON"
                 )
-            if (
-                surface.interaction_model.coating is not None
-                or surface.interaction_model.bsdf is not None
-            ):
+            if interaction.coating is not None or interaction.bsdf is not None:
                 raise NotImplementedError(
                     "OSLO writer cannot export coatings or scattering; use native JSON"
+                )
+            # Subclasses can change the ray physics while inheriting a supported
+            # interaction_type name. Only the explicitly mapped models are safe.
+            if type(interaction) not in {
+                RefractiveReflectiveModel,
+                ThinLensInteractionModel,
+            }:
+                raise NotImplementedError(
+                    "OSLO writer cannot export this interaction model; use native JSON"
                 )
             s_type = getattr(surface, "surface_type", "standard") or "standard"
             handler = get_handler_for_optiland_type(s_type)
@@ -198,10 +206,9 @@ class OpticToOsloEncoder:
                 surf_data["AST"] = True
 
             # Material — detect mirror via interaction_model.is_reflective
-            im = getattr(surface, "interaction_model", None)
-            is_mirror = bool(getattr(im, "is_reflective", False))
-            is_paraxial = bool(im.interaction_type == "thin_lens")
-            material_to_encode = "mirror" if is_mirror else surface.material_post
+            material_to_encode = (
+                "mirror" if interaction.is_reflective else surface.material_post
+            )
             if isinstance(material_to_encode, TabulatedMaterial):
                 surf_data["glass_wavelengths"] = material_to_encode.wavelengths
             elif isinstance(material_to_encode, AbbeMaterial):
@@ -241,8 +248,8 @@ class OpticToOsloEncoder:
                     surf_data["AP"] = float(self.optic.paraxial.EPD()) / 2.0
 
             # Paraxial case
-            if is_paraxial:
-                surf_data["PFL"] = float(surface.interaction_model.f)
+            if isinstance(interaction, ThinLensInteractionModel):
+                surf_data["PFL"] = float(interaction.f)
 
             self.data_model.surfaces[idx] = surf_data
 

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -59,21 +59,33 @@ class OpticToOsloEncoder:
         return self.data_model
 
     def _encode_aperture(self) -> None:
-        if self.optic.aperture:
-            ap_type = self.optic.aperture.ap_type
-            value = self.optic.aperture.value
-            if ap_type == "EPD":
-                self.data_model.aperture["EPD"] = value
-            elif ap_type == "imageFNO":
-                # Prefer EBR when the focal length is available; keep FNO as
-                # the fallback. Convert: EPD = EFL / FNO, EBR = EPD / 2.
-                try:
-                    efl = float(self.optic.paraxial.f2())
-                    self.data_model.aperture["EPD"] = efl / value
-                except Exception:
-                    self.data_model.aperture["FNO"] = value
-            elif ap_type == "objectNA":
-                self.data_model.aperture["NAO"] = value
+        if self.optic.aperture is None:
+            return
+        ap_type = self.optic.aperture.ap_type
+        value = self.optic.aperture.value
+        if ap_type == "objectNA":
+            self.data_model.aperture["NAO"] = value
+            return
+        if ap_type not in {"EPD", "imageFNO", "float_by_stop_size"}:
+            raise NotImplementedError("OSLO writer cannot export this system aperture")
+        infinite = self.optic.object_surface.is_infinite
+        try:
+            # OSLO EBR is the axial beam radius at surface 1, not at the
+            # entrance pupil. Store its diameter under the model's legacy key.
+            diameter = (
+                float(self.optic.paraxial.EPD())
+                if infinite
+                else 2 * abs(float(self.optic.paraxial.marginal_ray()[0][1].item()))
+            )
+        except ValueError:
+            if ap_type != "imageFNO" or not infinite:
+                raise
+            # Preserve the historical no-wavelength export for infinite objects.
+            self.data_model.aperture["FNO"] = value
+            return
+        if not math.isfinite(diameter) or diameter <= 0:
+            raise ValueError("OSLO export requires a finite positive entrance beam")
+        self.data_model.aperture["EPD"] = diameter
 
     def _encode_fields(self) -> None:
         if self.optic.fields:

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -40,8 +40,10 @@ class OpticToOsloEncoder:
         Returns:
             The populated OsloDataModel.
         """
+        self.data_model = OsloDataModel()
         self.data_model.name = self.optic.name or "LENS"
         self.data_model.num_surfaces = len(self.optic.surfaces) - 1  # Excluding object
+        self.data_model.settings["telecentric"] = self.optic.obj_space_telecentric
 
         self._encode_aperture()
         self._encode_fields()
@@ -63,8 +65,8 @@ class OpticToOsloEncoder:
             if ap_type == "EPD":
                 self.data_model.aperture["EPD"] = value
             elif ap_type == "imageFNO":
-                # OSLO always uses EBR (entrance beam radius), never FNO.
-                # Convert: EPD = EFL / FNO, EBR = EPD / 2.
+                # Prefer EBR when the focal length is available; keep FNO as
+                # the fallback. Convert: EPD = EFL / FNO, EBR = EPD / 2.
                 try:
                     efl = float(self.optic.paraxial.f2())
                     self.data_model.aperture["EPD"] = efl / value
@@ -76,16 +78,14 @@ class OpticToOsloEncoder:
     def _encode_fields(self) -> None:
         if self.optic.fields:
             fd = self.optic.fields.field_definition
-            f_type = (
-                FIELD_CLASS_TO_TYPE.get(type(fd).__name__, "angle") if fd else "angle"
-            )
+            f_type = FIELD_CLASS_TO_TYPE.get(type(fd).__name__) if fd else "angle"
             self.data_model.fields["type"] = f_type
             if f_type not in {"angle", "object_height"}:
                 raise NotImplementedError(
                     "OSLO writer cannot export this field definition; use native JSON"
                 )
-            # OSLO convention: store only the maximum absolute field value.
-            # The reader expands this to [0, 0.7*max, max] on load.
+            # ANG/OBH sets the normalization envelope. Explicit RST points
+            # below preserve each field's position, weight and vignetting.
             y_values = [v for f in self.optic.fields for v in (f.x, f.y)]
             max_y = max((abs(y) for y in y_values), default=0.0)
             self.data_model.fields["y"] = [max_y]
@@ -212,12 +212,6 @@ class OpticToOsloEncoder:
             if is_paraxial:
                 surf_data["PFL"] = float(surface.interaction_model.f)
 
-            # Decenter/Tilt
-            for k in ["DCX", "DCY", "DCZ", "TLA", "TLB", "TLC"]:
-                val = getattr(surface, k.lower(), 0.0)
-                if val != 0:
-                    surf_data[k] = float(val)
-
             self.data_model.surfaces[idx] = surf_data
 
     def _encode_material(self, material: Any) -> str:
@@ -241,11 +235,9 @@ class OpticToOsloEncoder:
             return f"  GLA {ns} {ns} {ns}"
 
         if isinstance(material, AbbeMaterial):
-            wavelengths = self.data_model.wavelengths.get("values") or [
-                0.58756,
-                0.48613,
-                0.65627,
-            ]
+            wavelengths = (
+                self.data_model.wavelengths.get("values") or DEFAULT_WAVELENGTHS_UM
+            )
             return "  GLA " + " ".join(
                 f"{float(material.n(w).item()):.12g}" for w in wavelengths
             )

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -177,12 +177,17 @@ class OpticToOsloEncoder:
                 raise NotImplementedError(
                     "OSLO writer cannot export coatings or scattering; use native JSON"
                 )
+            if isinstance(interaction, ThinLensInteractionModel):
+                # PFL transforms rays exactly between principal planes, unlike
+                # the native thin-lens phase (OSLO Program Reference p. 68).
+                # https://lambdares.com/hubfs/Support/support/oslo/oslo_releases/OSLOProgramReference.pdf#page=82
+                raise NotImplementedError(
+                    "OSLO writer cannot export native thin-lens interactions as "
+                    "perfect-imaging PFL surfaces; use native JSON"
+                )
             # Subclasses can change the ray physics while inheriting a supported
-            # interaction_type name. Only the explicitly mapped models are safe.
-            if type(interaction) not in {
-                RefractiveReflectiveModel,
-                ThinLensInteractionModel,
-            }:
+            # interaction_type name. Only the explicitly mapped model is safe.
+            if type(interaction) is not RefractiveReflectiveModel:
                 raise NotImplementedError(
                     "OSLO writer cannot export this interaction model; use native JSON"
                 )
@@ -258,10 +263,6 @@ class OpticToOsloEncoder:
                 # fields; without it only the chief ray is plotted.
                 with contextlib.suppress(Exception):
                     surf_data["AP"] = float(self.optic.paraxial.EPD()) / 2.0
-
-            # Paraxial case
-            if isinstance(interaction, ThinLensInteractionModel):
-                surf_data["PFL"] = float(interaction.f)
 
             self.data_model.surfaces[idx] = surf_data
 

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -228,6 +228,14 @@ class OpticToOsloEncoder:
                 raise NotImplementedError(
                     "OSLO writer cannot export this aperture shape; use native JSON"
                 )
+            if aperture is not None and (
+                not math.isfinite(aperture.r_max) or aperture.r_max <= 0
+            ):
+                # AP=0 does not retain a native zero-radius clipping boundary;
+                # infinite radii would be formatted as finite OSLO sentinels.
+                raise ValueError(
+                    "OSLO export requires a finite positive surface aperture radius"
+                )
             if idx == 0 and surface.is_infinite:
                 # Object surface with infinite conjugate: emit a large AP sentinel
                 # matching OSLO EDU convention: AP = tan(max_field_angle) * 1e10

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -191,7 +191,11 @@ class OpticToOsloEncoder:
             surf_data = handler.format(surface)
 
             # Common properties
-            th = float(surface.thickness)
+            # Native final-surface thickness does not move the detector. OSLO
+            # image TH would add defocus to the preceding physical gap instead.
+            th = (
+                0.0 if idx == self.data_model.num_surfaces else float(surface.thickness)
+            )
             if idx == 0 and math.isfinite(th) and abs(th) >= OBJECT_INFINITY_THRESHOLD:
                 raise NotImplementedError(
                     "OSLO cannot represent this finite object distance; use native JSON"

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -148,6 +148,10 @@ class OpticToOsloEncoder:
                     + weights[primary_idx + 1 :]
                 )
 
+            # OSLO requires wavelength 1 to carry nonzero weight (Program
+            # Reference p. 123). Check after moving the native primary first.
+            if weights[0] <= 0:
+                raise ValueError("OSLO primary wavelength weight must be positive")
             self.data_model.wavelengths["values"] = values
             self.data_model.wavelengths["weights"] = weights
             self.data_model.wavelengths["primary_index"] = 0

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -77,7 +77,7 @@ class OpticToOsloEncoder:
         infinite = self.optic.object_surface.is_infinite
         try:
             # OSLO EBR is the axial beam radius at surface 1, not at the
-            # entrance pupil. Store its diameter under the model's legacy key.
+            # entrance pupil. The shared model stores this diameter as EPD.
             diameter = (
                 float(self.optic.paraxial.EPD())
                 if infinite

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -16,6 +16,7 @@ from optiland.fileio.common import FIELD_CLASS_TO_TYPE
 from optiland.fileio.oslo.constants import (
     DEFAULT_WAVELENGTHS_UM,
     OBJECT_INFINITY_THRESHOLD,
+    THICKNESS_INFINITY_THRESHOLD,
 )
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
@@ -158,6 +159,7 @@ class OpticToOsloEncoder:
             self.data_model.wavelengths["primary_index"] = 0
 
     def _encode_surfaces(self) -> None:
+        positions = self.optic.surfaces.global_z_positions
         for idx, surface in enumerate(self.optic.surfaces):
             interaction = surface.interaction_model
             position, rotation = surface.geometry.cs.get_effective_transform()
@@ -195,17 +197,31 @@ class OpticToOsloEncoder:
             handler = get_handler_for_optiland_type(s_type)
             surf_data = handler.format(surface)
 
-            # Common properties
+            # Coordinates define the traced geometry. The construction-time
+            # thickness attribute can be zero for absolute-coordinate systems
+            # or stale after direct coordinate edits.
             # Native final-surface thickness does not move the detector. OSLO
             # image TH would add defocus to the preceding physical gap instead.
             th = (
-                0.0 if idx == self.data_model.num_surfaces else float(surface.thickness)
+                0.0
+                if idx == self.data_model.num_surfaces
+                else float((positions[idx + 1] - positions[idx]).item())
             )
+            if math.isnan(th):
+                raise ValueError("OSLO export requires defined axial surface spacings")
             if idx == 0 and math.isfinite(th) and abs(th) >= OBJECT_INFINITY_THRESHOLD:
                 raise NotImplementedError(
                     "OSLO cannot represent this finite object distance; use native JSON"
                 )
-            if be.isinf(th):
+            if (
+                idx > 0
+                and math.isfinite(th)
+                and abs(th) >= THICKNESS_INFINITY_THRESHOLD
+            ):
+                raise NotImplementedError(
+                    "OSLO cannot represent this finite surface spacing; use native JSON"
+                )
+            if math.isinf(th):
                 th = math.copysign(1e10, th)
             surf_data["TH"] = th
 

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -19,6 +19,7 @@ from optiland.fileio.oslo.constants import (
 )
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
+from optiland.fileio.oslo.validation import validate_object_na
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.propagation import HomogeneousPropagation
@@ -68,6 +69,7 @@ class OpticToOsloEncoder:
         ap_type = self.optic.aperture.ap_type
         value = self.optic.aperture.value
         if ap_type == "objectNA":
+            validate_object_na(self.optic, value)
             self.data_model.aperture["NAO"] = value
             return
         if ap_type not in {"EPD", "imageFNO", "float_by_stop_size"}:

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -290,7 +290,7 @@ class OpticToOsloEncoder:
             return f"  GLA {material.name}"
 
         if isinstance(material, TabulatedMaterial):
-            return "  GLA " + " ".join(f"{n:.12g}" for n in material.indices)
+            return "  GLA " + " ".join(str(n) for n in material.indices)
 
         if isinstance(material, IdealMaterial):
             if float(material.absorp.item()) != 0:
@@ -311,5 +311,5 @@ class OpticToOsloEncoder:
             self.data_model.wavelengths.get("values") or DEFAULT_WAVELENGTHS_UM
         )
         return "  GLA " + " ".join(
-            f"{float(material.n(w).item()):.12g}" for w in wavelengths
+            str(float(material.n(w).item())) for w in wavelengths
         )

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -275,10 +275,10 @@ class OpticToOsloEncoder:
                     "use native JSON"
                 )
             n = float(material.index.item())
-            # IdealMaterial with n≈1.0 is air - write AIR, not GLA 1.0 1.0 1.0
-            if abs(n - 1.0) < 1e-6:
+            # Small index differences still carry optical path and power.
+            if n == 1.0:
                 return "  AIR"
-            ns = f"{n:.7g}"
+            ns = str(n)
             return f"  GLA {ns} {ns} {ns}"
 
         # The remaining supported type is AbbeMaterial, sampled at the design

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -18,6 +18,7 @@ from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
+from optiland.propagation import HomogeneousPropagation
 
 if TYPE_CHECKING:
     from optiland.optic import Optic
@@ -161,6 +162,13 @@ class OpticToOsloEncoder:
                 raise NotImplementedError(
                     "OSLO writer cannot export phase profiles; use native JSON"
                 )
+            if (
+                surface.interaction_model.coating is not None
+                or surface.interaction_model.bsdf is not None
+            ):
+                raise NotImplementedError(
+                    "OSLO writer cannot export coatings or scattering; use native JSON"
+                )
             s_type = getattr(surface, "surface_type", "standard") or "standard"
             handler = get_handler_for_optiland_type(s_type)
             surf_data = handler.format(surface)
@@ -196,7 +204,7 @@ class OpticToOsloEncoder:
             if not checked:
                 aperture = aperture.aperture
             if aperture is not None and (
-                not isinstance(aperture, RadialAperture) or aperture.r_min != 0
+                type(aperture) is not RadialAperture or aperture.r_min != 0
             ):
                 raise NotImplementedError(
                     "OSLO writer cannot export this aperture shape; use native JSON"
@@ -232,6 +240,20 @@ class OpticToOsloEncoder:
         if material == "mirror":
             return "  RFL"
 
+        if type(material) not in {
+            Material,
+            TabulatedMaterial,
+            IdealMaterial,
+            AbbeMaterial,
+        }:
+            raise NotImplementedError(
+                "OSLO writer cannot export this material model; use native JSON"
+            )
+        if type(material.propagation_model) is not HomogeneousPropagation:
+            raise NotImplementedError(
+                "OSLO writer cannot export custom propagation; use native JSON"
+            )
+
         if isinstance(material, Material):
             return f"  GLA {material.name}"
 
@@ -239,6 +261,11 @@ class OpticToOsloEncoder:
             return "  GLA " + " ".join(f"{n:.12g}" for n in material.indices)
 
         if isinstance(material, IdealMaterial):
+            if float(material.absorp.item()) != 0:
+                raise NotImplementedError(
+                    "OSLO writer cannot export ideal-material absorption; "
+                    "use native JSON"
+                )
             n = float(material.index.item())
             # IdealMaterial with n≈1.0 is air - write AIR, not GLA 1.0 1.0 1.0
             if abs(n - 1.0) < 1e-6:
@@ -246,17 +273,11 @@ class OpticToOsloEncoder:
             ns = f"{n:.7g}"
             return f"  GLA {ns} {ns} {ns}"
 
-        if isinstance(material, AbbeMaterial):
-            wavelengths = (
-                self.data_model.wavelengths.get("values") or DEFAULT_WAVELENGTHS_UM
-            )
-            return "  GLA " + " ".join(
-                f"{float(material.n(w).item()):.12g}" for w in wavelengths
-            )
-
-        # Fallback
-        try:
-            name = getattr(material, "name", str(material))
-            return f"  GLA {name}"
-        except Exception:
-            return "  AIR"
+        # The remaining supported type is AbbeMaterial, sampled at the design
+        # wavelengths so export does not invent a catalog-glass identity.
+        wavelengths = (
+            self.data_model.wavelengths.get("values") or DEFAULT_WAVELENGTHS_UM
+        )
+        return "  GLA " + " ".join(
+            f"{float(material.n(w).item()):.12g}" for w in wavelengths
+        )

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -16,7 +16,7 @@ from optiland.fileio.common import FIELD_CLASS_TO_TYPE
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
-from optiland.physical_apertures import RadialAperture
+from optiland.physical_apertures import RadialAperture, UnclippedAperture
 
 if TYPE_CHECKING:
     from optiland.optic import Optic
@@ -136,6 +136,10 @@ class OpticToOsloEncoder:
 
             # Aperture
             # th >= 9.9e9 covers both be.inf (converted to 1e10) and 1e10 as-stored
+            aperture = surface.aperture
+            checked = not isinstance(aperture, UnclippedAperture)
+            if not checked:
+                aperture = aperture.aperture
             if idx == 0 and th >= 9.9e9:
                 # Object surface with infinite conjugate: emit a large AP sentinel
                 # matching OSLO EDU convention: AP = tan(max_field_angle) * 1e10
@@ -145,8 +149,9 @@ class OpticToOsloEncoder:
                 else:
                     sentinel = 1e10
                 surf_data["AP"] = sentinel
-            elif surface.aperture and isinstance(surface.aperture, RadialAperture):
-                surf_data["AP"] = float(surface.aperture.r_max)
+            elif isinstance(aperture, RadialAperture):
+                surf_data["AP"] = float(aperture.r_max)
+                surf_data["aperture_checked"] = checked
             elif surface.is_stop:
                 # No explicit physical aperture on stop: derive from paraxial EPD.
                 # OSLO requires AP on the stop to draw full ray bundles for off-axis

--- a/optiland/fileio/oslo/writer/encoder.py
+++ b/optiland/fileio/oslo/writer/encoder.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
 from optiland.fileio.common import FIELD_CLASS_TO_TYPE
+from optiland.fileio.oslo.constants import DEFAULT_WAVELENGTHS_UM
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.surfaces import get_handler_for_optiland_type
 from optiland.materials import AbbeMaterial, IdealMaterial, Material, TabulatedMaterial
@@ -173,7 +174,7 @@ class OpticToOsloEncoder:
             elif isinstance(material_to_encode, AbbeMaterial):
                 surf_data["glass_wavelengths"] = self.data_model.wavelengths.get(
                     "values"
-                ) or [0.58756, 0.48613, 0.65627]
+                ) or list(DEFAULT_WAVELENGTHS_UM)
             surf_data["material"] = self._encode_material(material_to_encode)
 
             # Aperture

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -147,7 +147,9 @@ class OsloDataFormatter:
                 if math.isinf(data["TH"])
                 else data["TH"]
             )
-            lines.append(f"  TH {self._fmt(th)}")  # 1e10 is OSLO's infinity convention
+            # Retain the shortest round-trippable value: rounding a finite
+            # object distance up to OSLO's cutoff changes the ray launch.
+            lines.append(f"  TH {th}")
 
         if "AP" in data:
             flag = "CHK " if data.get("aperture_checked") else ""

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -33,7 +33,7 @@ class OsloDataFormatter:
         lines: list[str] = []
         lines.append("// OSLO 5.00 0 0 0")
         lines.append(
-            f'LEN NEW "{self.model.name}" '
+            f'LEN NEW "{self._quote(self.model.name)}" '
             f"{self._fmt(self.model.scaling)} {self.model.num_surfaces}"
         )
 
@@ -52,6 +52,24 @@ class OsloDataFormatter:
         self._format_wavelength_footer(lines)
 
         lines.append(f"END {self.model.num_surfaces}")
+        points = self.model.fields.get("points", {})
+        if points:
+            lines.append("RST NEW")
+            for index, point in points.items():
+                values = [
+                    point["y"],
+                    point["x"],
+                    0,
+                    0,
+                    0,
+                    point["vy"] - 1,
+                    1 - point["vy"],
+                    point["vx"] - 1,
+                    1 - point["vx"],
+                    point["weight"],
+                ]
+                lines.append(f"F {index} {self._fmt_vals(values)}")
+            lines.append("END")
         lines.append("")
 
         return "\n".join(lines)
@@ -77,7 +95,11 @@ class OsloDataFormatter:
         for cmd, content in self.model.notes.items():
             if cmd == "DES":
                 continue  # already emitted explicitly above
-            lines.append(f'{cmd} "{content}"')
+            lines.append(f'{cmd} "{self._quote(content)}"')
+
+    @staticmethod
+    def _quote(content: str) -> str:
+        return content.replace("\\", "\\\\").replace('"', '\\"')
 
     def _format_wavelength_footer(self, lines: list[str]) -> None:
         """Emit WV/WW footer lines (after surfaces, before END) per convention."""
@@ -93,8 +115,8 @@ class OsloDataFormatter:
             lines.append(f"WW {self._fmt_vals(weights[: len(vals)])}")
 
     def _fmt_vals(self, values: list[float]) -> str:
-        """Format up to the first 3 values, matching OSLO's WV/WW convention."""
-        return " ".join(self._fmt(v) for v in values)
+        """Preserve all spectral and field entries with sufficient precision."""
+        return " ".join(f"{v:.12g}" for v in values)
 
     def _format_surface(
         self, lines: list[str], index: int, data: dict[str, Any]
@@ -116,7 +138,11 @@ class OsloDataFormatter:
             lines.append(f"  RD {self._fmt(data['RD'])}")
 
         if "TH" in data:
-            th = 1e10 if math.isinf(data["TH"]) else data["TH"]
+            th = (
+                math.copysign(1e10, data["TH"])
+                if math.isinf(data["TH"])
+                else data["TH"]
+            )
             lines.append(f"  TH {self._fmt(th)}")  # 1e10 is OSLO's infinity convention
 
         if "AP" in data:
@@ -162,5 +188,5 @@ class OsloDataFormatter:
     def _fmt(self, val: float) -> str:
         """Format float for OSLO using compact decimal notation (≤7 sig figs)."""
         if math.isinf(val):
-            return "1.0e+10"
+            return "-1.0e+10" if val < 0 else "1.0e+10"
         return f"{val:.7g}"

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -120,7 +120,8 @@ class OsloDataFormatter:
             lines.append(f"  TH {self._fmt(th)}")  # 1e10 is OSLO's infinity convention
 
         if "AP" in data:
-            lines.append(f"  AP {self._fmt(data['AP'])}")
+            flag = "CHK " if data.get("aperture_checked") else ""
+            lines.append(f"  AP {flag}{self._fmt(data['AP'])}")
 
         if data.get("AST"):
             lines.append("  AST")

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -94,11 +94,13 @@ class OsloDataFormatter:
 
     def _fmt_vals(self, values: list[float]) -> str:
         """Format up to the first 3 values, matching OSLO's WV/WW convention."""
-        return " ".join(self._fmt(v) for v in values[:3])
+        return " ".join(self._fmt(v) for v in values)
 
     def _format_surface(
         self, lines: list[str], index: int, data: dict[str, Any]
     ) -> None:
+        if "glass_wavelengths" in data:
+            lines.append(f"WV {self._fmt_vals(data['glass_wavelengths'])}")
         lines.append(data.get("material", "AIR"))
 
         self._format_surface_geometry(lines, data)

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -82,7 +82,8 @@ class OsloDataFormatter:
         if "FNO" in self.model.aperture:
             lines.append(f"FNO {self._fmt(self.model.aperture['FNO'])}")
         if "NAO" in self.model.aperture:
-            lines.append(f"NAO {self._fmt(self.model.aperture['NAO'])}")
+            # Rounding upward can turn a valid cone into NA == n_object.
+            lines.append(f"NAO {float(self.model.aperture['NAO'])}")
 
     def _format_field_commands(self, lines: list[str]) -> None:
         if "y" not in self.model.fields:
@@ -91,7 +92,9 @@ class OsloDataFormatter:
             "OBH" if self.model.fields.get("type") == "object_height" else "ANG"
         )
         for y in self.model.fields["y"]:
-            lines.append(f"{field_type_cmd} {self._fmt(y)}")
+            # Preserve the normalization used to encode fractional fields,
+            # including angular references immediately below 90 degrees.
+            lines.append(f"{field_type_cmd} {float(y)}")
 
     def _format_notes(self, lines: list[str]) -> None:
         for cmd, content in self.model.notes.items():
@@ -119,8 +122,8 @@ class OsloDataFormatter:
             lines.append(f"WW {self._fmt_vals(weights[: len(vals)])}")
 
     def _fmt_vals(self, values: list[float]) -> str:
-        """Preserve all spectral and field entries with sufficient precision."""
-        return " ".join(f"{v:.12g}" for v in values)
+        """Preserve distinct spectral samples and field normalization exactly."""
+        return " ".join(str(float(v)) for v in values)
 
     def _format_surface(
         self, lines: list[str], index: int, data: dict[str, Any]

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -42,6 +42,8 @@ class OsloDataFormatter:
         # DES and UNI are always emitted (OSLO EDU convention)
         lines.append('DES "Optiland"')
         lines.append(f"UNI {self._fmt(self.model.units)}")
+        if self.model.settings.get("telecentric"):
+            lines.append("TELE ON")
 
         self._format_field_commands(lines)
         self._format_notes(lines)
@@ -99,6 +101,8 @@ class OsloDataFormatter:
 
     @staticmethod
     def _quote(content: str) -> str:
+        if "\n" in content or "\r" in content:
+            raise ValueError("OSLO names and notes must fit on a single line")
         return content.replace("\\", "\\\\").replace('"', '\\"')
 
     def _format_wavelength_footer(self, lines: list[str]) -> None:

--- a/optiland/fileio/oslo/writer/formatter.py
+++ b/optiland/fileio/oslo/writer/formatter.py
@@ -130,6 +130,13 @@ class OsloDataFormatter:
             lines.append(f"CC {self._fmt(data['CC'])}")
 
     def _format_surface_aspherics(self, lines: list[str], data: dict[str, Any]) -> None:
+        if "ASP" in data:
+            coefficients = {
+                k: v for k, v in data.items() if k.startswith("AS") and k[2:].isdigit()
+            }
+            lines.append(f"ASP {data['ASP']} {len(coefficients)}")
+            for key, value in coefficients.items():
+                lines.append(f"{key} {self._fmt(value)}")
         for key in ("AD", "AE", "AF", "AG"):
             if key in data:
                 lines.append(f"{key} {self._fmt(data[key])}")

--- a/optiland/materials/__init__.py
+++ b/optiland/materials/__init__.py
@@ -21,6 +21,7 @@ from .material_utils import (
     plot_nk,
 )
 from .registry import MaterialRegistry
+from .tabulated import TabulatedMaterial
 from .warnings import OptilandMaterialWarning
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "BaseMaterial",
     # From ideal.py
     "IdealMaterial",
+    "TabulatedMaterial",
     # From material.py
     "Material",
     # From material_file.py

--- a/optiland/materials/tabulated.py
+++ b/optiland/materials/tabulated.py
@@ -36,6 +36,8 @@ class TabulatedMaterial(BaseMaterial):
 
     def _calculate_n(self, wavelength: Any, **kwargs: Any) -> Any:
         wave = be.asarray(wavelength)
+        if not be.all(be.isfinite(wave)):
+            raise ValueError("Tabulated wavelengths must be finite")
         if be.any(wave < self.wavelengths[0]) or be.any(wave > self.wavelengths[-1]):
             raise ValueError(f"Wavelength outside tabulated range for {self.name!r}")
         return be.atleast_1d(

--- a/optiland/materials/tabulated.py
+++ b/optiland/materials/tabulated.py
@@ -1,0 +1,58 @@
+"""In-memory refractive-index samples with bounded linear interpolation."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import optiland.backend as be
+from optiland.materials.base import BaseMaterial
+
+
+class TabulatedMaterial(BaseMaterial):
+    """Preserve measured or imported indices at their specified wavelengths.
+
+    Args:
+        wavelengths: Distinct positive wavelengths in micrometers.
+        indices: Corresponding positive refractive indices.
+        name: Optional source material name.
+
+    Values between samples are linearly interpolated. Extrapolation is rejected;
+    samples alone do not determine a dispersion formula outside their range.
+    """
+
+    def __init__(self, wavelengths: list[float], indices: list[float], name: str = ""):
+        super().__init__()
+        if len(wavelengths) != len(indices) or len(wavelengths) < 2:
+            raise ValueError("Tabulated material requires at least two paired samples")
+        pairs = sorted(zip(wavelengths, indices, strict=True))
+        if any(not math.isfinite(v) or v <= 0 for pair in pairs for v in pair):
+            raise ValueError("Wavelengths and indices must be finite and positive")
+        if len(set(wavelengths)) != len(wavelengths):
+            raise ValueError("Tabulated material wavelengths must be distinct")
+        self.wavelengths = [float(w) for w, _ in pairs]
+        self.indices = [float(n) for _, n in pairs]
+        self.name = name
+
+    def _calculate_n(self, wavelength: Any, **kwargs: Any) -> Any:
+        wave = be.asarray(wavelength)
+        if be.any(wave < self.wavelengths[0]) or be.any(wave > self.wavelengths[-1]):
+            raise ValueError(f"Wavelength outside tabulated range for {self.name!r}")
+        return be.atleast_1d(
+            be.interp(wave, be.array(self.wavelengths), be.array(self.indices))
+        )
+
+    def _calculate_k(self, wavelength: Any, **kwargs: Any) -> Any:
+        return be.zeros_like(be.asarray(wavelength))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "wavelengths": self.wavelengths,
+            "indices": self.indices,
+            "name": self.name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TabulatedMaterial:
+        return cls(data["wavelengths"], data["indices"], data.get("name", ""))

--- a/optiland/materials/tabulated.py
+++ b/optiland/materials/tabulated.py
@@ -19,6 +19,7 @@ class TabulatedMaterial(BaseMaterial):
 
     Values between samples are linearly interpolated. Extrapolation is rejected;
     samples alone do not determine a dispersion formula outside their range.
+    Sample wavelengths must remain distinct in the active backend precision.
     """
 
     def __init__(self, wavelengths: list[float], indices: list[float], name: str = ""):
@@ -40,9 +41,15 @@ class TabulatedMaterial(BaseMaterial):
             raise ValueError("Tabulated wavelengths must be finite")
         if be.any(wave < self.wavelengths[0]) or be.any(wave > self.wavelengths[-1]):
             raise ValueError(f"Wavelength outside tabulated range for {self.name!r}")
-        return be.atleast_1d(
-            be.interp(wave, be.array(self.wavelengths), be.array(self.indices))
-        )
+        samples = be.array(self.wavelengths)
+        # Distinct Python floats can coincide after conversion to float32.
+        # A zero-width interpolation interval would produce NaN indices.
+        if be.any(samples[1:] <= samples[:-1]):
+            raise ValueError(
+                "Tabulated wavelengths must remain distinct at the active "
+                "backend precision"
+            )
+        return be.atleast_1d(be.interp(wave, samples, be.array(self.indices)))
 
     def _calculate_k(self, wavelength: Any, **kwargs: Any) -> Any:
         return be.zeros_like(be.asarray(wavelength))

--- a/optiland/materials/tabulated.py
+++ b/optiland/materials/tabulated.py
@@ -57,4 +57,4 @@ class TabulatedMaterial(BaseMaterial):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TabulatedMaterial:
-        return cls(data["wavelengths"], data["indices"], data.get("name", ""))
+        return cls(data["wavelengths"], data["indices"], data["name"])

--- a/optiland/physical_apertures/__init__.py
+++ b/optiland/physical_apertures/__init__.py
@@ -7,3 +7,4 @@ from .offset_radial import OffsetRadialAperture
 from .elliptical import EllipticalAperture
 from .polygon import PolygonAperture, FileAperture
 from .rotated import RotatedAperture
+from .unclipped import UnclippedAperture

--- a/optiland/physical_apertures/__init__.py
+++ b/optiland/physical_apertures/__init__.py
@@ -6,3 +6,4 @@ from .rectangular import RectangularAperture
 from .offset_radial import OffsetRadialAperture
 from .elliptical import EllipticalAperture
 from .polygon import PolygonAperture, FileAperture
+from .rotated import RotatedAperture

--- a/optiland/physical_apertures/elliptical.py
+++ b/optiland/physical_apertures/elliptical.py
@@ -37,7 +37,12 @@ class EllipticalAperture(BaseAperture):
             tuple: The extent of the aperture in the x and y directions.
 
         """
-        return -self.a, self.a, -self.b, self.b
+        return (
+            self.offset_x - self.a,
+            self.offset_x + self.a,
+            self.offset_y - self.b,
+            self.offset_y + self.b,
+        )
 
     def contains(self, x, y):
         """Checks if the given point is inside the aperture.

--- a/optiland/physical_apertures/rotated.py
+++ b/optiland/physical_apertures/rotated.py
@@ -1,4 +1,4 @@
-"""Rotation of an existing physical aperture around the surface origin."""
+"""Rotation of an existing physical aperture around a specified pivot."""
 
 from __future__ import annotations
 
@@ -14,17 +14,34 @@ class RotatedAperture(BaseAperture):
     Args:
         aperture: The aperture to rotate.
         angle: Rotation angle in radians.
+        center_x: Pivot x-coordinate, defaulting to the surface origin.
+        center_y: Pivot y-coordinate, defaulting to the surface origin.
     """
 
-    def __init__(self, aperture: BaseAperture, angle: float):
+    def __init__(
+        self,
+        aperture: BaseAperture,
+        angle: float,
+        center_x: float = 0.0,
+        center_y: float = 0.0,
+    ):
         self.aperture = aperture
         self.angle = angle
+        self.center_x = center_x
+        self.center_y = center_y
 
     @property
     def extent(self) -> tuple[float, float, float, float]:
         x0, x1, y0, y1 = self.aperture.extent
         c, s = math.cos(self.angle), math.sin(self.angle)
-        corners = [(c * x - s * y, s * x + c * y) for x in (x0, x1) for y in (y0, y1)]
+        corners = [
+            (
+                self.center_x + c * (x - self.center_x) - s * (y - self.center_y),
+                self.center_y + s * (x - self.center_x) + c * (y - self.center_y),
+            )
+            for x in (x0, x1)
+            for y in (y0, y1)
+        ]
         return (
             min(x for x, _ in corners),
             max(x for x, _ in corners),
@@ -34,18 +51,30 @@ class RotatedAperture(BaseAperture):
 
     def contains(self, x: Any, y: Any) -> Any:
         c, s = math.cos(self.angle), math.sin(self.angle)
-        return self.aperture.contains(c * x + s * y, -s * x + c * y)
+        x, y = x - self.center_x, y - self.center_y
+        return self.aperture.contains(
+            self.center_x + c * x + s * y, self.center_y - s * x + c * y
+        )
 
     def scale(self, scale_factor: float) -> None:
         self.aperture.scale(scale_factor)
+        self.center_x *= scale_factor
+        self.center_y *= scale_factor
 
     def to_dict(self) -> dict[str, Any]:
         return {
             **super().to_dict(),
             "aperture": self.aperture.to_dict(),
             "angle": self.angle,
+            "center_x": self.center_x,
+            "center_y": self.center_y,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> RotatedAperture:
-        return cls(BaseAperture.from_dict(data["aperture"]), data["angle"])
+        return cls(
+            BaseAperture.from_dict(data["aperture"]),
+            data["angle"],
+            data.get("center_x", 0.0),
+            data.get("center_y", 0.0),
+        )

--- a/optiland/physical_apertures/rotated.py
+++ b/optiland/physical_apertures/rotated.py
@@ -75,6 +75,6 @@ class RotatedAperture(BaseAperture):
         return cls(
             BaseAperture.from_dict(data["aperture"]),
             data["angle"],
-            data.get("center_x", 0.0),
-            data.get("center_y", 0.0),
+            data["center_x"],
+            data["center_y"],
         )

--- a/optiland/physical_apertures/rotated.py
+++ b/optiland/physical_apertures/rotated.py
@@ -1,0 +1,51 @@
+"""Rotation of an existing physical aperture around the surface origin."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from optiland.physical_apertures.base import BaseAperture
+
+
+class RotatedAperture(BaseAperture):
+    """Rotate an aperture counterclockwise about +z.
+
+    Args:
+        aperture: The aperture to rotate.
+        angle: Rotation angle in radians.
+    """
+
+    def __init__(self, aperture: BaseAperture, angle: float):
+        self.aperture = aperture
+        self.angle = angle
+
+    @property
+    def extent(self) -> tuple[float, float, float, float]:
+        x0, x1, y0, y1 = self.aperture.extent
+        c, s = math.cos(self.angle), math.sin(self.angle)
+        corners = [(c * x - s * y, s * x + c * y) for x in (x0, x1) for y in (y0, y1)]
+        return (
+            min(x for x, _ in corners),
+            max(x for x, _ in corners),
+            min(y for _, y in corners),
+            max(y for _, y in corners),
+        )
+
+    def contains(self, x: Any, y: Any) -> Any:
+        c, s = math.cos(self.angle), math.sin(self.angle)
+        return self.aperture.contains(c * x + s * y, -s * x + c * y)
+
+    def scale(self, scale_factor: float) -> None:
+        self.aperture.scale(scale_factor)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "aperture": self.aperture.to_dict(),
+            "angle": self.angle,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RotatedAperture:
+        return cls(BaseAperture.from_dict(data["aperture"]), data["angle"])

--- a/optiland/physical_apertures/unclipped.py
+++ b/optiland/physical_apertures/unclipped.py
@@ -1,0 +1,32 @@
+"""A drawing boundary whose shape does not clip traced rays."""
+
+from __future__ import annotations
+
+from optiland.physical_apertures.base import BaseAperture
+
+
+class UnclippedAperture(BaseAperture):
+    """Retain an aperture's display shape while disabling ray clipping."""
+
+    def __init__(self, aperture: BaseAperture):
+        self.aperture = aperture
+
+    @property
+    def extent(self):
+        return self.aperture.extent
+
+    def contains(self, x, y):
+        return self.aperture.contains(x, y)
+
+    def clip(self, rays):
+        """Leave ray intensity unchanged; this is a drawing boundary."""
+
+    def scale(self, scale_factor):
+        self.aperture.scale(scale_factor)
+
+    def to_dict(self):
+        return {"type": self.__class__.__name__, "aperture": self.aperture.to_dict()}
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(BaseAperture.from_dict(data["aperture"]))

--- a/scripts/audit_oslo_examples.py
+++ b/scripts/audit_oslo_examples.py
@@ -1,0 +1,113 @@
+"""Audit a locally downloaded official OSLO demo ZIP; never execute its commands."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import tempfile
+import warnings
+import zipfile
+from collections import Counter
+from pathlib import Path
+
+import optiland.backend as be
+from optiland.fileio import load_oslo_file
+
+SOURCE = (
+    "https://lambdares.com/hubfs/Support/support/oslo/oslo_examples/OSLOLensDemos.zip"
+)
+
+
+def audit(archive: Path, backend: str) -> dict:
+    """Return per-file permissive, strict and on-axis ray-trace outcomes."""
+    be.set_backend(backend)
+    rows = []
+    with (
+        tempfile.TemporaryDirectory(prefix="oslo-audit-") as directory,
+        zipfile.ZipFile(archive) as zipped,
+    ):
+        for name in sorted(zipped.namelist()):
+            if not name.lower().endswith(".len"):
+                continue
+            raw = zipped.read(name)
+            # Do not extract archive-supplied paths or execute any embedded CCL.
+            path = Path(directory) / "example.len"
+            path.write_bytes(raw)
+            row = {"file": name, "sha256": hashlib.sha256(raw).hexdigest()}
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                try:
+                    optic = load_oslo_file(path)
+                    row["import_error"] = None
+                except Exception as exc:  # Audit all files, including broken examples.
+                    optic = None
+                    row["import_error"] = f"{type(exc).__name__}: {exc}"
+                row["warnings"] = list(dict.fromkeys(str(w.message) for w in caught))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                try:
+                    load_oslo_file(path, strict=True)
+                    row["strict_error"] = None
+                except Exception as exc:
+                    row["strict_error"] = f"{type(exc).__name__}: {exc}"
+                if optic is not None:
+                    try:
+                        rays = optic.trace(
+                            0,
+                            0,
+                            optic.primary_wavelength,
+                            num_rays=5,
+                            distribution="line_y",
+                        )
+                        finite = (
+                            be.isfinite(rays.x)
+                            & be.isfinite(rays.y)
+                            & be.isfinite(rays.z)
+                        )
+                        row["finite_transmitted_rays"] = int(
+                            be.sum(finite & (rays.i > 0)).item()
+                        )
+                        row["trace_error"] = None
+                    except Exception as exc:
+                        row["trace_error"] = f"{type(exc).__name__}: {exc}"
+            row = json.loads(
+                json.dumps(row).replace(str(path).replace("\\", "\\\\"), name)
+            )
+            rows.append(row)
+    return {
+        "source": SOURCE,
+        "archive_sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
+        "python": platform.python_version(),
+        "backend": backend,
+        "summary": dict(
+            Counter(
+                "failed"
+                if row["import_error"]
+                else "warned"
+                if row["warnings"]
+                else "clean"
+                for row in rows
+            )
+        ),
+        "strict_successes": sum(row["strict_error"] is None for row in rows),
+        "note": "Import and on-axis smoke success do not certify "
+        "optical equivalence to OSLO.",
+        "files": rows,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--backend", choices=("numpy", "torch"), default="numpy")
+    args = parser.parse_args()
+    report = audit(args.archive, args.backend)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({k: v for k, v in report.items() if k != "files"}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_oslo_examples.py
+++ b/scripts/audit_oslo_examples.py
@@ -72,9 +72,14 @@ def audit(archive: Path, backend: str) -> dict:
                         row["trace_error"] = None
                     except Exception as exc:
                         row["trace_error"] = f"{type(exc).__name__}: {exc}"
-            row = json.loads(
-                json.dumps(row).replace(str(path).replace("\\", "\\\\"), name)
-            )
+            # Replace paths in strings before JSON encoding, so quotes and
+            # backslashes in archive member names remain ordinary text.
+            row["warnings"] = [
+                message.replace(str(path), name) for message in row["warnings"]
+            ]
+            for key in ("import_error", "strict_error", "trace_error"):
+                if row.get(key):
+                    row[key] = row[key].replace(str(path), name)
             rows.append(row)
     return {
         "source": SOURCE,

--- a/tests/test_fileio/conftest.py
+++ b/tests/test_fileio/conftest.py
@@ -1,0 +1,33 @@
+"""Shared prescriptions for OSLO import and export regression tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def lens_file(tmp_path):
+    """Write an original, small prescription with independently known power."""
+
+    def write(
+        *,
+        system="",
+        surface="",
+        second="",
+        image="",
+        footer="",
+        aperture="EBR 2",
+        distance="1e20",
+    ):
+        path = tmp_path / "edge.len"
+        path.write_text(
+            'LEN NEW "edge cases" 50 3\n'
+            f"{aperture}\nANG 0\n{system}\nTH {distance}\nNXT\n"
+            f"GLA 1.5\nRD 20\nTH 2\nAP 3\n{surface}\nNXT\n"
+            f"AIR\nRD -20\nTH 20\n{second}\nNXT\nAIR\n{image}\n"
+            f"END 3\n{footer}",
+            encoding="utf-8",
+        )
+        return path
+
+    return write

--- a/tests/test_fileio/test_oslo_apertures.py
+++ b/tests/test_fileio/test_oslo_apertures.py
@@ -1,0 +1,59 @@
+"""OSLO polygon boundaries must satisfy the documented vertex geometry."""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.fileio import load_oslo_file
+from tests.utils import assert_allclose
+
+
+def polygon_commands(vertices):
+    commands = [f"APN 1\nATP A {len(vertices)}"]
+    commands.extend(
+        f"AVX{index} A {x}\nAVY{index} A {y}"
+        for index, (x, y) in enumerate(vertices, 1)
+    )
+    return "\n".join(commands)
+
+
+@pytest.mark.parametrize(
+    "vertices",
+    [
+        [(0, 0), (1, 1), (2, 2)],  # Collinear triangle.
+        [(0, 0), (1, 1), (0, 0)],  # Repeated vertex.
+        [(-1, -1), (1, 1), (-1, 1), (1, -1)],  # Crossing edges.
+        [(0, 0), (2, 0), (0.5, 0.5), (0, 2)],  # Concave quadrangle.
+        [(0, 0), (1, 0), (2, 0), (0, 1)],  # Straight interior angle.
+    ],
+)
+@pytest.mark.parametrize("strict", [False, True])
+def test_invalid_polygon_boundaries_are_rejected(lens_file, vertices, strict):
+    with pytest.raises(ValueError, match="polygon.*nondegenerate.*convex"):
+        load_oslo_file(lens_file(surface=polygon_commands(vertices)), strict=strict)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("units", [1, 10])
+@pytest.mark.parametrize(
+    "vertices,point",
+    [
+        ([(0, 0), (2, 0), (0, 2)], (0.5, 0.5)),
+        ([(-1, -1), (1, -1), (1, 1), (-1, 1)], (0, 0)),
+    ],
+)
+def test_polygon_winding_and_units_preserve_interior_clipping(
+    lens_file, set_test_backend, vertices, point, reverse, units
+):
+    optic = load_oslo_file(
+        lens_file(
+            system=f"UNI {units}",
+            surface=polygon_commands(vertices[::-1] if reverse else vertices),
+        ),
+        strict=True,
+    )
+    aperture = optic.surfaces[1].aperture
+    x = be.array([point[0], 3]) * units
+    y = be.array([point[1], 3]) * units
+    assert_allclose(aperture.contains(x, y), [True, False])

--- a/tests/test_fileio/test_oslo_audit.py
+++ b/tests/test_fileio/test_oslo_audit.py
@@ -1,9 +1,98 @@
-"""The example audit preserves diagnostics for arbitrary archive member names."""
+"""The example audit distinguishes import, strict validation and tracing outcomes."""
 
+import hashlib
 import json
+import runpy
+import sys
 import zipfile
 
+import optiland.backend as be
+from optiland.optic import Optic
+from scripts import audit_oslo_examples
 from scripts.audit_oslo_examples import audit
+
+
+CLEAN_LENS = (
+    'LEN NEW "audit" 50 3\nEBR 2\nANG 0\n'
+    "TH 1e20\nNXT\nGLA 1.5\nRD 20\nTH 2\n"
+    "NXT\nAIR\nRD -20\nTH 20\nNXT\nAIR\nEND 3\n"
+)
+
+
+def test_audit_counts_each_outcome_and_skips_non_lens_members(
+    tmp_path, set_test_backend
+):
+    archive = tmp_path / "outcomes.zip"
+    members = {
+        "a-clean.LEN": CLEAN_LENS,
+        "b-broken.len": 'LEN NEW "broken" 1 3\nRD invalid\n',
+        "c-warned.len": CLEAN_LENS.replace("RD 20", "UNMAPPED\nRD 20"),
+        "readme.txt": "Not an optical prescription",
+    }
+    with zipfile.ZipFile(archive, "w") as zipped:
+        for name, content in members.items():
+            zipped.writestr(name, content)
+    report = audit(archive, be.get_backend())
+    clean, broken, warned = report["files"]
+    assert [row["file"] for row in report["files"]] == sorted(members)[:3]
+    assert report["summary"] == {"clean": 1, "failed": 1, "warned": 1}
+    assert report["strict_successes"] == 1
+    assert report["archive_sha256"] == hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert clean["sha256"] == hashlib.sha256(CLEAN_LENS.encode()).hexdigest()
+    assert clean["warnings"] == []
+    assert (
+        clean["strict_error"] is clean["import_error"] is clean["trace_error"] is None
+    )
+    assert clean["finite_transmitted_rays"] == 5
+    assert broken["import_error"].startswith("ValueError: b-broken.len:")
+    assert broken["strict_error"].startswith("ValueError: b-broken.len:")
+    assert "trace_error" not in broken
+    assert "finite_transmitted_rays" not in broken
+    assert "UNMAPPED" in warned["strict_error"]
+    assert warned["import_error"] is warned["trace_error"] is None
+    assert "oslo-audit-" not in json.dumps(report)
+
+
+def test_audit_records_trace_failure_without_changing_import_status(
+    tmp_path, monkeypatch, set_test_backend
+):
+    archive = tmp_path / "trace.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("clean.len", CLEAN_LENS)
+
+    def fail_trace(self, *args, **kwargs):
+        raise RuntimeError("trace failed after import")
+
+    monkeypatch.setattr(Optic, "trace", fail_trace)
+    report = audit(archive, be.get_backend())
+    row = report["files"][0]
+    assert report["summary"] == {"clean": 1}
+    assert report["strict_successes"] == 1
+    assert row["import_error"] is row["strict_error"] is None
+    assert row["trace_error"] == "RuntimeError: trace failed after import"
+    assert "finite_transmitted_rays" not in row
+
+
+def test_audit_cli_writes_full_report_and_prints_only_summary(
+    tmp_path, monkeypatch, capsys
+):
+    archive = tmp_path / "cli.zip"
+    output = tmp_path / "report.json"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("clean.len", CLEAN_LENS)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["audit_oslo_examples", str(archive), str(output), "--backend", "numpy"],
+    )
+    # Execute the entry point in-process so CI coverage includes the CLI itself.
+    runpy.run_path(audit_oslo_examples.__file__, run_name="__main__")
+    report = json.loads(output.read_text(encoding="utf-8"))
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == {key: value for key, value in report.items() if key != "files"}
+    assert report["backend"] == "numpy"
+    assert report["summary"] == {"clean": 1}
+    assert report["files"][0]["finite_transmitted_rays"] == 5
 
 
 def test_archive_member_names_are_normalized_before_json_encoding(tmp_path):

--- a/tests/test_fileio/test_oslo_audit.py
+++ b/tests/test_fileio/test_oslo_audit.py
@@ -1,0 +1,28 @@
+"""The example audit preserves diagnostics for arbitrary archive member names."""
+
+import json
+import zipfile
+
+from scripts.audit_oslo_examples import audit
+
+
+def test_archive_member_names_are_normalized_before_json_encoding(tmp_path):
+    name = 'demos/quoted "lens"\\example.len'
+    archive = tmp_path / "examples.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr(
+            name,
+            'LEN NEW "audit" 50 3\nEBR 2\nANG 0\n'
+            "TH 1e20\nNXT\nGLA 1.5\nRD 20\nTH 2\n"
+            "UNMAPPED\nNXT\nAIR\nRD -20\nTH 20\nNXT\nAIR\nEND 3\n",
+        )
+        # ZipFile normalizes native directory separators when writing on Windows.
+        name = zipped.namelist()[0]
+    report = audit(archive, "numpy")
+    row = json.loads(json.dumps(report))["files"][0]
+    assert row["file"] == name
+    assert row["import_error"] is None
+    assert name in row["warnings"][0]
+    assert name in row["strict_error"]
+    assert "oslo-audit-" not in json.dumps(report)
+    assert report["summary"] == {"warned": 1}

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -1,0 +1,72 @@
+"""Independent OSLO command and physical-behavior regression tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from optiland.fileio import load_oslo_file
+from optiland.fileio.oslo.reader.parser import OsloDataParser
+
+
+def write_lens(tmp_path, text):
+    path = tmp_path / "commands.len"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_statements_quotes_comments_and_empty_image(tmp_path):
+    path = write_lens(tmp_path, '\ufefflen new "a; b // c" 1 2\n'
+                      'ebr 2; ang 1 // inline\n'
+                      'th 1e20; nxt // surface 1\n'
+                      'rd 30; th 5; nxt; end 2\n')
+    data = OsloDataParser(path).parse()
+    assert data.name == "a; b // c"
+    assert data.aperture["EPD"] == 4
+    assert list(data.surfaces) == [0, 1, 2]
+    assert data.surfaces[1]["RD"] == 30
+
+
+def test_gto_updates_selected_surface_and_parser_reuse(tmp_path):
+    path = write_lens(tmp_path, 'LEN NEW "navigation" 1 2\nTH 1e10\n'
+                      'NXT\nRD 10\nNXT\nAIR\nGTO 1\nTH 3\nEND 2\n')
+    parser = OsloDataParser(path)
+    for _ in range(2):
+        data = parser.parse()
+        assert data.surfaces[1]["TH"] == 3
+        assert data.surfaces[1]["RD"] == 10
+        assert len(data.surfaces) == 3
+
+
+def test_unknown_optical_command_is_reported_and_strict_rejects(tmp_path):
+    path = write_lens(tmp_path, 'LEN NEW "unsupported" 1 1\nTH 1e10\n'
+                      'NXT\nMAGIC 8\nEND 1\n')
+    with pytest.warns(UserWarning, match="MAGIC"):
+        data = OsloDataParser(path).parse()
+    diagnostic = data.diagnostics[0]
+    assert diagnostic.command == "MAGIC"
+    assert diagnostic.line == 4
+    assert diagnostic.surface == 1
+    with pytest.raises(ValueError, match="MAGIC"):
+        OsloDataParser(path, strict=True).parse()
+
+
+@pytest.mark.parametrize("command", ["RD", "TH nope", "AP nan", 'DES "unterminated'])
+def test_malformed_command_has_source_context(tmp_path, command):
+    path = write_lens(tmp_path, f'LEN NEW "bad" 1 0\n{command}\nEND 0\n')
+    with pytest.raises(ValueError, match=r"commands.len:2"):
+        OsloDataParser(path).parse()
+
+
+def test_legacy_encoding_and_trailing_analysis_are_not_executed(tmp_path):
+    path = tmp_path / "legacy.len"
+    path.write_bytes('LEN NEW "Caf\xe9" 1 1\nTH 1e10\nNXT\nEND 1\n'
+                     'DLNR 0 11\nRD 999\n'.encode("cp1252"))
+    data = OsloDataParser(path).parse()
+    assert data.name == "Caf\xe9"
+    assert "RD" not in data.surfaces[1]
+
+
+def test_public_loader_exposes_strict_mode(tmp_path):
+    path = write_lens(tmp_path, 'LEN NEW "strict" 1 1\nNXT\nUNKNOWN 1\nEND 1\n')
+    with pytest.raises(ValueError, match="UNKNOWN"):
+        load_oslo_file(path, strict=True)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 import optiland.backend as be
-from optiland.fileio import load_oslo_file
+from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from tests.utils import assert_allclose
 
@@ -132,3 +132,47 @@ def test_image_na_and_telecentric(tmp_path, set_test_backend):
     assert optic.aperture.ap_type == "EPD"
     assert_allclose(optic.aperture.value, .2 / power)
     assert optic.obj_space_telecentric is True
+
+
+@pytest.mark.parametrize("command,radius", [("CV .05", 20), ("CVF -.1", -10),
+                                            ("RDF 0", be.inf), ("RD 0", be.inf)])
+def test_curvature_and_fixed_aliases(tmp_path, set_test_backend, command, radius):
+    optic = load_oslo_file(simple_lens(tmp_path, surface=command), strict=True)
+    assert_allclose(optic.surfaces[1].geometry.radius, radius)
+
+
+def test_oslo_standard_asphere_power_and_scaled_sag(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='UNI 10',
+                                     surface='RD 0\nAD .001\nAE .00001'), strict=True)
+    sag = optic.surfaces[1].geometry.sag(be.array([20.0]), be.array([0.0]))
+    assert_allclose(sag, [10 * (.001 * 2**4 + .00001 * 2**6)])
+    out = tmp_path / 'asphere.len'
+    save_oslo_file(optic, out)
+    restored = load_oslo_file(out, strict=True)
+    assert_allclose(restored.surfaces[1].geometry.sag(be.array([20.0]), 0), sag)
+
+
+@pytest.mark.parametrize("command,expected", [
+    ('ASP ASR 6\nAS1 .01\nAS6 1e-9', .01 * 4 + 1e-9 * 2**12),
+    ('ASP ARA 3\nAS1 .01\nAS3 .001', .01 * 2 + .001 * 2**3),
+    ('ASP ASX 2\nAS0 .02\nAS1 .01\nAS4 .003', .02 + .01 * 2),
+])
+def test_general_asphere_equations(tmp_path, set_test_backend, command, expected):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='RD 0\n' + command), strict=True)
+    assert_allclose(optic.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])), [expected])
+
+
+@pytest.mark.parametrize("cvx", [0, .025])
+def test_toric_profile_matches_independent_equation(tmp_path, set_test_backend, cvx):
+    optic = load_oslo_file(simple_lens(tmp_path, surface=f'CVX {cvx}\nAD .0001'), strict=True)
+    x, y = be.array([1.0]), be.array([2.0])
+    zy = 20 - (20**2 - 4)**.5 + .0001 * 2**4
+    expected = zy if cvx == 0 else 40 - ((40 - zy)**2 - 1)**.5
+    assert_allclose(optic.surfaces[1].geometry.sag(x, y), [expected])
+
+
+def test_hatched_reflector_and_fixed_air(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='RFH'), strict=True)
+    assert optic.surfaces[1].interaction_model.is_reflective
+    optic = load_oslo_file(simple_lens(tmp_path, surface='AIF'), strict=True)
+    assert_allclose(optic.surfaces[1].material_post.n(.55), 1)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -17,10 +17,13 @@ def write_lens(tmp_path, text):
 
 
 def test_statements_quotes_comments_and_empty_image(tmp_path):
-    path = write_lens(tmp_path, '\ufefflen new "a; b // c" 1 2\n'
-                      'ebr 2; ang 1 // inline\n'
-                      'th 1e20; nxt // surface 1\n'
-                      'rd 30; th 5; nxt; end 2\n')
+    path = write_lens(
+        tmp_path,
+        '\ufefflen new "a; b // c" 1 2\n'
+        "ebr 2; ang 1 // inline\n"
+        "th 1e20; nxt // surface 1\n"
+        "rd 30; th 5; nxt; end 2\n",
+    )
     data = OsloDataParser(path).parse()
     assert data.name == "a; b // c"
     assert data.aperture["EPD"] == 4
@@ -29,8 +32,10 @@ def test_statements_quotes_comments_and_empty_image(tmp_path):
 
 
 def test_gto_updates_selected_surface_and_parser_reuse(tmp_path):
-    path = write_lens(tmp_path, 'LEN NEW "navigation" 1 2\nTH 1e10\n'
-                      'NXT\nRD 10\nNXT\nAIR\nGTO 1\nTH 3\nEND 2\n')
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "navigation" 1 2\nTH 1e10\nNXT\nRD 10\nNXT\nAIR\nGTO 1\nTH 3\nEND 2\n',
+    )
     parser = OsloDataParser(path)
     for _ in range(2):
         data = parser.parse()
@@ -40,8 +45,9 @@ def test_gto_updates_selected_surface_and_parser_reuse(tmp_path):
 
 
 def test_unknown_optical_command_is_reported_and_strict_rejects(tmp_path):
-    path = write_lens(tmp_path, 'LEN NEW "unsupported" 1 1\nTH 1e10\n'
-                      'NXT\nMAGIC 8\nEND 1\n')
+    path = write_lens(
+        tmp_path, 'LEN NEW "unsupported" 1 1\nTH 1e10\nNXT\nMAGIC 8\nEND 1\n'
+    )
     with pytest.warns(UserWarning, match="MAGIC"):
         data = OsloDataParser(path).parse()
     diagnostic = data.diagnostics[0]
@@ -61,8 +67,11 @@ def test_malformed_command_has_source_context(tmp_path, command):
 
 def test_legacy_encoding_and_trailing_analysis_are_not_executed(tmp_path):
     path = tmp_path / "legacy.len"
-    path.write_bytes('LEN NEW "Caf\xe9" 1 1\nTH 1e10\nNXT\nEND 1\n'
-                     'DLNR 0 11\nRD 999\n'.encode("cp1252"))
+    path.write_bytes(
+        'LEN NEW "Caf\xe9" 1 1\nTH 1e10\nNXT\nEND 1\nDLNR 0 11\nRD 999\n'.encode(
+            "cp1252"
+        )
+    )
     data = OsloDataParser(path).parse()
     assert data.name == "Caf\xe9"
     assert "RD" not in data.surfaces[1]
@@ -75,22 +84,29 @@ def test_public_loader_exposes_strict_mode(tmp_path):
 
 
 def simple_lens(tmp_path, system="", surface="", footer=""):
-    return write_lens(tmp_path, 'LEN NEW "commands" 50 3\nEBR 2\nANG 0\n'
-                      f'{system}\nTH 1e20\nNXT\nGLA 1.5 1.5 1.5\n'
-                      f'RD 20\nTH 2\nAP 3\n{surface}\nNXT\n'
-                      f'AIR\nRD -20\nTH 20\nNXT\nAIR\n{footer}\nEND 3\n')
+    return write_lens(
+        tmp_path,
+        'LEN NEW "commands" 50 3\nEBR 2\nANG 0\n'
+        f"{system}\nTH 1e20\nNXT\nGLA 1.5 1.5 1.5\n"
+        f"RD 20\nTH 2\nAP 3\n{surface}\nNXT\n"
+        f"AIR\nRD -20\nTH 20\nNXT\nAIR\n{footer}\nEND 3\n",
+    )
 
 
 def test_wavelength_slots_replace_preserve_order_weights_and_defaults(tmp_path):
-    path = simple_lens(tmp_path, footer='WV .6 .5 .7\nWW 1 2 3\n'
-                       'WV2 .45\nWV4 .8\nWW2 4\nWW4 5')
+    path = simple_lens(
+        tmp_path, footer="WV .6 .5 .7\nWW 1 2 3\nWV2 .45\nWV4 .8\nWW2 4\nWW4 5"
+    )
     data = OsloDataParser(path).parse()
-    assert data.wavelengths["values"] == [.6, .45, .7, .8]
+    assert data.wavelengths["values"] == [0.6, 0.45, 0.7, 0.8]
     assert data.wavelengths["weights"] == [1, 4, 3, 5]
-    path = simple_lens(tmp_path, system='WV .6 .5 .7', footer='WV .55\nWW 2')
-    assert OsloDataParser(path).parse().wavelengths["values"] == [.55]
+    path = simple_lens(tmp_path, system="WV .6 .5 .7", footer="WV .55\nWW 2")
+    assert OsloDataParser(path).parse().wavelengths["values"] == [0.55]
     assert OsloDataParser(simple_lens(tmp_path)).parse().wavelengths["values"] == [
-        .58756, .48613, .65627]
+        0.58756,
+        0.48613,
+        0.65627,
+    ]
 
 
 @pytest.mark.parametrize("command", ["WV 0", "WV -1", "WW -1", "UNI 0", "UNI -2"])
@@ -99,167 +115,220 @@ def test_invalid_system_values_rejected(tmp_path, command):
         OsloDataParser(simple_lens(tmp_path, footer=command)).parse()
 
 
-def test_units_scale_prescription_aperture_and_object_height(tmp_path, set_test_backend):
-    path = simple_lens(tmp_path, system='UNI 25.4\nOBH 1')
+def test_units_scale_prescription_aperture_and_object_height(
+    tmp_path, set_test_backend
+):
+    path = simple_lens(tmp_path, system="UNI 25.4\nOBH 1")
     # Finite object: the field is a length in the same units as the lens.
-    path.write_text(path.read_text().replace('TH 1e20', 'TH 10'))
+    path.write_text(path.read_text().replace("TH 1e20", "TH 10"))
     optic = load_oslo_file(path)
     assert_allclose(optic.surfaces[1].geometry.radius, 20 * 25.4)
     assert_allclose(optic.surfaces[1].thickness, 2 * 25.4)
     assert_allclose(optic.surfaces[1].aperture.extent[1], 3 * 25.4)
     assert_allclose(optic.aperture.value, 4 * 25.4)
     assert_allclose(optic.fields.y_fields[-1], 25.4)
-    assert_allclose(optic.wavelengths.primary_wavelength.value, .58756)
+    assert_allclose(optic.wavelengths.primary_wavelength.value, 0.58756)
 
 
 def test_infinite_object_field_uses_actual_oslo_distance(tmp_path, set_test_backend):
-    path = simple_lens(tmp_path, system='OBH -1e20')
+    path = simple_lens(tmp_path, system="OBH -1e20")
     optic = load_oslo_file(path)
     assert_allclose(optic.fields.y_fields[-1], 45)
     assert be.isinf(optic.surfaces[0].thickness)
 
 
 def test_system_aperture_last_command_wins(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='FNO 8\nEBR 3'))
+    optic = load_oslo_file(simple_lens(tmp_path, system="FNO 8\nEBR 3"))
     assert optic.aperture.ap_type == "EPD"
     assert_allclose(optic.aperture.value, 6)
 
 
 def test_image_na_and_telecentric(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='NAP .1\nTELE ON'))
+    optic = load_oslo_file(simple_lens(tmp_path, system="NAP .1\nTELE ON"))
     # Thick symmetric lens power = (n-1)(1/R1-1/R2+(n-1)t/(n R1 R2)).
-    power = .5 * (.1 - .5 * 2 / (1.5 * 400))
+    power = 0.5 * (0.1 - 0.5 * 2 / (1.5 * 400))
     assert optic.aperture.ap_type == "EPD"
-    assert_allclose(optic.aperture.value, .2 / power)
+    assert_allclose(optic.aperture.value, 0.2 / power)
     assert optic.obj_space_telecentric is True
 
 
-@pytest.mark.parametrize("command,radius", [("CV .05", 20), ("CVF -.1", -10),
-                                            ("RDF 0", be.inf), ("RD 0", be.inf)])
+@pytest.mark.parametrize(
+    "command,radius",
+    [("CV .05", 20), ("CVF -.1", -10), ("RDF 0", be.inf), ("RD 0", be.inf)],
+)
 def test_curvature_and_fixed_aliases(tmp_path, set_test_backend, command, radius):
     optic = load_oslo_file(simple_lens(tmp_path, surface=command), strict=True)
     assert_allclose(optic.surfaces[1].geometry.radius, radius)
 
 
 def test_oslo_standard_asphere_power_and_scaled_sag(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='UNI 10',
-                                     surface='RD 0\nAD .001\nAE .00001'), strict=True)
+    optic = load_oslo_file(
+        simple_lens(tmp_path, system="UNI 10", surface="RD 0\nAD .001\nAE .00001"),
+        strict=True,
+    )
     sag = optic.surfaces[1].geometry.sag(be.array([20.0]), be.array([0.0]))
-    assert_allclose(sag, [10 * (.001 * 2**4 + .00001 * 2**6)])
-    out = tmp_path / 'asphere.len'
+    assert_allclose(sag, [10 * (0.001 * 2**4 + 0.00001 * 2**6)])
+    out = tmp_path / "asphere.len"
     save_oslo_file(optic, out)
     restored = load_oslo_file(out, strict=True)
     assert_allclose(restored.surfaces[1].geometry.sag(be.array([20.0]), 0), sag)
 
 
-@pytest.mark.parametrize("command,expected", [
-    ('ASP ASR 6\nAS1 .01\nAS6 1e-9', .01 * 4 + 1e-9 * 2**12),
-    ('ASP ARA 3\nAS1 .01\nAS3 .001', .01 * 2 + .001 * 2**3),
-    ('ASP ASX 2\nAS0 .02\nAS1 .01\nAS4 .003', .02 + .01 * 2),
-])
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("ASP ASR 6\nAS1 .01\nAS6 1e-9", 0.01 * 4 + 1e-9 * 2**12),
+        ("ASP ARA 3\nAS1 .01\nAS3 .001", 0.01 * 2 + 0.001 * 2**3),
+        ("ASP ASX 2\nAS0 .02\nAS1 .01\nAS4 .003", 0.02 + 0.01 * 2),
+    ],
+)
 def test_general_asphere_equations(tmp_path, set_test_backend, command, expected):
     with pytest.warns(UserWarning, match="asphere.*paraxial"):
-        optic = load_oslo_file(simple_lens(tmp_path, surface='RD 0\n' + command))
-    assert_allclose(optic.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])), [expected])
+        optic = load_oslo_file(simple_lens(tmp_path, surface="RD 0\n" + command))
+    assert_allclose(
+        optic.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])), [expected]
+    )
 
 
-@pytest.mark.parametrize("cvx", [0, .025])
+@pytest.mark.parametrize("cvx", [0, 0.025])
 def test_toric_profile_matches_independent_equation(tmp_path, set_test_backend, cvx):
-    optic = load_oslo_file(simple_lens(tmp_path, surface=f'CVX {cvx}\nAD .0001'), strict=True)
+    optic = load_oslo_file(
+        simple_lens(tmp_path, surface=f"CVX {cvx}\nAD .0001"), strict=True
+    )
     x, y = be.array([1.0]), be.array([2.0])
-    zy = 20 - (20**2 - 4)**.5 + .0001 * 2**4
-    expected = zy if cvx == 0 else 40 - ((40 - zy)**2 - 1)**.5
+    zy = 20 - (20**2 - 4) ** 0.5 + 0.0001 * 2**4
+    expected = zy if cvx == 0 else 40 - ((40 - zy) ** 2 - 1) ** 0.5
     assert_allclose(optic.surfaces[1].geometry.sag(x, y), [expected])
 
 
 def test_hatched_reflector_and_fixed_air(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='RFH'), strict=True)
+    optic = load_oslo_file(simple_lens(tmp_path, surface="RFH"), strict=True)
     assert optic.surfaces[1].interaction_model.is_reflective
-    optic = load_oslo_file(simple_lens(tmp_path, surface='AIF'), strict=True)
-    assert_allclose(optic.surfaces[1].material_post.n(.55), 1)
+    optic = load_oslo_file(simple_lens(tmp_path, surface="AIF"), strict=True)
+    assert_allclose(optic.surfaces[1].material_post.n(0.55), 1)
 
 
-@pytest.mark.parametrize("definition", ['GLA CUSTOM 1.7 1.72 1.68',
-                                         'GLA 1.7 1.72 1.68',
-                                         'GLA MOD G1 1.7 1.72 1.68'])
-def test_embedded_indices_use_definition_wavelengths(tmp_path, set_test_backend, definition):
-    path = simple_lens(tmp_path, surface='WV .6 .4 .8\n' + definition,
-                       footer='WV .6\nWW 1')
+@pytest.mark.parametrize(
+    "definition",
+    ["GLA CUSTOM 1.7 1.72 1.68", "GLA 1.7 1.72 1.68", "GLA MOD G1 1.7 1.72 1.68"],
+)
+def test_embedded_indices_use_definition_wavelengths(
+    tmp_path, set_test_backend, definition
+):
+    path = simple_lens(
+        tmp_path, surface="WV .6 .4 .8\n" + definition, footer="WV .6\nWW 1"
+    )
     optic = load_oslo_file(path, strict=True)
     material = optic.surfaces[1].material_post
-    assert_allclose(material.n(be.array([.4, .6, .8])), [1.72, 1.7, 1.68])
-    out = tmp_path / 'material.len'
+    assert_allclose(material.n(be.array([0.4, 0.6, 0.8])), [1.72, 1.7, 1.68])
+    out = tmp_path / "material.len"
     save_oslo_file(optic, out)
-    assert_allclose(load_oslo_file(out).surfaces[1].material_post.n(.6), 1.7)
+    assert_allclose(load_oslo_file(out).surfaces[1].material_post.n(0.6), 1.7)
 
 
 def test_single_direct_index_and_unknown_glass_strict(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='GLA 1.65'), strict=True)
-    assert_allclose(optic.surfaces[1].material_post.n(.55), 1.65)
+    optic = load_oslo_file(simple_lens(tmp_path, surface="GLA 1.65"), strict=True)
+    assert_allclose(optic.surfaces[1].material_post.n(0.55), 1.65)
     with pytest.raises(ValueError, match="MISSING_GLASS"):
-        load_oslo_file(simple_lens(tmp_path, surface='GLA MISSING_GLASS'), strict=True)
+        load_oslo_file(simple_lens(tmp_path, surface="GLA MISSING_GLASS"), strict=True)
 
 
-def test_tabulated_material_validation_interpolation_and_serialization(set_test_backend):
+def test_tabulated_material_validation_interpolation_and_serialization(
+    set_test_backend,
+):
     from optiland.materials import BaseMaterial, TabulatedMaterial
-    mat = TabulatedMaterial([.6, .4, .8], [1.5, 1.6, 1.4], name='example')
-    assert_allclose(mat.n(be.array([.4, .5, .6, .7, .8])), [1.6, 1.55, 1.5, 1.45, 1.4])
-    assert_allclose(BaseMaterial.from_dict(mat.to_dict()).n(.5), 1.55)
+
+    mat = TabulatedMaterial([0.6, 0.4, 0.8], [1.5, 1.6, 1.4], name="example")
+    assert_allclose(
+        mat.n(be.array([0.4, 0.5, 0.6, 0.7, 0.8])), [1.6, 1.55, 1.5, 1.45, 1.4]
+    )
+    assert_allclose(BaseMaterial.from_dict(mat.to_dict()).n(0.5), 1.55)
     with pytest.raises(ValueError, match="range"):
-        mat.n(.9)
+        mat.n(0.9)
     with pytest.raises(ValueError):
-        TabulatedMaterial([.5, .5], [1.5, 1.6])
+        TabulatedMaterial([0.5, 0.5], [1.5, 1.6])
 
 
-@pytest.mark.parametrize('shape,points,expected', [
-    (1, [(1, 0), (0, 0), (1, 1.1), (2.1, 0)], [True, True, False, False]),
-    (2, [(1.9, .9), (2.1, 0), (0, 1.1)], [True, False, False]),
-])
+@pytest.mark.parametrize(
+    "shape,points,expected",
+    [
+        (1, [(1, 0), (0, 0), (1, 1.1), (2.1, 0)], [True, True, False, False]),
+        (2, [(1.9, 0.9), (2.1, 0), (0, 1.1)], [True, False, False]),
+    ],
+)
 def test_special_aperture_shapes(tmp_path, set_test_backend, shape, points, expected):
-    commands = f'APN 1\nATP A {shape}\nAAC A 4\nAX1 A 0\nAX2 A 2\nAY1 A -1\nAY2 A 1'
+    commands = f"APN 1\nATP A {shape}\nAAC A 4\nAX1 A 0\nAX2 A 2\nAY1 A -1\nAY2 A 1"
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
     aperture = optic.surfaces[1].aperture
-    assert_allclose(aperture.contains(be.array([p[0] for p in points]),
-                                     be.array([p[1] for p in points])), expected)
+    assert_allclose(
+        aperture.contains(
+            be.array([p[0] for p in points]), be.array([p[1] for p in points])
+        ),
+        expected,
+    )
 
 
 def test_obstruction_groups_and_native_serialization(tmp_path, set_test_backend):
     from optiland.physical_apertures import BaseAperture
-    commands = ('AP CHK 3\nAPN 2\nATP A 1\nAAC A 2\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1\n'
-                'ATP B 2\nAAC B 4\nAGN B 1\nAX1 B -.1\nAX2 B .1\nAY1 B -.1\nAY2 B .1')
-    aperture = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True).surfaces[1].aperture
+
+    commands = (
+        "AP CHK 3\nAPN 2\nATP A 1\nAAC A 2\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1\n"
+        "ATP B 2\nAAC B 4\nAGN B 1\nAX1 B -.1\nAX2 B .1\nAY1 B -.1\nAY2 B .1"
+    )
+    aperture = (
+        load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+        .surfaces[1]
+        .aperture
+    )
     for ap in [aperture, BaseAperture.from_dict(aperture.to_dict())]:
-        assert_allclose(ap.contains(be.array([0, .5, 2, 4]), be.array([0, 0, 0, 0])),
-                        [True, False, True, False])
+        assert_allclose(
+            ap.contains(be.array([0, 0.5, 2, 4]), be.array([0, 0, 0, 0])),
+            [True, False, True, False],
+        )
 
 
 def test_rotated_scaled_rectangle_and_triangle(tmp_path, set_test_backend):
-    commands = 'APN 1\nATP A 2\nAAC A 4\nAX1 A -2\nAX2 A 2\nAY1 A -1\nAY2 A 1\nAAN A 90'
-    ap = load_oslo_file(simple_lens(tmp_path, system='UNI 10', surface=commands), strict=True).surfaces[1].aperture
+    commands = "APN 1\nATP A 2\nAAC A 4\nAX1 A -2\nAX2 A 2\nAY1 A -1\nAY2 A 1\nAAN A 90"
+    ap = (
+        load_oslo_file(
+            simple_lens(tmp_path, system="UNI 10", surface=commands), strict=True
+        )
+        .surfaces[1]
+        .aperture
+    )
     assert_allclose(ap.contains(be.array([0, 15]), be.array([15, 0])), [True, False])
-    commands = ('APN 1\nATP A 3\nAAC A 4\nAVX1 A 0\nAVY1 A 0\n'
-                'AVX2 A 2\nAVY2 A 0\nAVX3 A 0\nAVY3 A 2')
-    ap = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True).surfaces[1].aperture
-    assert_allclose(ap.contains(be.array([.5, 1.5]), be.array([.5, 1.5])), [True, False])
+    commands = (
+        "APN 1\nATP A 3\nAAC A 4\nAVX1 A 0\nAVY1 A 0\n"
+        "AVX2 A 2\nAVY2 A 0\nAVX3 A 0\nAVY3 A 2"
+    )
+    ap = (
+        load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+        .surfaces[1]
+        .aperture
+    )
+    assert_allclose(
+        ap.contains(be.array([0.5, 1.5]), be.array([0.5, 1.5])), [True, False]
+    )
 
 
 def test_checked_aperture_and_hole_diagnostic(tmp_path):
-    path = simple_lens(tmp_path, surface='AP CHK 1.5')
-    assert OsloDataParser(path).parse().surfaces[1]['AP'] == 1.5
-    path = simple_lens(tmp_path, surface='APN 1\nATP A 1\nAAC A 1')
-    with pytest.raises(ValueError, match='hole'):
+    path = simple_lens(tmp_path, surface="AP CHK 1.5")
+    assert OsloDataParser(path).parse().surfaces[1]["AP"] == 1.5
+    path = simple_lens(tmp_path, surface="APN 1\nATP A 1\nAAC A 1")
+    with pytest.raises(ValueError, match="hole"):
         load_oslo_file(path, strict=True)
 
 
-@pytest.mark.parametrize('order', [1, -1])
+@pytest.mark.parametrize("order", [1, -1])
 def test_oslo_tilt_sign_order_and_decenter(tmp_path, set_test_backend, order):
     import numpy as np
+
     a, b, c = np.deg2rad([-10, -20, 30])
     rx = np.array([[1, 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
     ry = np.array([[np.cos(b), 0, np.sin(b)], [0, 1, 0], [-np.sin(b), 0, np.cos(b)]])
     rz = np.array([[np.cos(c), -np.sin(c), 0], [np.sin(c), np.cos(c), 0], [0, 0, 1]])
     expected = rx @ ry @ rz if order == 1 else rz @ ry @ rx
-    commands = f'DT {order}\nDCX 1\nDCY 2\nDCZ 3\nTLA 10\nTLB 20\nTLC 30'
+    commands = f"DT {order}\nDCX 1\nDCY 2\nDCZ 3\nTLA 10\nTLB 20\nTLC 30"
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
     position, rotation = optic.surfaces[1].geometry.cs.get_effective_transform()
     assert_allclose(rotation, expected)
@@ -268,312 +337,492 @@ def test_oslo_tilt_sign_order_and_decenter(tmp_path, set_test_backend, order):
 
 
 def test_coordinate_return_global_reference_and_pivot(tmp_path, set_test_backend):
-    commands = 'DCY 4\nTLA 30\nRCO'
+    commands = "DCY 4\nTLA 30\nRCO"
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
-    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2])
-    path = simple_lens(tmp_path, surface='DCY 4')
-    path.write_text(path.read_text().replace('RD -20', 'RD -20\nGC -1\nDCY 2\nDCZ 5'))
+    assert_allclose(
+        optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2]
+    )
+    path = simple_lens(tmp_path, surface="DCY 4")
+    path.write_text(path.read_text().replace("RD -20", "RD -20\nGC -1\nDCY 2\nDCZ 5"))
     optic = load_oslo_file(path, strict=True)
-    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 6, 5])
-    optic = load_oslo_file(simple_lens(tmp_path, surface='TLA 90\nTOZ 1\nRCO'), strict=True)
-    assert_allclose(optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, -1, 1])
+    assert_allclose(
+        optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 6, 5]
+    )
+    optic = load_oslo_file(
+        simple_lens(tmp_path, surface="TLA 90\nTOZ 1\nRCO"), strict=True
+    )
+    assert_allclose(
+        optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, -1, 1]
+    )
 
 
 def test_single_axis_mirror_bend_has_expected_physical_path(tmp_path, set_test_backend):
-    path = write_lens(tmp_path, 'LEN NEW "fold" 1 2\nEBR 1\nANG 0\nTH 1e20\n'
-                      'NXT\nRFH\nTLA 45\nBEN\nTH -10\nNXT\nAIR\nEND 2\n')
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "fold" 1 2\nEBR 1\nANG 0\nTH 1e20\n'
+        "NXT\nRFH\nTLA 45\nBEN\nTH -10\nNXT\nAIR\nEND 2\n",
+    )
     optic = load_oslo_file(path, strict=True)
-    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, -10, 0], atol=1e-12)
+    assert_allclose(
+        optic.surfaces[2].geometry.cs.get_effective_transform()[0],
+        [0, -10, 0],
+        atol=1e-12,
+    )
     from optiland.rays import RealRays
-    rays = RealRays(be.array([0.0]), be.array([0.0]), be.array([-1.0]),
-                    be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .55)
+
+    rays = RealRays(
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([-1.0]),
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([1.0]),
+        1,
+        0.55,
+    )
     optic.surfaces.trace(rays, skip=1)
     assert_allclose(rays.y, [-10], atol=1e-12)
     assert_allclose(rays.i, [1])
 
 
-def test_multiple_pickups_relative_indices_curvature_and_length(tmp_path, set_test_backend):
-    path = write_lens(tmp_path, 'LEN NEW "pickups" 1 4\nEBR 1\nANG 0\nTH 1e20\n'
-                      'NXT\nGLA 1.5\nRD 10\nCC -1\nAD .001\nTH 2\nAP 3\n'
-                      'NXT\nPK CVM -1 .01\nPK TH -1 1\nPK AP -1\nPK GLA -1\n'
-                      'NXT\nAIR\nPK CV -1 0\nPK LNM -2 0 10\nNXT\nAIR\nEND 4\n')
+def test_multiple_pickups_relative_indices_curvature_and_length(
+    tmp_path, set_test_backend
+):
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "pickups" 1 4\nEBR 1\nANG 0\nTH 1e20\n'
+        "NXT\nGLA 1.5\nRD 10\nCC -1\nAD .001\nTH 2\nAP 3\n"
+        "NXT\nPK CVM -1 .01\nPK TH -1 1\nPK AP -1\nPK GLA -1\n"
+        "NXT\nAIR\nPK CV -1 0\nPK LNM -2 0 10\nNXT\nAIR\nEND 4\n",
+    )
     optic = load_oslo_file(path, strict=True)
-    assert_allclose(optic.surfaces[2].geometry.radius, 1 / (-.1 + .01))
+    assert_allclose(optic.surfaces[2].geometry.radius, 1 / (-0.1 + 0.01))
     assert_allclose(optic.surfaces[2].geometry.k, -1)
-    assert_allclose(optic.surfaces[2].geometry.coefficients[1], -.001)
+    assert_allclose(optic.surfaces[2].geometry.coefficients[1], -0.001)
     assert_allclose(optic.surfaces[2].thickness, 3)
     assert_allclose(optic.surfaces[3].thickness, 5)
     assert_allclose(optic.surfaces[2].aperture.extent[1], 3)
-    assert_allclose(optic.surfaces[2].material_post.n(.55), 1.5)
+    assert_allclose(optic.surfaces[2].material_post.n(0.55), 1.5)
 
 
 def test_special_aperture_pickup_and_coordinate_inverse(tmp_path, set_test_backend):
-    path = write_lens(tmp_path, 'LEN NEW "pickup pose" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\n'
-                      'AIR\nDCY 2\nTLA 10\nTLB 20\nTLC 30\nAPN 1\n'
-                      'ATP A 2\nAAC A 4\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2\n'
-                      'NXT\nAIR\nPK TDM -1\nAPN 1\nAPK A -1 A\nTH 5\nNXT\nAIR\nEND 3\n')
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "pickup pose" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\n'
+        "AIR\nDCY 2\nTLA 10\nTLB 20\nTLC 30\nAPN 1\n"
+        "ATP A 2\nAAC A 4\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2\n"
+        "NXT\nAIR\nPK TDM -1\nAPN 1\nAPK A -1 A\nTH 5\nNXT\nAIR\nEND 3\n",
+    )
     optic = load_oslo_file(path, strict=True)
     position, rotation = optic.surfaces[2].geometry.cs.get_effective_transform()
     assert_allclose(position, [0, 0, 0], atol=1e-12)
     assert_allclose(rotation, be.eye(3), atol=1e-12)
-    assert_allclose(optic.surfaces[2].aperture.contains(be.array([0, 2]), be.array([1.5, 0])), [True, False])
+    assert_allclose(
+        optic.surfaces[2].aperture.contains(be.array([0, 2]), be.array([1.5, 0])),
+        [True, False],
+    )
 
 
-@pytest.mark.parametrize('pickup', ['PK TH 2', 'PK TH -5', 'PK UNKNOWN -1'])
+@pytest.mark.parametrize("pickup", ["PK TH 2", "PK TH -5", "PK UNKNOWN -1"])
 def test_invalid_or_unsupported_pickups_rejected(tmp_path, pickup):
     path = simple_lens(tmp_path, surface=pickup)
-    with pytest.raises(ValueError, match='PK'):
+    with pytest.raises(ValueError, match="PK"):
         load_oslo_file(path, strict=True)
 
 
-@pytest.mark.parametrize('command,target,component,index', [
-    ('PY 1', 1, 'marginal_height', 2),
-    ('PYC .1', .1, 'chief_height', 2),
-    ('PU -.05', -.05, 'marginal_slope', 1),
-])
-def test_paraxial_solves_use_requested_surface_and_value(tmp_path, set_test_backend, command, target, component, index):
-    optic = load_oslo_file(simple_lens(tmp_path, system='ANG 5', surface=command), strict=True)
-    heights, slopes = optic.paraxial.chief_ray() if component.startswith('chief') else optic.paraxial.marginal_ray()
-    assert_allclose((heights if component.endswith('height') else slopes)[index], target, atol=1e-9)
-    if command.startswith('PY'):
+@pytest.mark.parametrize(
+    "command,target,component,index",
+    [
+        ("PY 1", 1, "marginal_height", 2),
+        ("PYC .1", 0.1, "chief_height", 2),
+        ("PU -.05", -0.05, "marginal_slope", 1),
+    ],
+)
+def test_paraxial_solves_use_requested_surface_and_value(
+    tmp_path, set_test_backend, command, target, component, index
+):
+    optic = load_oslo_file(
+        simple_lens(tmp_path, system="ANG 5", surface=command), strict=True
+    )
+    heights, slopes = (
+        optic.paraxial.chief_ray()
+        if component.startswith("chief")
+        else optic.paraxial.marginal_ray()
+    )
+    assert_allclose(
+        (heights if component.endswith("height") else slopes)[index], target, atol=1e-9
+    )
+    if command.startswith("PY"):
         # Moving an interior surface must retain the subsequent nominal spacing.
-        assert_allclose(optic.surfaces[3].geometry.cs.z - optic.surfaces[2].geometry.cs.z, 20)
+        assert_allclose(
+            optic.surfaces[3].geometry.cs.z - optic.surfaces[2].geometry.cs.z, 20
+        )
 
 
 def test_edge_contact_solve_and_unsatisfiable_solve(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='EC 2'), strict=True)
-    assert_allclose(optic.surfaces[2].geometry.cs.z, 2 * (20 - (400 - 4)**.5))
-    path = simple_lens(tmp_path, surface='AIF\nPY 1')
-    with pytest.raises(ValueError, match='PY'):
+    optic = load_oslo_file(simple_lens(tmp_path, surface="EC 2"), strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.z, 2 * (20 - (400 - 4) ** 0.5))
+    path = simple_lens(tmp_path, surface="AIF\nPY 1")
+    with pytest.raises(ValueError, match="PY"):
         load_oslo_file(path, strict=True)
 
 
 def test_chief_angle_solve(tmp_path, set_test_backend):
-    path = simple_lens(tmp_path, system='ANG 5')
-    path.write_text(path.read_text().replace('RD -20', 'RD -20\nPUC .03'))
+    path = simple_lens(tmp_path, system="ANG 5")
+    path.write_text(path.read_text().replace("RD -20", "RD -20\nPUC .03"))
     optic = load_oslo_file(path, strict=True)
-    assert_allclose(optic.paraxial.chief_ray()[1][2], .03, atol=1e-9)
+    assert_allclose(optic.paraxial.chief_ray()[1][2], 0.03, atol=1e-9)
 
 
-def test_explicit_field_table_signed_xy_weights_and_vignetting(tmp_path, set_test_backend):
-    path = simple_lens(tmp_path, system='ANG 10')
-    path.write_text(path.read_text() + 'RST NEW\nF 1 -.5 .25 0 0 0 -.8 .8 -.9 .9 2\nF 2 0 0 0 0 0 -1 1 -1 1 0\nEND\n')
+def test_explicit_field_table_signed_xy_weights_and_vignetting(
+    tmp_path, set_test_backend
+):
+    path = simple_lens(tmp_path, system="ANG 10")
+    path.write_text(
+        path.read_text()
+        + "RST NEW\nF 1 -.5 .25 0 0 0 -.8 .8 -.9 .9 2\nF 2 0 0 0 0 0 -1 1 -1 1 0\nEND\n"
+    )
     optic = load_oslo_file(path, strict=True)
     import math
+
     assert len(optic.fields) == 2
-    assert_allclose(optic.fields[0].y, math.degrees(math.atan(-.5 * math.tan(math.radians(10)))))
-    assert_allclose(optic.fields[0].x, math.degrees(math.atan(.25 * math.tan(math.radians(10)))))
-    assert_allclose([optic.fields[0].vy, optic.fields[0].vx], [.2, .1])
+    assert_allclose(
+        optic.fields[0].y, math.degrees(math.atan(-0.5 * math.tan(math.radians(10))))
+    )
+    assert_allclose(
+        optic.fields[0].x, math.degrees(math.atan(0.25 * math.tan(math.radians(10))))
+    )
+    assert_allclose([optic.fields[0].vy, optic.fields[0].vx], [0.2, 0.1])
     assert [f.weight for f in optic.fields] == [2, 0]
 
 
-@pytest.mark.parametrize('footer', ['CFG NEW\nEND\n', 'RST NEW\nF 1 0 0 1 0 0 -1 1 -1 1 1\nEND\n'])
+@pytest.mark.parametrize(
+    "footer", ["CFG NEW\nEND\n", "RST NEW\nF 1 0 0 1 0 0 -1 1 -1 1 1\nEND\n"]
+)
 def test_unsupported_configuration_and_field_aiming_are_diagnosed(tmp_path, footer):
     path = simple_lens(tmp_path)
     path.write_text(path.read_text() + footer)
-    with pytest.raises(ValueError, match='CFG|field'):
+    with pytest.raises(ValueError, match="CFG|field"):
         load_oslo_file(path, strict=True)
 
 
-@pytest.mark.parametrize('command,target', [('FNO 5', .1), ('PUK .1', .1)])
-def test_image_aperture_definitions_at_finite_conjugates(tmp_path, set_test_backend, command, target):
+@pytest.mark.parametrize("command,target", [("FNO 5", 0.1), ("PUK .1", 0.1)])
+def test_image_aperture_definitions_at_finite_conjugates(
+    tmp_path, set_test_backend, command, target
+):
     path = simple_lens(tmp_path, system=command)
-    path.write_text(path.read_text().replace('TH 1e20', 'TH 100'))
+    path.write_text(path.read_text().replace("TH 1e20", "TH 100"))
     optic = load_oslo_file(path, strict=True)
     assert_allclose(abs(optic.paraxial.marginal_ray()[1][-2]), target)
 
 
 def test_gaussian_image_height_uses_focal_plane(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='GIH 2'), strict=True)
+    optic = load_oslo_file(simple_lens(tmp_path, system="GIH 2"), strict=True)
     import math
+
     expected = math.degrees(math.atan(2 / float(optic.paraxial.f2())))
     assert_allclose(optic.fields[-1].y, abs(expected))
 
 
-@pytest.mark.parametrize('material,order', [('AIR', 1), ('RFL', -1)])
-def test_linear_grating_diffraction_direction_and_lens_units(tmp_path, set_test_backend, material, order):
+@pytest.mark.parametrize("material,order", [("AIR", 1), ("RFL", -1)])
+def test_linear_grating_diffraction_direction_and_lens_units(
+    tmp_path, set_test_backend, material, order
+):
     from optiland.rays import RealRays
-    path = write_lens(tmp_path, f'LEN NEW "grating" 1 2\nUNI 10\nEBR .1\nWV .5\nTH 1e20\nNXT\n{material}\nGSP .0002\nGOR {order}\nTH 1\nNXT\nAIR\nEND 2\n')
+
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "grating" 1 2\nUNI 10\nEBR .1\nWV .5\nTH 1e20\nNXT\n'
+        f"{material}\nGSP .0002\nGOR {order}\nTH 1\nNXT\nAIR\nEND 2\n",
+    )
     optic = load_oslo_file(path, strict=True)
-    rays = RealRays(be.array([0.0]), be.array([0.0]), be.array([-1.0]), be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .5)
+    rays = RealRays(
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([-1.0]),
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([1.0]),
+        1,
+        0.5,
+    )
     optic.surfaces[1].trace(rays)
     assert_allclose(rays.L, [0], atol=1e-12)
-    assert_allclose(rays.M, [order * .5 / 2])
-    assert_allclose(rays.N, [(.9375)**.5 * (1 if material == 'AIR' else -1)])
+    assert_allclose(rays.M, [order * 0.5 / 2])
+    assert_allclose(rays.N, [(0.9375) ** 0.5 * (1 if material == "AIR" else -1)])
 
 
 def test_perfect_lens_reports_nonparaxial_approximation(tmp_path):
-    with pytest.raises(ValueError, match='PFL.*perfect'):
-        load_oslo_file(simple_lens(tmp_path, surface='PFL 20'), strict=True)
+    with pytest.raises(ValueError, match="PFL.*perfect"):
+        load_oslo_file(simple_lens(tmp_path, surface="PFL 20"), strict=True)
 
 
 def test_metadata_and_deleting_surface_data(tmp_path, set_test_backend):
-    commands = 'NOT "lens note"\nCC -1\nAD .001\nATD\nCVX .1\nCXD\nDCY 2\nTLA 10\nTDD\nGC 0\nGCD\nRCO\nRCD\nBEN\nBED\nAPN 1\nAPD\nPY 2\nTSD\nPU .1\nCSD\nBDI 2 1\nVX 1 0 0 0\nPF 1 0 1 2 3\nLMO EGR\nLMN "element"\nLME'
+    commands = (
+        'NOT "lens note"\nCC -1\nAD .001\nATD\nCVX .1\nCXD\n'
+        "DCY 2\nTLA 10\nTDD\nGC 0\nGCD\nRCO\nRCD\nBEN\nBED\n"
+        "APN 1\nAPD\nPY 2\nTSD\nPU .1\nCSD\nBDI 2 1\nVX 1 0 0 0\n"
+        'PF 1 0 1 2 3\nLMO EGR\nLMN "element"\nLME'
+    )
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
     assert_allclose(optic.surfaces[1].geometry.radius, 20)
-    assert_allclose(optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, 0, 0])
+    assert_allclose(
+        optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, 0, 0]
+    )
     assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
-    assert_allclose(optic.surfaces[1].geometry.sag(be.array([0]), be.array([1])), 20 - 399**.5)
+    assert_allclose(
+        optic.surfaces[1].geometry.sag(be.array([0]), be.array([1])), 20 - 399**0.5
+    )
 
 
-@pytest.mark.parametrize('aperture,setting,intensity', [('AP 1', '', 1), ('AP CHK 1', '', 0), ('AP CHK 1', 'APCK OFF', 1), ('AP UNC 1', 'APCK ON', 1)])
-def test_aperture_checking_distinguishes_drawing_bounds(tmp_path, set_test_backend, aperture, setting, intensity):
+@pytest.mark.parametrize(
+    "aperture,setting,intensity",
+    [
+        ("AP 1", "", 1),
+        ("AP CHK 1", "", 0),
+        ("AP CHK 1", "APCK OFF", 1),
+        ("AP UNC 1", "APCK ON", 1),
+    ],
+)
+def test_aperture_checking_distinguishes_drawing_bounds(
+    tmp_path, set_test_backend, aperture, setting, intensity
+):
     from optiland.rays import RealRays
-    optic = load_oslo_file(simple_lens(tmp_path, system=setting, surface=aperture), strict=True)
-    rays = RealRays(be.array([2.0]), be.array([0.0]), be.array([-1.0]), be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .55)
+
+    optic = load_oslo_file(
+        simple_lens(tmp_path, system=setting, surface=aperture), strict=True
+    )
+    rays = RealRays(
+        be.array([2.0]),
+        be.array([0.0]),
+        be.array([-1.0]),
+        be.array([0.0]),
+        be.array([0.0]),
+        be.array([1.0]),
+        1,
+        0.55,
+    )
     optic.surfaces[1].trace(rays)
     assert_allclose(rays.i, [intensity])
     assert_allclose(optic.surfaces[1].aperture.extent, [-1, 1, -1, 1])
 
 
 def test_legacy_special_apertures_omit_zero_bounds(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='APN 1\nATP A 2\nAAC A 4\nAX1 A -.2\nAY1 A -1.5\nAY2 A 1.5'), strict=True)
-    assert_allclose(optic.surfaces[1].aperture.contains(be.array([-.1, .1]), be.array([0, 0])), [True, False])
+    optic = load_oslo_file(
+        simple_lens(
+            tmp_path,
+            surface="APN 1\nATP A 2\nAAC A 4\nAX1 A -.2\nAY1 A -1.5\nAY2 A 1.5",
+        ),
+        strict=True,
+    )
+    assert_allclose(
+        optic.surfaces[1].aperture.contains(be.array([-0.1, 0.1]), be.array([0, 0])),
+        [True, False],
+    )
 
 
-@pytest.mark.parametrize('checked', [False, True])
+@pytest.mark.parametrize("checked", [False, True])
 def test_roundtrip_preserves_radial_clipping_mode(tmp_path, set_test_backend, checked):
     from optiland.physical_apertures import UnclippedAperture
-    optic = load_oslo_file(simple_lens(tmp_path, surface='AP CHK 1' if checked else 'AP 1'), strict=True)
-    target = tmp_path / 'aperture.len'
+
+    optic = load_oslo_file(
+        simple_lens(tmp_path, surface="AP CHK 1" if checked else "AP 1"), strict=True
+    )
+    target = tmp_path / "aperture.len"
     save_oslo_file(optic, target)
     restored = load_oslo_file(target, strict=True)
     assert isinstance(restored.surfaces[1].aperture, UnclippedAperture) is not checked
     assert_allclose(restored.surfaces[1].aperture.extent, [-1, 1, -1, 1])
 
 
-def test_review1_solved_thickness_feeds_pickups_and_export(tmp_path, set_test_backend):
-    path = simple_lens(tmp_path, surface='PY 1')
-    path.write_text(path.read_text().replace('TH 20', 'TH 20\nPK TH -1 1'))
+def test_solved_thickness_feeds_pickups_and_export(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, surface="PY 1")
+    path.write_text(path.read_text().replace("TH 20", "TH 20\nPK TH -1 1"))
     optic = load_oslo_file(path, strict=True)
     assert_allclose(optic.surfaces[1].thickness, 30)
     assert_allclose(optic.surfaces[2].thickness, 31)
     assert_allclose(optic.surfaces[3].geometry.cs.z, 61)
-    target = tmp_path / 'solved.len'
+    target = tmp_path / "solved.len"
     save_oslo_file(optic, target)
     assert_allclose(load_oslo_file(target, strict=True).surfaces[2].geometry.cs.z, 30)
 
 
-@pytest.mark.parametrize('commands', ['PY 1\nTH 2', 'PK TH 0 1\nTHF 2', 'PU -.05\nRD 20'])
-def test_review1_literal_parameters_replace_constraints(tmp_path, set_test_backend, commands):
+@pytest.mark.parametrize(
+    "commands", ["PY 1\nTH 2", "PK TH 0 1\nTHF 2", "PU -.05\nRD 20"]
+)
+def test_literal_parameters_replace_constraints(tmp_path, set_test_backend, commands):
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
     assert_allclose(optic.surfaces[1].geometry.radius, 20)
     assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
 
 
-def test_review1_offset_ellipse_rotated_extent(tmp_path, set_test_backend):
-    from optiland.physical_apertures import EllipticalAperture, RotatedAperture
+def test_offset_ellipse_rotated_extent(tmp_path, set_test_backend):
     import math
+
+    from optiland.physical_apertures import EllipticalAperture, RotatedAperture
+
     ap = RotatedAperture(EllipticalAperture(2, 1, 3, 4), math.pi / 2)
     assert_allclose(ap.extent, [-5, -3, 1, 5])
     assert_allclose(ap.contains(be.array([-4.0]), be.array([3.0])), [True])
 
 
-def test_review1_historical_glass_approximation_is_explicit(tmp_path, monkeypatch):
+def test_historical_glass_approximation_is_explicit(tmp_path, monkeypatch):
     import optiland.fileio.oslo.reader.converter as module
+
     def unavailable(*args, **kwargs):
-        raise ValueError('no glass')
-    monkeypatch.setattr(module, 'Material', unavailable)
-    path = simple_lens(tmp_path, surface='GLA BAF13')
-    with pytest.raises(ValueError, match='approximate'):
+        raise ValueError("no glass")
+
+    monkeypatch.setattr(module, "Material", unavailable)
+    path = simple_lens(tmp_path, surface="GLA BAF13")
+    with pytest.raises(ValueError, match="approximate"):
         load_oslo_file(path, strict=True)
-    with pytest.warns(UserWarning, match='approximate'):
+    with pytest.warns(UserWarning, match="approximate"):
         load_oslo_file(path)
 
 
-@pytest.mark.parametrize('text', ['', 'LEN NEW "bad" 1 3\nNXT\nEND 3\n', 'LEN WRONG "bad" 1 1\nNXT\nEND 1\n'])
-def test_review2_invalid_lens_structure(tmp_path, text):
-    with pytest.raises(ValueError, match='LEN|surface|prescription'):
+@pytest.mark.parametrize(
+    "text", ["", 'LEN NEW "bad" 1 3\nNXT\nEND 3\n', 'LEN WRONG "bad" 1 1\nNXT\nEND 1\n']
+)
+def test_invalid_lens_structure(tmp_path, text):
+    with pytest.raises(ValueError, match="LEN|surface|prescription"):
         load_oslo_file(write_lens(tmp_path, text), strict=True)
 
 
-@pytest.mark.parametrize('commands', ['RD 10 extra', 'DT 2', 'GC .5', 'EBR 0', 'FNO 0', 'NAP -1', 'GLA', 'GLA MOD', 'PK TH', 'AS1 .1'])
-def test_review2_invalid_or_incomplete_commands(tmp_path, commands):
+@pytest.mark.parametrize(
+    "commands",
+    [
+        "RD 10 extra",
+        "DT 2",
+        "GC .5",
+        "EBR 0",
+        "FNO 0",
+        "NAP -1",
+        "GLA",
+        "GLA MOD",
+        "PK TH",
+        "AS1 .1",
+    ],
+)
+def test_invalid_or_incomplete_commands(tmp_path, commands):
     with pytest.raises(ValueError):
         load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
 
 
-def test_review2_last_stop_and_diagnostic_model_serialization(tmp_path):
-    path = simple_lens(tmp_path, surface='AST')
-    path.write_text(path.read_text().replace('RD -20', 'RD -20\nAST'))
+def test_last_stop_and_diagnostic_model_serialization(tmp_path):
+    path = simple_lens(tmp_path, surface="AST")
+    path.write_text(path.read_text().replace("RD -20", "RD -20\nAST"))
     optic = load_oslo_file(path, strict=True)
     assert not optic.surfaces[1].is_stop
     assert optic.surfaces[2].is_stop
-    with pytest.warns(UserWarning, match='MAGIC'):
-        model = OsloDataParser(simple_lens(tmp_path, system='TELE ON', surface='MAGIC')).parse()
-    assert model.to_dict()['settings']['telecentric']
-    assert model.to_dict()['diagnostics'][0]['command'] == 'MAGIC'
+    with pytest.warns(UserWarning, match="MAGIC"):
+        model = OsloDataParser(
+            simple_lens(tmp_path, system="TELE ON", surface="MAGIC")
+        ).parse()
+    assert model.to_dict()["settings"]["telecentric"]
+    assert model.to_dict()["diagnostics"][0]["command"] == "MAGIC"
 
 
-def test_review2_tilt_pickup_retains_pivot(tmp_path, set_test_backend):
-    path = write_lens(tmp_path, 'LEN NEW "pivot inverse" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\nAIR\nTLA 20\nDCY 2\nTOZ 4\nNXT\nAIR\nPK TDM -1\nTH 5\nNXT\nAIR\nEND 3\n')
+def test_tilt_pickup_retains_pivot(tmp_path, set_test_backend):
+    path = write_lens(
+        tmp_path,
+        'LEN NEW "pivot inverse" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\nAIR\n'
+        "TLA 20\nDCY 2\nTOZ 4\nNXT\nAIR\nPK TDM -1\nTH 5\nNXT\nAIR\nEND 3\n",
+    )
     optic = load_oslo_file(path, strict=True)
     position, rotation = optic.surfaces[2].geometry.cs.get_effective_transform()
     assert_allclose(position, [0, 0, 0], atol=1e-12)
     assert_allclose(rotation, be.eye(3), atol=1e-12)
 
 
-def test_review2_invalid_tabulated_query(set_test_backend):
+def test_invalid_tabulated_query(set_test_backend):
     from optiland.materials import TabulatedMaterial
-    material = TabulatedMaterial([.4, .8], [1.6, 1.4])
-    with pytest.raises(ValueError, match='finite|range'):
-        material.n(float('nan'))
+
+    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.4])
+    with pytest.raises(ValueError, match="finite|range"):
+        material.n(float("nan"))
 
 
-@pytest.mark.parametrize('commands', ['GSP .002\nGOR 1', 'DCY 2', 'APN 1\nATP A 2\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2'])
-def test_review2_writer_rejects_unsupported_data_before_overwriting(tmp_path, commands):
+@pytest.mark.parametrize(
+    "commands",
+    [
+        "GSP .002\nGOR 1",
+        "DCY 2",
+        "APN 1\nATP A 2\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2",
+    ],
+)
+def test_writer_rejects_unsupported_data_before_overwriting(tmp_path, commands):
     optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
-    output = tmp_path / 'protected.len'
-    output.write_text('existing file')
-    with pytest.raises((ValueError, NotImplementedError), match='export|writer'):
+    output = tmp_path / "protected.len"
+    output.write_text("existing file")
+    with pytest.raises((ValueError, NotImplementedError), match="export|writer"):
         save_oslo_file(optic, output)
-    assert output.read_text() == 'existing file'
+    assert output.read_text() == "existing file"
 
 
-def test_review2_mixed_material_spectra_roundtrip(tmp_path, set_test_backend):
-    from optiland.materials import TabulatedMaterial, AbbeMaterial
-    optic = load_oslo_file(simple_lens(tmp_path, system='WV .4 .5 .6 .7'))
-    optic.surfaces[1].material_post = TabulatedMaterial([.4, .5, .6, .7], [1.6, 1.55, 1.5, 1.45])
-    optic.surfaces[2].material_post = AbbeMaterial(1.6, 50, model='buchdahl')
-    path = tmp_path / 'mixed.len'
+def test_mixed_material_spectra_roundtrip(tmp_path, set_test_backend):
+    from optiland.materials import AbbeMaterial, TabulatedMaterial
+
+    optic = load_oslo_file(simple_lens(tmp_path, system="WV .4 .5 .6 .7"))
+    optic.surfaces[1].material_post = TabulatedMaterial(
+        [0.4, 0.5, 0.6, 0.7], [1.6, 1.55, 1.5, 1.45]
+    )
+    optic.surfaces[2].material_post = AbbeMaterial(1.6, 50, model="buchdahl")
+    path = tmp_path / "mixed.len"
     save_oslo_file(optic, path)
     restored = load_oslo_file(path, strict=True)
-    wave = be.array([.4, .5, .6, .7])
-    assert_allclose(restored.surfaces[2].material_post.n(wave), optic.surfaces[2].material_post.n(wave), atol=1e-6)
+    wave = be.array([0.4, 0.5, 0.6, 0.7])
+    assert_allclose(
+        restored.surfaces[2].material_post.n(wave),
+        optic.surfaces[2].material_post.n(wave),
+        atol=1e-6,
+    )
 
 
-def test_review2_names_fields_and_signed_infinity_roundtrip(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='ANG 10'))
+def test_names_fields_and_signed_infinity_roundtrip(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system="ANG 10"))
     optic.name = 'a "quoted" lens; // design'
     optic.fields.fields.clear()
-    optic.fields.add(y=-3, x=2, weight=2, vx=.1, vy=.2)
+    optic.fields.add(y=-3, x=2, weight=2, vx=0.1, vy=0.2)
     optic.fields.add(y=5, x=-1, weight=0)
-    optic.surfaces[0].thickness = -float('inf')
-    path = tmp_path / 'metadata.len'
+    optic.surfaces[0].thickness = -float("inf")
+    path = tmp_path / "metadata.len"
     save_oslo_file(optic, path)
     restored = load_oslo_file(path, strict=True)
     assert restored.name == optic.name
     assert_allclose(restored.fields.x_fields, [2, -1])
     assert_allclose(restored.fields.y_fields, [-3, 5])
     assert [f.weight for f in restored.fields] == [2, 0]
-    assert_allclose(restored.fields[0].vx, .1)
+    assert_allclose(restored.fields[0].vx, 0.1)
     assert restored.surfaces[0].thickness < 0
 
 
-def test_review2_nonfinite_coordinate_reference_is_rejected(tmp_path):
-    with pytest.raises(ValueError, match='finite|infinite'):
-        load_oslo_file(simple_lens(tmp_path, surface='GC 0'), strict=True)
+def test_nonfinite_coordinate_reference_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="finite|infinite"):
+        load_oslo_file(simple_lens(tmp_path, surface="GC 0"), strict=True)
 
 
-def test_review2_legacy_zero_coordinate_return_undoes_local_decenter(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='DCY 2\nTLA 15\nRCO 0'), strict=True)
-    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2])
+def test_legacy_zero_coordinate_return_undoes_local_decenter(
+    tmp_path, set_test_backend
+):
+    optic = load_oslo_file(
+        simple_lens(tmp_path, surface="DCY 2\nTLA 15\nRCO 0"), strict=True
+    )
+    assert_allclose(
+        optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2]
+    )
 
 
-def test_review2_infinite_object_field_survives_absolute_pose_mapping(tmp_path, set_test_backend):
-    optic = load_oslo_file(simple_lens(tmp_path, system='OBH -1e18', surface='DCY .1\nRCO'), strict=True)
+def test_infinite_object_field_survives_absolute_pose_mapping(
+    tmp_path, set_test_backend
+):
+    optic = load_oslo_file(
+        simple_lens(tmp_path, system="OBH -1e18", surface="DCY .1\nRCO"), strict=True
+    )
     import math
-    assert optic.fields.field_definition.__class__.__name__ == 'AngleField'
-    assert_allclose(optic.fields[-1].y, math.degrees(math.atan(.01)))
-    rays = optic.trace(0, 0, optic.primary_wavelength, num_rays=3, distribution='line_y')
+
+    assert optic.fields.field_definition.__class__.__name__ == "AngleField"
+    assert_allclose(optic.fields[-1].y, math.degrees(math.atan(0.01)))
+    rays = optic.trace(
+        0, 0, optic.primary_wavelength, num_rays=3, distribution="line_y"
+    )
     assert be.any(be.isfinite(rays.y) & (rays.i > 0))

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -54,7 +54,7 @@ def test_unknown_optical_command_is_reported_and_strict_rejects(tmp_path):
 
 @pytest.mark.parametrize("command", ["RD", "TH nope", "AP nan", 'DES "unterminated'])
 def test_malformed_command_has_source_context(tmp_path, command):
-    path = write_lens(tmp_path, f'LEN NEW "bad" 1 0\n{command}\nEND 0\n')
+    path = write_lens(tmp_path, f'LEN NEW "bad" 1 1\n{command}\nNXT\nEND 1\n')
     with pytest.raises(ValueError, match=r"commands.len:2"):
         OsloDataParser(path).parse()
 
@@ -478,3 +478,101 @@ def test_review1_historical_glass_approximation_is_explicit(tmp_path, monkeypatc
         load_oslo_file(path, strict=True)
     with pytest.warns(UserWarning, match='approximate'):
         load_oslo_file(path)
+
+
+@pytest.mark.parametrize('text', ['', 'LEN NEW "bad" 1 3\nNXT\nEND 3\n', 'LEN WRONG "bad" 1 1\nNXT\nEND 1\n'])
+def test_review2_invalid_lens_structure(tmp_path, text):
+    with pytest.raises(ValueError, match='LEN|surface|prescription'):
+        load_oslo_file(write_lens(tmp_path, text), strict=True)
+
+
+@pytest.mark.parametrize('commands', ['RD 10 extra', 'DT 2', 'GC .5', 'EBR 0', 'FNO 0', 'NAP -1', 'GLA', 'GLA MOD', 'PK TH', 'AS1 .1'])
+def test_review2_invalid_or_incomplete_commands(tmp_path, commands):
+    with pytest.raises(ValueError):
+        load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+
+
+def test_review2_last_stop_and_diagnostic_model_serialization(tmp_path):
+    path = simple_lens(tmp_path, surface='AST')
+    path.write_text(path.read_text().replace('RD -20', 'RD -20\nAST'))
+    optic = load_oslo_file(path, strict=True)
+    assert not optic.surfaces[1].is_stop
+    assert optic.surfaces[2].is_stop
+    with pytest.warns(UserWarning, match='MAGIC'):
+        model = OsloDataParser(simple_lens(tmp_path, system='TELE ON', surface='MAGIC')).parse()
+    assert model.to_dict()['settings']['telecentric']
+    assert model.to_dict()['diagnostics'][0]['command'] == 'MAGIC'
+
+
+def test_review2_tilt_pickup_retains_pivot(tmp_path, set_test_backend):
+    path = write_lens(tmp_path, 'LEN NEW "pivot inverse" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\nAIR\nTLA 20\nDCY 2\nTOZ 4\nNXT\nAIR\nPK TDM -1\nTH 5\nNXT\nAIR\nEND 3\n')
+    optic = load_oslo_file(path, strict=True)
+    position, rotation = optic.surfaces[2].geometry.cs.get_effective_transform()
+    assert_allclose(position, [0, 0, 0], atol=1e-12)
+    assert_allclose(rotation, be.eye(3), atol=1e-12)
+
+
+def test_review2_invalid_tabulated_query(set_test_backend):
+    from optiland.materials import TabulatedMaterial
+    material = TabulatedMaterial([.4, .8], [1.6, 1.4])
+    with pytest.raises(ValueError, match='finite|range'):
+        material.n(float('nan'))
+
+
+@pytest.mark.parametrize('commands', ['GSP .002\nGOR 1', 'DCY 2', 'APN 1\nATP A 2\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2'])
+def test_review2_writer_rejects_unsupported_data_before_overwriting(tmp_path, commands):
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    output = tmp_path / 'protected.len'
+    output.write_text('existing file')
+    with pytest.raises((ValueError, NotImplementedError), match='export|writer'):
+        save_oslo_file(optic, output)
+    assert output.read_text() == 'existing file'
+
+
+def test_review2_mixed_material_spectra_roundtrip(tmp_path, set_test_backend):
+    from optiland.materials import TabulatedMaterial, AbbeMaterial
+    optic = load_oslo_file(simple_lens(tmp_path, system='WV .4 .5 .6 .7'))
+    optic.surfaces[1].material_post = TabulatedMaterial([.4, .5, .6, .7], [1.6, 1.55, 1.5, 1.45])
+    optic.surfaces[2].material_post = AbbeMaterial(1.6, 50, model='buchdahl')
+    path = tmp_path / 'mixed.len'
+    save_oslo_file(optic, path)
+    restored = load_oslo_file(path, strict=True)
+    wave = be.array([.4, .5, .6, .7])
+    assert_allclose(restored.surfaces[2].material_post.n(wave), optic.surfaces[2].material_post.n(wave), atol=1e-6)
+
+
+def test_review2_names_fields_and_signed_infinity_roundtrip(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='ANG 10'))
+    optic.name = 'a "quoted" lens; // design'
+    optic.fields.fields.clear()
+    optic.fields.add(y=-3, x=2, weight=2, vx=.1, vy=.2)
+    optic.fields.add(y=5, x=-1, weight=0)
+    optic.surfaces[0].thickness = -float('inf')
+    path = tmp_path / 'metadata.len'
+    save_oslo_file(optic, path)
+    restored = load_oslo_file(path, strict=True)
+    assert restored.name == optic.name
+    assert_allclose(restored.fields.x_fields, [2, -1])
+    assert_allclose(restored.fields.y_fields, [-3, 5])
+    assert [f.weight for f in restored.fields] == [2, 0]
+    assert_allclose(restored.fields[0].vx, .1)
+    assert restored.surfaces[0].thickness < 0
+
+
+def test_review2_nonfinite_coordinate_reference_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match='finite|infinite'):
+        load_oslo_file(simple_lens(tmp_path, surface='GC 0'), strict=True)
+
+
+def test_review2_legacy_zero_coordinate_return_undoes_local_decenter(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='DCY 2\nTLA 15\nRCO 0'), strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2])
+
+
+def test_review2_infinite_object_field_survives_absolute_pose_mapping(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='OBH -1e18', surface='DCY .1\nRCO'), strict=True)
+    import math
+    assert optic.fields.field_definition.__class__.__name__ == 'AngleField'
+    assert_allclose(optic.fields[-1].y, math.degrees(math.atan(.01)))
+    rays = optic.trace(0, 0, optic.primary_wavelength, num_rays=3, distribution='line_y')
+    assert be.any(be.isfinite(rays.y) & (rays.i > 0))

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -439,3 +439,42 @@ def test_roundtrip_preserves_radial_clipping_mode(tmp_path, set_test_backend, ch
     restored = load_oslo_file(target, strict=True)
     assert isinstance(restored.surfaces[1].aperture, UnclippedAperture) is not checked
     assert_allclose(restored.surfaces[1].aperture.extent, [-1, 1, -1, 1])
+
+
+def test_review1_solved_thickness_feeds_pickups_and_export(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, surface='PY 1')
+    path.write_text(path.read_text().replace('TH 20', 'TH 20\nPK TH -1 1'))
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(optic.surfaces[1].thickness, 30)
+    assert_allclose(optic.surfaces[2].thickness, 31)
+    assert_allclose(optic.surfaces[3].geometry.cs.z, 61)
+    target = tmp_path / 'solved.len'
+    save_oslo_file(optic, target)
+    assert_allclose(load_oslo_file(target, strict=True).surfaces[2].geometry.cs.z, 30)
+
+
+@pytest.mark.parametrize('commands', ['PY 1\nTH 2', 'PK TH 0 1\nTHF 2', 'PU -.05\nRD 20'])
+def test_review1_literal_parameters_replace_constraints(tmp_path, set_test_backend, commands):
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    assert_allclose(optic.surfaces[1].geometry.radius, 20)
+    assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
+
+
+def test_review1_offset_ellipse_rotated_extent(tmp_path, set_test_backend):
+    from optiland.physical_apertures import EllipticalAperture, RotatedAperture
+    import math
+    ap = RotatedAperture(EllipticalAperture(2, 1, 3, 4), math.pi / 2)
+    assert_allclose(ap.extent, [-5, -3, 1, 5])
+    assert_allclose(ap.contains(be.array([-4.0]), be.array([3.0])), [True])
+
+
+def test_review1_historical_glass_approximation_is_explicit(tmp_path, monkeypatch):
+    import optiland.fileio.oslo.reader.converter as module
+    def unavailable(*args, **kwargs):
+        raise ValueError('no glass')
+    monkeypatch.setattr(module, 'Material', unavailable)
+    path = simple_lens(tmp_path, surface='GLA BAF13')
+    with pytest.raises(ValueError, match='approximate'):
+        load_oslo_file(path, strict=True)
+    with pytest.warns(UserWarning, match='approximate'):
+        load_oslo_file(path)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -387,3 +387,29 @@ def test_gaussian_image_height_uses_focal_plane(tmp_path, set_test_backend):
     import math
     expected = math.degrees(math.atan(2 / float(optic.paraxial.f2())))
     assert_allclose(optic.fields[-1].y, abs(expected))
+
+
+@pytest.mark.parametrize('material,order', [('AIR', 1), ('RFL', -1)])
+def test_linear_grating_diffraction_direction_and_lens_units(tmp_path, set_test_backend, material, order):
+    from optiland.rays import RealRays
+    path = write_lens(tmp_path, f'LEN NEW "grating" 1 2\nUNI 10\nEBR .1\nWV .5\nTH 1e20\nNXT\n{material}\nGSP .0002\nGOR {order}\nTH 1\nNXT\nAIR\nEND 2\n')
+    optic = load_oslo_file(path, strict=True)
+    rays = RealRays(be.array([0.0]), be.array([0.0]), be.array([-1.0]), be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .5)
+    optic.surfaces[1].trace(rays)
+    assert_allclose(rays.L, [0], atol=1e-12)
+    assert_allclose(rays.M, [order * .5 / 2])
+    assert_allclose(rays.N, [(.9375)**.5 * (1 if material == 'AIR' else -1)])
+
+
+def test_perfect_lens_reports_nonparaxial_approximation(tmp_path):
+    with pytest.raises(ValueError, match='PFL.*perfect'):
+        load_oslo_file(simple_lens(tmp_path, surface='PFL 20'), strict=True)
+
+
+def test_metadata_and_deleting_surface_data(tmp_path, set_test_backend):
+    commands = 'NOT "lens note"\nCC -1\nAD .001\nATD\nCVX .1\nCXD\nDCY 2\nTLA 10\nTDD\nGC 0\nGCD\nRCO\nRCD\nBEN\nBED\nAPN 1\nAPD\nPY 2\nTSD\nPU .1\nCSD\nBDI 2 1\nVX 1 0 0 0\nPF 1 0 1 2 3\nLMO EGR\nLMN "element"\nLME'
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    assert_allclose(optic.surfaces[1].geometry.radius, 20)
+    assert_allclose(optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, 0, 0])
+    assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
+    assert_allclose(optic.surfaces[1].geometry.sag(be.array([0]), be.array([1])), 20 - 399**.5)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+import optiland.backend as be
 from optiland.fileio import load_oslo_file
 from optiland.fileio.oslo.reader.parser import OsloDataParser
+from tests.utils import assert_allclose
 
 
 def write_lens(tmp_path, text):
@@ -70,3 +72,63 @@ def test_public_loader_exposes_strict_mode(tmp_path):
     path = write_lens(tmp_path, 'LEN NEW "strict" 1 1\nNXT\nUNKNOWN 1\nEND 1\n')
     with pytest.raises(ValueError, match="UNKNOWN"):
         load_oslo_file(path, strict=True)
+
+
+def simple_lens(tmp_path, system="", surface="", footer=""):
+    return write_lens(tmp_path, 'LEN NEW "commands" 50 3\nEBR 2\nANG 0\n'
+                      f'{system}\nTH 1e20\nNXT\nGLA 1.5 1.5 1.5\n'
+                      f'RD 20\nTH 2\nAP 3\n{surface}\nNXT\n'
+                      f'AIR\nRD -20\nTH 20\nNXT\nAIR\n{footer}\nEND 3\n')
+
+
+def test_wavelength_slots_replace_preserve_order_weights_and_defaults(tmp_path):
+    path = simple_lens(tmp_path, footer='WV .6 .5 .7\nWW 1 2 3\n'
+                       'WV2 .45\nWV4 .8\nWW2 4\nWW4 5')
+    data = OsloDataParser(path).parse()
+    assert data.wavelengths["values"] == [.6, .45, .7, .8]
+    assert data.wavelengths["weights"] == [1, 4, 3, 5]
+    path = simple_lens(tmp_path, system='WV .6 .5 .7', footer='WV .55\nWW 2')
+    assert OsloDataParser(path).parse().wavelengths["values"] == [.55]
+    assert OsloDataParser(simple_lens(tmp_path)).parse().wavelengths["values"] == [
+        .58756, .48613, .65627]
+
+
+@pytest.mark.parametrize("command", ["WV 0", "WV -1", "WW -1", "UNI 0", "UNI -2"])
+def test_invalid_system_values_rejected(tmp_path, command):
+    with pytest.raises(ValueError):
+        OsloDataParser(simple_lens(tmp_path, footer=command)).parse()
+
+
+def test_units_scale_prescription_aperture_and_object_height(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, system='UNI 25.4\nOBH 1')
+    # Finite object: the field is a length in the same units as the lens.
+    path.write_text(path.read_text().replace('TH 1e20', 'TH 10'))
+    optic = load_oslo_file(path)
+    assert_allclose(optic.surfaces[1].geometry.radius, 20 * 25.4)
+    assert_allclose(optic.surfaces[1].thickness, 2 * 25.4)
+    assert_allclose(optic.surfaces[1].aperture.r_max, 3 * 25.4)
+    assert_allclose(optic.aperture.value, 4 * 25.4)
+    assert_allclose(optic.fields.y_fields[-1], 25.4)
+    assert_allclose(optic.wavelengths.primary_wavelength.value, .58756)
+
+
+def test_infinite_object_field_uses_actual_oslo_distance(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, system='OBH -1e20')
+    optic = load_oslo_file(path)
+    assert_allclose(optic.fields.y_fields[-1], 45)
+    assert be.isinf(optic.surfaces[0].thickness)
+
+
+def test_system_aperture_last_command_wins(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='FNO 8\nEBR 3'))
+    assert optic.aperture.ap_type == "EPD"
+    assert_allclose(optic.aperture.value, 6)
+
+
+def test_image_na_and_telecentric(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='NAP .1\nTELE ON'))
+    # Thick symmetric lens power = (n-1)(1/R1-1/R2+(n-1)t/(n R1 R2)).
+    power = .5 * (.1 - .5 * 2 / (1.5 * 400))
+    assert optic.aperture.ap_type == "EPD"
+    assert_allclose(optic.aperture.value, .2 / power)
+    assert optic.obj_space_telecentric is True

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -106,7 +106,7 @@ def test_units_scale_prescription_aperture_and_object_height(tmp_path, set_test_
     optic = load_oslo_file(path)
     assert_allclose(optic.surfaces[1].geometry.radius, 20 * 25.4)
     assert_allclose(optic.surfaces[1].thickness, 2 * 25.4)
-    assert_allclose(optic.surfaces[1].aperture.r_max, 3 * 25.4)
+    assert_allclose(optic.surfaces[1].aperture.extent[1], 3 * 25.4)
     assert_allclose(optic.aperture.value, 4 * 25.4)
     assert_allclose(optic.fields.y_fields[-1], 25.4)
     assert_allclose(optic.wavelengths.primary_wavelength.value, .58756)
@@ -224,7 +224,7 @@ def test_special_aperture_shapes(tmp_path, set_test_backend, shape, points, expe
 
 def test_obstruction_groups_and_native_serialization(tmp_path, set_test_backend):
     from optiland.physical_apertures import BaseAperture
-    commands = ('APN 2\nATP A 1\nAAC A 2\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1\n'
+    commands = ('AP CHK 3\nAPN 2\nATP A 1\nAAC A 2\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1\n'
                 'ATP B 2\nAAC B 4\nAGN B 1\nAX1 B -.1\nAX2 B .1\nAY1 B -.1\nAY2 B .1')
     aperture = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True).surfaces[1].aperture
     for ap in [aperture, BaseAperture.from_dict(aperture.to_dict())]:
@@ -302,7 +302,7 @@ def test_multiple_pickups_relative_indices_curvature_and_length(tmp_path, set_te
     assert_allclose(optic.surfaces[2].geometry.coefficients[1], -.001)
     assert_allclose(optic.surfaces[2].thickness, 3)
     assert_allclose(optic.surfaces[3].thickness, 5)
-    assert_allclose(optic.surfaces[2].aperture.r_max, 3)
+    assert_allclose(optic.surfaces[2].aperture.extent[1], 3)
     assert_allclose(optic.surfaces[2].material_post.n(.55), 1.5)
 
 
@@ -413,3 +413,29 @@ def test_metadata_and_deleting_surface_data(tmp_path, set_test_backend):
     assert_allclose(optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, 0, 0])
     assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
     assert_allclose(optic.surfaces[1].geometry.sag(be.array([0]), be.array([1])), 20 - 399**.5)
+
+
+@pytest.mark.parametrize('aperture,setting,intensity', [('AP 1', '', 1), ('AP CHK 1', '', 0), ('AP CHK 1', 'APCK OFF', 1), ('AP UNC 1', 'APCK ON', 1)])
+def test_aperture_checking_distinguishes_drawing_bounds(tmp_path, set_test_backend, aperture, setting, intensity):
+    from optiland.rays import RealRays
+    optic = load_oslo_file(simple_lens(tmp_path, system=setting, surface=aperture), strict=True)
+    rays = RealRays(be.array([2.0]), be.array([0.0]), be.array([-1.0]), be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .55)
+    optic.surfaces[1].trace(rays)
+    assert_allclose(rays.i, [intensity])
+    assert_allclose(optic.surfaces[1].aperture.extent, [-1, 1, -1, 1])
+
+
+def test_legacy_special_apertures_omit_zero_bounds(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='APN 1\nATP A 2\nAAC A 4\nAX1 A -.2\nAY1 A -1.5\nAY2 A 1.5'), strict=True)
+    assert_allclose(optic.surfaces[1].aperture.contains(be.array([-.1, .1]), be.array([0, 0])), [True, False])
+
+
+@pytest.mark.parametrize('checked', [False, True])
+def test_roundtrip_preserves_radial_clipping_mode(tmp_path, set_test_backend, checked):
+    from optiland.physical_apertures import UnclippedAperture
+    optic = load_oslo_file(simple_lens(tmp_path, surface='AP CHK 1' if checked else 'AP 1'), strict=True)
+    target = tmp_path / 'aperture.len'
+    save_oslo_file(optic, target)
+    restored = load_oslo_file(target, strict=True)
+    assert isinstance(restored.surfaces[1].aperture, UnclippedAperture) is not checked
+    assert_allclose(restored.surfaces[1].aperture.extent, [-1, 1, -1, 1])

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -208,3 +208,43 @@ def test_tabulated_material_validation_interpolation_and_serialization(set_test_
         mat.n(.9)
     with pytest.raises(ValueError):
         TabulatedMaterial([.5, .5], [1.5, 1.6])
+
+
+@pytest.mark.parametrize('shape,points,expected', [
+    (1, [(1, 0), (0, 0), (1, 1.1), (2.1, 0)], [True, True, False, False]),
+    (2, [(1.9, .9), (2.1, 0), (0, 1.1)], [True, False, False]),
+])
+def test_special_aperture_shapes(tmp_path, set_test_backend, shape, points, expected):
+    commands = f'APN 1\nATP A {shape}\nAAC A 4\nAX1 A 0\nAX2 A 2\nAY1 A -1\nAY2 A 1'
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    aperture = optic.surfaces[1].aperture
+    assert_allclose(aperture.contains(be.array([p[0] for p in points]),
+                                     be.array([p[1] for p in points])), expected)
+
+
+def test_obstruction_groups_and_native_serialization(tmp_path, set_test_backend):
+    from optiland.physical_apertures import BaseAperture
+    commands = ('APN 2\nATP A 1\nAAC A 2\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1\n'
+                'ATP B 2\nAAC B 4\nAGN B 1\nAX1 B -.1\nAX2 B .1\nAY1 B -.1\nAY2 B .1')
+    aperture = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True).surfaces[1].aperture
+    for ap in [aperture, BaseAperture.from_dict(aperture.to_dict())]:
+        assert_allclose(ap.contains(be.array([0, .5, 2, 4]), be.array([0, 0, 0, 0])),
+                        [True, False, True, False])
+
+
+def test_rotated_scaled_rectangle_and_triangle(tmp_path, set_test_backend):
+    commands = 'APN 1\nATP A 2\nAAC A 4\nAX1 A -2\nAX2 A 2\nAY1 A -1\nAY2 A 1\nAAN A 90'
+    ap = load_oslo_file(simple_lens(tmp_path, system='UNI 10', surface=commands), strict=True).surfaces[1].aperture
+    assert_allclose(ap.contains(be.array([0, 15]), be.array([15, 0])), [True, False])
+    commands = ('APN 1\nATP A 3\nAAC A 4\nAVX1 A 0\nAVY1 A 0\n'
+                'AVX2 A 2\nAVY2 A 0\nAVX3 A 0\nAVY3 A 2')
+    ap = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True).surfaces[1].aperture
+    assert_allclose(ap.contains(be.array([.5, 1.5]), be.array([.5, 1.5])), [True, False])
+
+
+def test_checked_aperture_and_hole_diagnostic(tmp_path):
+    path = simple_lens(tmp_path, surface='AP CHK 1.5')
+    assert OsloDataParser(path).parse().surfaces[1]['AP'] == 1.5
+    path = simple_lens(tmp_path, surface='APN 1\nATP A 1\nAAC A 1')
+    with pytest.raises(ValueError, match='hole'):
+        load_oslo_file(path, strict=True)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -323,3 +323,32 @@ def test_invalid_or_unsupported_pickups_rejected(tmp_path, pickup):
     path = simple_lens(tmp_path, surface=pickup)
     with pytest.raises(ValueError, match='PK'):
         load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize('command,target,component,index', [
+    ('PY 1', 1, 'marginal_height', 2),
+    ('PYC .1', .1, 'chief_height', 2),
+    ('PU -.05', -.05, 'marginal_slope', 1),
+])
+def test_paraxial_solves_use_requested_surface_and_value(tmp_path, set_test_backend, command, target, component, index):
+    optic = load_oslo_file(simple_lens(tmp_path, system='ANG 5', surface=command), strict=True)
+    heights, slopes = optic.paraxial.chief_ray() if component.startswith('chief') else optic.paraxial.marginal_ray()
+    assert_allclose((heights if component.endswith('height') else slopes)[index], target, atol=1e-9)
+    if command.startswith('PY'):
+        # Moving an interior surface must retain the subsequent nominal spacing.
+        assert_allclose(optic.surfaces[3].geometry.cs.z - optic.surfaces[2].geometry.cs.z, 20)
+
+
+def test_edge_contact_solve_and_unsatisfiable_solve(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='EC 2'), strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.z, 2 * (20 - (400 - 4)**.5))
+    path = simple_lens(tmp_path, surface='AIF\nPY 1')
+    with pytest.raises(ValueError, match='PY'):
+        load_oslo_file(path, strict=True)
+
+
+def test_chief_angle_solve(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, system='ANG 5')
+    path.write_text(path.read_text().replace('RD -20', 'RD -20\nPUC .03'))
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(optic.paraxial.chief_ray()[1][2], .03, atol=1e-9)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -158,7 +158,8 @@ def test_oslo_standard_asphere_power_and_scaled_sag(tmp_path, set_test_backend):
     ('ASP ASX 2\nAS0 .02\nAS1 .01\nAS4 .003', .02 + .01 * 2),
 ])
 def test_general_asphere_equations(tmp_path, set_test_backend, command, expected):
-    optic = load_oslo_file(simple_lens(tmp_path, surface='RD 0\n' + command), strict=True)
+    with pytest.warns(UserWarning, match="asphere.*paraxial"):
+        optic = load_oslo_file(simple_lens(tmp_path, surface='RD 0\n' + command))
     assert_allclose(optic.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])), [expected])
 
 

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -784,7 +784,7 @@ def test_names_fields_and_signed_infinity_roundtrip(tmp_path, set_test_backend):
     optic.fields.fields.clear()
     optic.fields.add(y=-3, x=2, weight=2, vx=0.1, vy=0.2)
     optic.fields.add(y=5, x=-1, weight=0)
-    optic.surfaces[0].thickness = -float("inf")
+    optic.updater.set_thickness(-float("inf"), 0)
     path = tmp_path / "metadata.len"
     save_oslo_file(optic, path)
     restored = load_oslo_file(path, strict=True)

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -248,3 +248,44 @@ def test_checked_aperture_and_hole_diagnostic(tmp_path):
     path = simple_lens(tmp_path, surface='APN 1\nATP A 1\nAAC A 1')
     with pytest.raises(ValueError, match='hole'):
         load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize('order', [1, -1])
+def test_oslo_tilt_sign_order_and_decenter(tmp_path, set_test_backend, order):
+    import numpy as np
+    a, b, c = np.deg2rad([-10, -20, 30])
+    rx = np.array([[1, 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
+    ry = np.array([[np.cos(b), 0, np.sin(b)], [0, 1, 0], [-np.sin(b), 0, np.cos(b)]])
+    rz = np.array([[np.cos(c), -np.sin(c), 0], [np.sin(c), np.cos(c), 0], [0, 0, 1]])
+    expected = rx @ ry @ rz if order == 1 else rz @ ry @ rx
+    commands = f'DT {order}\nDCX 1\nDCY 2\nDCZ 3\nTLA 10\nTLB 20\nTLC 30'
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    position, rotation = optic.surfaces[1].geometry.cs.get_effective_transform()
+    assert_allclose(rotation, expected)
+    assert_allclose(position, [1, 2, 3] if order == 1 else expected @ [1, 2, 3])
+    assert be.isinf(optic.surfaces[0].geometry.cs.z)
+
+
+def test_coordinate_return_global_reference_and_pivot(tmp_path, set_test_backend):
+    commands = 'DCY 4\nTLA 30\nRCO'
+    optic = load_oslo_file(simple_lens(tmp_path, surface=commands), strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 0, 2])
+    path = simple_lens(tmp_path, surface='DCY 4')
+    path.write_text(path.read_text().replace('RD -20', 'RD -20\nGC -1\nDCY 2\nDCZ 5'))
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, 6, 5])
+    optic = load_oslo_file(simple_lens(tmp_path, surface='TLA 90\nTOZ 1\nRCO'), strict=True)
+    assert_allclose(optic.surfaces[1].geometry.cs.get_effective_transform()[0], [0, -1, 1])
+
+
+def test_single_axis_mirror_bend_has_expected_physical_path(tmp_path, set_test_backend):
+    path = write_lens(tmp_path, 'LEN NEW "fold" 1 2\nEBR 1\nANG 0\nTH 1e20\n'
+                      'NXT\nRFH\nTLA 45\nBEN\nTH -10\nNXT\nAIR\nEND 2\n')
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(optic.surfaces[2].geometry.cs.get_effective_transform()[0], [0, -10, 0], atol=1e-12)
+    from optiland.rays import RealRays
+    rays = RealRays(be.array([0.0]), be.array([0.0]), be.array([-1.0]),
+                    be.array([0.0]), be.array([0.0]), be.array([1.0]), 1, .55)
+    optic.surfaces.trace(rays, skip=1)
+    assert_allclose(rays.y, [-10], atol=1e-12)
+    assert_allclose(rays.i, [1])

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -176,3 +176,35 @@ def test_hatched_reflector_and_fixed_air(tmp_path, set_test_backend):
     assert optic.surfaces[1].interaction_model.is_reflective
     optic = load_oslo_file(simple_lens(tmp_path, surface='AIF'), strict=True)
     assert_allclose(optic.surfaces[1].material_post.n(.55), 1)
+
+
+@pytest.mark.parametrize("definition", ['GLA CUSTOM 1.7 1.72 1.68',
+                                         'GLA 1.7 1.72 1.68',
+                                         'GLA MOD G1 1.7 1.72 1.68'])
+def test_embedded_indices_use_definition_wavelengths(tmp_path, set_test_backend, definition):
+    path = simple_lens(tmp_path, surface='WV .6 .4 .8\n' + definition,
+                       footer='WV .6\nWW 1')
+    optic = load_oslo_file(path, strict=True)
+    material = optic.surfaces[1].material_post
+    assert_allclose(material.n(be.array([.4, .6, .8])), [1.72, 1.7, 1.68])
+    out = tmp_path / 'material.len'
+    save_oslo_file(optic, out)
+    assert_allclose(load_oslo_file(out).surfaces[1].material_post.n(.6), 1.7)
+
+
+def test_single_direct_index_and_unknown_glass_strict(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, surface='GLA 1.65'), strict=True)
+    assert_allclose(optic.surfaces[1].material_post.n(.55), 1.65)
+    with pytest.raises(ValueError, match="MISSING_GLASS"):
+        load_oslo_file(simple_lens(tmp_path, surface='GLA MISSING_GLASS'), strict=True)
+
+
+def test_tabulated_material_validation_interpolation_and_serialization(set_test_backend):
+    from optiland.materials import BaseMaterial, TabulatedMaterial
+    mat = TabulatedMaterial([.6, .4, .8], [1.5, 1.6, 1.4], name='example')
+    assert_allclose(mat.n(be.array([.4, .5, .6, .7, .8])), [1.6, 1.55, 1.5, 1.45, 1.4])
+    assert_allclose(BaseMaterial.from_dict(mat.to_dict()).n(.5), 1.55)
+    with pytest.raises(ValueError, match="range"):
+        mat.n(.9)
+    with pytest.raises(ValueError):
+        TabulatedMaterial([.5, .5], [1.5, 1.6])

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -352,3 +352,38 @@ def test_chief_angle_solve(tmp_path, set_test_backend):
     path.write_text(path.read_text().replace('RD -20', 'RD -20\nPUC .03'))
     optic = load_oslo_file(path, strict=True)
     assert_allclose(optic.paraxial.chief_ray()[1][2], .03, atol=1e-9)
+
+
+def test_explicit_field_table_signed_xy_weights_and_vignetting(tmp_path, set_test_backend):
+    path = simple_lens(tmp_path, system='ANG 10')
+    path.write_text(path.read_text() + 'RST NEW\nF 1 -.5 .25 0 0 0 -.8 .8 -.9 .9 2\nF 2 0 0 0 0 0 -1 1 -1 1 0\nEND\n')
+    optic = load_oslo_file(path, strict=True)
+    import math
+    assert len(optic.fields) == 2
+    assert_allclose(optic.fields[0].y, math.degrees(math.atan(-.5 * math.tan(math.radians(10)))))
+    assert_allclose(optic.fields[0].x, math.degrees(math.atan(.25 * math.tan(math.radians(10)))))
+    assert_allclose([optic.fields[0].vy, optic.fields[0].vx], [.2, .1])
+    assert [f.weight for f in optic.fields] == [2, 0]
+
+
+@pytest.mark.parametrize('footer', ['CFG NEW\nEND\n', 'RST NEW\nF 1 0 0 1 0 0 -1 1 -1 1 1\nEND\n'])
+def test_unsupported_configuration_and_field_aiming_are_diagnosed(tmp_path, footer):
+    path = simple_lens(tmp_path)
+    path.write_text(path.read_text() + footer)
+    with pytest.raises(ValueError, match='CFG|field'):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize('command,target', [('FNO 5', .1), ('PUK .1', .1)])
+def test_image_aperture_definitions_at_finite_conjugates(tmp_path, set_test_backend, command, target):
+    path = simple_lens(tmp_path, system=command)
+    path.write_text(path.read_text().replace('TH 1e20', 'TH 100'))
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(abs(optic.paraxial.marginal_ray()[1][-2]), target)
+
+
+def test_gaussian_image_height_uses_focal_plane(tmp_path, set_test_backend):
+    optic = load_oslo_file(simple_lens(tmp_path, system='GIH 2'), strict=True)
+    import math
+    expected = math.degrees(math.atan(2 / float(optic.paraxial.f2())))
+    assert_allclose(optic.fields[-1].y, abs(expected))

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -233,22 +233,6 @@ def test_single_direct_index_and_unknown_glass_strict(tmp_path, set_test_backend
         load_oslo_file(simple_lens(tmp_path, surface="GLA MISSING_GLASS"), strict=True)
 
 
-def test_tabulated_material_validation_interpolation_and_serialization(
-    set_test_backend,
-):
-    from optiland.materials import BaseMaterial, TabulatedMaterial
-
-    mat = TabulatedMaterial([0.6, 0.4, 0.8], [1.5, 1.6, 1.4], name="example")
-    assert_allclose(
-        mat.n(be.array([0.4, 0.5, 0.6, 0.7, 0.8])), [1.6, 1.55, 1.5, 1.45, 1.4]
-    )
-    assert_allclose(BaseMaterial.from_dict(mat.to_dict()).n(0.5), 1.55)
-    with pytest.raises(ValueError, match="range"):
-        mat.n(0.9)
-    with pytest.raises(ValueError):
-        TabulatedMaterial([0.5, 0.5], [1.5, 1.6])
-
-
 @pytest.mark.parametrize(
     "shape,points,expected",
     [
@@ -732,14 +716,6 @@ def test_tilt_pickup_retains_pivot(tmp_path, set_test_backend):
     position, rotation = optic.surfaces[2].geometry.cs.get_effective_transform()
     assert_allclose(position, [0, 0, 0], atol=1e-12)
     assert_allclose(rotation, be.eye(3), atol=1e-12)
-
-
-def test_invalid_tabulated_query(set_test_backend):
-    from optiland.materials import TabulatedMaterial
-
-    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.4])
-    with pytest.raises(ValueError, match="finite|range"):
-        material.n(float("nan"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fileio/test_oslo_commands.py
+++ b/tests/test_fileio/test_oslo_commands.py
@@ -289,3 +289,37 @@ def test_single_axis_mirror_bend_has_expected_physical_path(tmp_path, set_test_b
     optic.surfaces.trace(rays, skip=1)
     assert_allclose(rays.y, [-10], atol=1e-12)
     assert_allclose(rays.i, [1])
+
+
+def test_multiple_pickups_relative_indices_curvature_and_length(tmp_path, set_test_backend):
+    path = write_lens(tmp_path, 'LEN NEW "pickups" 1 4\nEBR 1\nANG 0\nTH 1e20\n'
+                      'NXT\nGLA 1.5\nRD 10\nCC -1\nAD .001\nTH 2\nAP 3\n'
+                      'NXT\nPK CVM -1 .01\nPK TH -1 1\nPK AP -1\nPK GLA -1\n'
+                      'NXT\nAIR\nPK CV -1 0\nPK LNM -2 0 10\nNXT\nAIR\nEND 4\n')
+    optic = load_oslo_file(path, strict=True)
+    assert_allclose(optic.surfaces[2].geometry.radius, 1 / (-.1 + .01))
+    assert_allclose(optic.surfaces[2].geometry.k, -1)
+    assert_allclose(optic.surfaces[2].geometry.coefficients[1], -.001)
+    assert_allclose(optic.surfaces[2].thickness, 3)
+    assert_allclose(optic.surfaces[3].thickness, 5)
+    assert_allclose(optic.surfaces[2].aperture.r_max, 3)
+    assert_allclose(optic.surfaces[2].material_post.n(.55), 1.5)
+
+
+def test_special_aperture_pickup_and_coordinate_inverse(tmp_path, set_test_backend):
+    path = write_lens(tmp_path, 'LEN NEW "pickup pose" 1 3\nEBR 1\nANG 0\nTH 1e20\nNXT\n'
+                      'AIR\nDCY 2\nTLA 10\nTLB 20\nTLC 30\nAPN 1\n'
+                      'ATP A 2\nAAC A 4\nAX1 A -1\nAX2 A 1\nAY1 A -2\nAY2 A 2\n'
+                      'NXT\nAIR\nPK TDM -1\nAPN 1\nAPK A -1 A\nTH 5\nNXT\nAIR\nEND 3\n')
+    optic = load_oslo_file(path, strict=True)
+    position, rotation = optic.surfaces[2].geometry.cs.get_effective_transform()
+    assert_allclose(position, [0, 0, 0], atol=1e-12)
+    assert_allclose(rotation, be.eye(3), atol=1e-12)
+    assert_allclose(optic.surfaces[2].aperture.contains(be.array([0, 2]), be.array([1.5, 0])), [True, False])
+
+
+@pytest.mark.parametrize('pickup', ['PK TH 2', 'PK TH -5', 'PK UNKNOWN -1'])
+def test_invalid_or_unsupported_pickups_rejected(tmp_path, pickup):
+    path = simple_lens(tmp_path, surface=pickup)
+    with pytest.raises(ValueError, match='PK'):
+        load_oslo_file(path, strict=True)

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 import optiland.backend as be
+from optiland.fields.field_types import AngleField, ObjectHeightField
 from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.model import OsloDataModel
 from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
@@ -832,3 +833,54 @@ def test_telecentric_launch_rejects_invalid_cone(lens_file, aperture):
             lens_file(system="OBH 2\nTELE ON", distance="100", aperture=aperture),
             strict=True,
         )
+
+
+@pytest.mark.parametrize(
+    "distance,infinite", [(99999999, False), (1e8, True), (-1e8, True)]
+)
+@pytest.mark.parametrize("transformed", [False, True])
+def test_oslo_object_infinity_boundary(
+    lens_file, set_test_backend, distance, infinite, transformed
+):
+    # The OSLO cutoff is in lens units, before conversion to millimeters.
+    optic = load_oslo_file(
+        lens_file(
+            system="UNI .001\nOBH 2",
+            distance=str(distance),
+            surface="DCY 0" if transformed else "",
+        ),
+        strict=True,
+    )
+    assert optic.object_surface.is_infinite == infinite
+    if infinite:
+        assert float(optic.object_surface.geometry.cs.z) == -math.copysign(
+            math.inf, distance
+        )
+        assert isinstance(optic.fields.field_definition, AngleField)
+    else:
+        assert_allclose(optic.object_surface.geometry.cs.z, -99999.999)
+        assert isinstance(optic.fields.field_definition, ObjectHeightField)
+
+
+def test_export_rejects_finite_object_at_oslo_infinity_boundary(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(distance="100"), strict=True)
+    optic.updater.set_thickness(1e8, 0)
+    path = tmp_path / "finite-object.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="finite object distance"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"
+
+
+def test_export_preserves_finite_object_just_below_infinity_boundary(
+    lens_file, tmp_path, set_test_backend
+):
+    distance = math.nextafter(1e8, 0)
+    optic = load_oslo_file(lens_file(distance=str(distance)), strict=True)
+    path = tmp_path / "large-finite-object.len"
+    save_oslo_file(optic, path)
+    restored = load_oslo_file(path, strict=True)
+    assert not restored.object_surface.is_infinite
+    assert float(restored.object_surface.geometry.cs.z) == -distance

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -610,3 +610,16 @@ def test_later_solve_preserves_an_earlier_edge_contact(lens_file, set_test_backe
     assert_allclose(optic.surfaces[2].geometry.radius, -20)
     with pytest.raises(ValueError, match="EC at surface 1"):
         load_oslo_file(path, strict=True)
+
+
+def test_deferred_asphere_diagnostic_points_to_coefficient(lens_file):
+    path = lens_file(surface="AS1 .01")
+    source_line = path.read_text().splitlines().index("AS1 .01") + 1
+    with pytest.warns(UserWarning, match="general coefficients require"):
+        model = OsloDataParser(path).parse()
+    diagnostic = model.diagnostics[0]
+    assert diagnostic.line == source_line
+    assert diagnostic.surface == 1
+    with pytest.raises(ValueError) as error:
+        OsloDataParser(path, strict=True).parse()
+    assert f"{path}:{source_line}:" in str(error.value)

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -899,3 +899,38 @@ def test_indexed_wavelength_edit_preserves_other_defaults(lens_file, slot):
 def test_indexed_wavelength_cannot_restore_removed_slots_implicitly(lens_file):
     with pytest.raises(ValueError, match="undefined wavelength slots"):
         OsloDataParser(lens_file(system="WV .55\nWV3 .7")).parse()
+
+
+@pytest.mark.parametrize("kind", [1, 2])
+def test_special_aperture_rotates_about_its_centroid(lens_file, set_test_backend, kind):
+    optic = load_oslo_file(
+        lens_file(
+            system="UNI 2",
+            surface=f"APN 1\nATP A {kind}\nAX1 A 2\nAX2 A 6\n"
+            "AY1 A 1\nAY2 A 3\nAAN A 90",
+        ),
+        strict=True,
+    )
+    aperture = optic.surfaces[1].aperture
+    # Rotating a 4-by-2 boundary leaves its center (4, 2) fixed, then UNI=2
+    # makes the extent [6, 10] x [0, 8]. The displaced origin must not pass.
+    assert_allclose(aperture.extent, [6, 10, 0, 8])
+    points_x, points_y = be.array([8, 8, 10.1, -4]), be.array([4, 7, 4, 8])
+    expected = [True, True, False, False]
+    assert_allclose(aperture.contains(points_x, points_y), expected)
+    restored = BaseAperture.from_dict(aperture.to_dict())
+    assert_allclose(restored.contains(points_x, points_y), expected)
+    restored.scale(3)
+    assert_allclose(restored.extent, [18, 30, 0, 24])
+    assert_allclose(restored.contains(points_x * 3, points_y * 3), expected)
+
+
+def test_legacy_rotated_aperture_json_keeps_origin_pivot():
+    aperture = BaseAperture.from_dict(
+        {
+            "type": "RotatedAperture",
+            "aperture": RectangularAperture(2, 6, 1, 3).to_dict(),
+            "angle": math.pi / 2,
+        }
+    )
+    assert_allclose(aperture.extent, [-3, -1, 2, 6])

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -1019,3 +1019,23 @@ def test_ideal_material_export_preserves_optical_path(
     # One meter through the medium must retain its optical-path excess over
     # vacuum; near-unity indices are still refracting media, not exactly air.
     assert (exported_index - 1) * 1000 == pytest.approx((index - 1) * 1000, abs=1e-10)
+
+
+@pytest.mark.parametrize("command", ["WW 0 1 1", "WW1 0"])
+def test_primary_wavelength_weight_must_be_positive(lens_file, command):
+    with pytest.raises(ValueError, match="primary wavelength weight"):
+        OsloDataParser(lens_file(system=command)).parse()
+
+
+@pytest.mark.parametrize("primary_index", [0, 1])
+def test_zero_primary_weight_export_preserves_destination(
+    lens_file, tmp_path, primary_index
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.wavelengths.primary_index = primary_index
+    optic.wavelengths[primary_index].weight = 0
+    path = tmp_path / "zero-primary-weight.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="primary wavelength weight"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -884,3 +884,18 @@ def test_export_preserves_finite_object_just_below_infinity_boundary(
     restored = load_oslo_file(path, strict=True)
     assert not restored.object_surface.is_infinite
     assert float(restored.object_surface.geometry.cs.z) == -distance
+
+
+@pytest.mark.parametrize("slot", [1, 2])
+def test_indexed_wavelength_edit_preserves_other_defaults(lens_file, slot):
+    model = OsloDataParser(lens_file(system=f"WV{slot} .55\nWW2 3")).parse()
+    expected = [0.58756, 0.48613, 0.65627]
+    expected[slot - 1] = 0.55
+    assert model.wavelengths["values"] == expected
+    assert model.wavelengths["weights"] == [1, 3, 1]
+    assert model.surfaces[1]["glass_wavelengths"] == expected
+
+
+def test_indexed_wavelength_cannot_restore_removed_slots_implicitly(lens_file):
+    with pytest.raises(ValueError, match="undefined wavelength slots"):
+        OsloDataParser(lens_file(system="WV .55\nWV3 .7")).parse()

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -29,34 +29,6 @@ from optiland.rays import RealRays
 from tests.utils import assert_allclose
 
 
-@pytest.fixture
-def lens_file(tmp_path):
-    """Write an original, small prescription with independently known power."""
-
-    def write(
-        *,
-        system="",
-        surface="",
-        second="",
-        image="",
-        footer="",
-        aperture="EBR 2",
-        distance="1e20",
-    ):
-        path = tmp_path / "edge.len"
-        path.write_text(
-            'LEN NEW "edge cases" 50 3\n'
-            f"{aperture}\nANG 0\n{system}\nTH {distance}\nNXT\n"
-            f"GLA 1.5\nRD 20\nTH 2\nAP 3\n{surface}\nNXT\n"
-            f"AIR\nRD -20\nTH 20\n{second}\nNXT\nAIR\n{image}\n"
-            f"END 3\n{footer}",
-            encoding="utf-8",
-        )
-        return path
-
-    return write
-
-
 @pytest.mark.parametrize(
     "command,message",
     [

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -748,3 +748,14 @@ def test_surface_loss_and_scatter_export_preserves_destination(
     with pytest.raises(NotImplementedError, match="coatings or scattering"):
         save_oslo_file(optic, path)
     assert path.read_text() == "saved design"
+
+
+def test_resetting_special_apertures_clears_their_pickups(lens_file, set_test_backend):
+    optic = load_oslo_file(
+        lens_file(
+            surface="APN 1\nAX1 A -1\nAX2 A 1\nAY1 A -1\nAY2 A 1",
+            second="APN 1\nAPK A 1 A\nAPN 0",
+        ),
+        strict=True,
+    )
+    assert optic.surfaces[2].aperture is None

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -665,3 +665,86 @@ def test_diverging_fno_uses_a_positive_entrance_pupil(lens_file, set_test_backen
     )
     assert float(optic.paraxial.EPD()) > 0
     assert_allclose(abs(optic.paraxial.marginal_ray()[1][-2]), [0.1])
+
+
+@pytest.mark.parametrize("drawing", [False, True])
+def test_offset_radial_export_preserves_destination(lens_file, tmp_path, drawing):
+    from optiland.physical_apertures import OffsetRadialAperture
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    aperture = OffsetRadialAperture(1, offset_x=2)
+    optic.surfaces[1].aperture = UnclippedAperture(aperture) if drawing else aperture
+    path = tmp_path / "offset-aperture.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="aperture"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"
+
+
+def test_custom_material_cannot_export_as_its_catalog_like_name(lens_file, tmp_path):
+    from optiland.materials import BaseMaterial
+
+    class CustomMaterial(BaseMaterial):
+        name = "BK7"
+
+        def _calculate_n(self, wavelength):
+            return be.array([1.8])
+
+        def _calculate_k(self, wavelength):
+            return be.array([0.0])
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[1].material_post = CustomMaterial()
+    path = tmp_path / "custom-material.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="material"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"
+
+
+@pytest.mark.parametrize("index", [1.0, 1.5])
+def test_absorbing_ideal_material_export_preserves_destination(
+    lens_file, tmp_path, index
+):
+    from optiland.materials import IdealMaterial
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[1].material_post = IdealMaterial(index, 0.01)
+    path = tmp_path / "absorbing.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="absorption"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"
+
+
+def test_custom_propagation_export_preserves_destination(lens_file, tmp_path):
+    from optiland.propagation.base import BasePropagationModel
+
+    class CustomPropagation(BasePropagationModel):
+        def propagate(self, rays, t):
+            rays.x = rays.x + t
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[1].material_post.propagation_model = CustomPropagation()
+    path = tmp_path / "custom-propagation.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="propagation"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"
+
+
+@pytest.mark.parametrize("property_name", ["coating", "bsdf"])
+def test_surface_loss_and_scatter_export_preserves_destination(
+    lens_file, tmp_path, property_name
+):
+    from optiland.coatings import SimpleCoating
+    from optiland.scatter import LambertianBSDF
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    effect = SimpleCoating(0.5) if property_name == "coating" else LambertianBSDF()
+    setattr(optic.surfaces[1].interaction_model, property_name, effect)
+    path = tmp_path / "surface-effect.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="coatings or scattering"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -926,17 +926,6 @@ def test_special_aperture_rotates_about_its_centroid(lens_file, set_test_backend
     assert_allclose(restored.contains(points_x * 3, points_y * 3), expected)
 
 
-def test_legacy_rotated_aperture_json_keeps_origin_pivot():
-    aperture = BaseAperture.from_dict(
-        {
-            "type": "RotatedAperture",
-            "aperture": RectangularAperture(2, 6, 1, 3).to_dict(),
-            "angle": math.pi / 2,
-        }
-    )
-    assert_allclose(aperture.extent, [-3, -1, 2, 6])
-
-
 @pytest.mark.parametrize(
     "distance,medium,na",
     [("1e20", "", 0.1), ("100", "", 1), ("100", "", 1.1), ("100", "GLA 1.5", 1.6)],

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -561,6 +561,7 @@ def test_encoder_reuse_does_not_retain_old_prescription(lens_file):
     encoder = OpticToOsloEncoder(optic)
     original = encoder.encode()
     optic.set_aperture("objectNA", 0.1)
+    optic.updater.set_thickness(100, 0)
     optic.surfaces.remove(2)
     updated = encoder.encode()
     assert updated.aperture == {"NAO": 0.1}
@@ -828,7 +829,7 @@ def test_telecentric_chief_solves_do_not_use_a_nontelecentric_ray(lens_file, com
 
 @pytest.mark.parametrize("aperture", ["NAO 1", "NAO 1.1", "PUK 0"])
 def test_telecentric_launch_rejects_invalid_cone(lens_file, aperture):
-    with pytest.raises(ValueError, match="TELE.*NA"):
+    with pytest.raises(ValueError, match="NAO|TELE.*NA"):
         load_oslo_file(
             lens_file(system="OBH 2\nTELE ON", distance="100", aperture=aperture),
             strict=True,
@@ -934,3 +935,37 @@ def test_legacy_rotated_aperture_json_keeps_origin_pivot():
         }
     )
     assert_allclose(aperture.extent, [-3, -1, 2, 6])
+
+
+@pytest.mark.parametrize(
+    "distance,medium,na",
+    [("1e20", "", 0.1), ("100", "", 1), ("100", "", 1.1), ("100", "GLA 1.5", 1.6)],
+)
+def test_object_na_rejects_invalid_launch(
+    lens_file, set_test_backend, distance, medium, na
+):
+    with pytest.raises(ValueError, match="NAO"):
+        load_oslo_file(
+            lens_file(distance=distance, system=medium, aperture=f"NAO {na}")
+        )
+
+
+def test_object_na_respects_object_medium_index(lens_file, set_test_backend):
+    optic = load_oslo_file(
+        lens_file(distance="100", system="GLA 1.5", aperture="NAO 1.2"), strict=True
+    )
+    # NA/n = 0.8; tan(arcsin(0.8)) = 4/3 in the object medium.
+    assert_allclose(optic.paraxial.marginal_ray()[1][0], 4 / 3)
+
+
+@pytest.mark.parametrize("distance,na", [("1e20", 0.1), ("100", 1.1)])
+def test_invalid_object_na_export_preserves_destination(
+    lens_file, tmp_path, distance, na
+):
+    optic = load_oslo_file(lens_file(distance=distance), strict=True)
+    optic.set_aperture("objectNA", na)
+    path = tmp_path / "invalid-na.len"
+    path.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="NAO"):
+        save_oslo_file(optic, path)
+    assert path.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -759,3 +759,76 @@ def test_resetting_special_apertures_clears_their_pickups(lens_file, set_test_ba
         strict=True,
     )
     assert optic.surfaces[2].aperture is None
+
+
+def test_telecentric_import_survives_native_serialization(lens_file, set_test_backend):
+    from optiland.optic import Optic
+
+    optic = load_oslo_file(
+        lens_file(system="OBH 2\nTELE ON", aperture="NAO .1", distance="100"),
+        strict=True,
+    )
+    assert Optic.from_dict(optic.to_dict()).obj_space_telecentric
+
+
+def test_telecentric_entrance_beam_can_launch_real_rays(lens_file, set_test_backend):
+    from optiland.rays.ray_aiming.paraxial import ParaxialRayAimer
+
+    optic = load_oslo_file(
+        lens_file(system="OBH 2\nTELE ON", distance="100"), strict=True
+    )
+    x, y, z, l, m, n = ParaxialRayAimer(optic).aim_rays(
+        (0, 1), optic.primary_wavelength, (be.zeros(2), be.array([0.0, 1.0]))
+    )
+    # The chief ray is parallel to z; the marginal ray advances 2 mm in y
+    # across the 100 mm object distance. Both originate at the field point.
+    assert_allclose(y, [2, 2])
+    assert_allclose(m / n, [0, 0.02])
+    assert_allclose(l, [0, 0])
+
+
+def test_failed_solve_retains_telecentricity(lens_file, set_test_backend):
+    with pytest.warns(UserWarning, match="retained saved prescription"):
+        optic = load_oslo_file(
+            lens_file(
+                system="OBH 2\nTELE ON",
+                aperture="NAO .1",
+                distance="100",
+                surface="EC 40",
+            )
+        )
+    assert optic.obj_space_telecentric
+
+
+@pytest.mark.parametrize(
+    "distance,system",
+    [
+        ("1e20", "TELE ON"),
+        ("100", "OBH 2\nGLA 1.5\nTELE ON"),
+        ("100", "ANG 2\nTELE ON"),
+    ],
+)
+def test_unsupported_telecentric_launch_is_diagnosed(lens_file, distance, system):
+    path = lens_file(distance=distance, system=system)
+    with pytest.warns(UserWarning, match="TELE.*launch"):
+        load_oslo_file(path)
+    with pytest.raises(ValueError, match="TELE.*launch"):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize("command", ["PYC 1", "PUC .05"])
+def test_telecentric_chief_solves_do_not_use_a_nontelecentric_ray(lens_file, command):
+    path = lens_file(
+        system="OBH 2\nTELE ON", distance="100", aperture="NAO .1", surface=command
+    )
+    with pytest.raises(ValueError, match="telecentric chief-ray"):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize("aperture", ["NAO 1", "NAO 1.1", "PUK 0"])
+def test_telecentric_launch_rejects_invalid_cone(lens_file, aperture):
+    with pytest.raises(ValueError, match="TELE.*NA"):
+        load_oslo_file(
+            lens_file(system="OBH 2\nTELE ON", distance="100", aperture=aperture),
+            strict=True,
+        )

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -577,3 +577,36 @@ def test_multiline_export_name_preserves_destination(lens_file, tmp_path, name):
     with pytest.raises(ValueError, match="single line"):
         save_oslo_file(optic, target)
     assert target.read_text() == "saved design"
+
+
+def test_large_checked_aperture_still_clips_after_unit_conversion(
+    lens_file, set_test_backend
+):
+    optic = load_oslo_file(
+        lens_file(system="UNI .000001", surface="AP CHK 2000000"), strict=True
+    )
+    aperture = optic.surfaces[1].aperture
+    assert aperture is not None
+    assert_allclose(aperture.r_max, 2)
+    x, y = be.array([1.0, 3.0]), be.zeros(2)
+    rays = RealRays(x, y, be.zeros(2), be.zeros(2), be.zeros(2), be.ones(2), 1, 0.55)
+    aperture.clip(rays)
+    assert_allclose(rays.i, [1, 0])
+
+
+def test_later_solve_preserves_an_earlier_edge_contact(lens_file, set_test_backend):
+    path = lens_file(surface="EC 2", second="PU 0")
+    with pytest.warns(
+        UserWarning, match="EC at surface 1.*retained saved prescription"
+    ):
+        optic = load_oslo_file(path)
+    x, y = be.zeros(1), be.array([2.0])
+    edge_thickness = (
+        optic.surfaces[1].thickness
+        + optic.surfaces[2].geometry.sag(x, y)
+        - optic.surfaces[1].geometry.sag(x, y)
+    )
+    assert_allclose(edge_thickness, [0], atol=1e-12)
+    assert_allclose(optic.surfaces[2].geometry.radius, -20)
+    with pytest.raises(ValueError, match="EC at surface 1"):
+        load_oslo_file(path, strict=True)

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -353,12 +353,12 @@ def test_general_even_asphere_export_preserves_sag(
     lens_file, tmp_path, set_test_backend, command, power
 ):
     optic = load_oslo_file(
-        lens_file(surface=f"RD 0\nASP ASR 1\n{command}"), strict=True
+        lens_file(surface=f"RD 0\nASP ASR 1\n{command}"), strict=power > 2
     )
     path = tmp_path / "general-asphere.len"
     save_oslo_file(optic, path)
     assert "ASP ASR" in path.read_text()
-    restored = load_oslo_file(path, strict=True)
+    restored = load_oslo_file(path, strict=power > 2)
     assert_allclose(
         restored.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])),
         [0.001 * 2**power],
@@ -969,3 +969,35 @@ def test_invalid_object_na_export_preserves_destination(
     with pytest.raises(ValueError, match="NAO"):
         save_oslo_file(optic, path)
     assert path.read_text() == "saved design"
+
+
+@pytest.mark.parametrize(
+    "kind,coefficient",
+    [("ASR", 1), ("ARA", 1), ("ARA", 2)] + [("ASX", i) for i in range(6)],
+)
+def test_low_order_asphere_paraxial_limit_is_diagnosed(lens_file, kind, coefficient):
+    path = lens_file(surface=f"ASP {kind} 6\nAS{coefficient} .01")
+    with pytest.warns(UserWarning, match="asphere.*paraxial"):
+        load_oslo_file(path)
+    with pytest.raises(ValueError, match="asphere.*paraxial"):
+        load_oslo_file(path, strict=True)
+
+
+def test_quadratic_sag_preserves_real_surface_power(lens_file, set_test_backend):
+    path = lens_file(surface="RD 0\nASP ASR 1\nAS1 .01", second="RD 0")
+    with pytest.warns(UserWarning, match="asphere.*paraxial"):
+        optic = load_oslo_file(path)
+    x, y = be.zeros(1), be.array([1e-5])
+    surface = optic.surfaces[1]
+    rays = RealRays(x, y, surface.geometry.sag(x, y), x, x, be.ones(1), 1, 0.55)
+    surface.interaction_model.interact_real_rays(rays)
+    # z=.01*y^2 gives curvature .02; Snell's small-height limit is
+    # u/y = -(1.5-1)*.02/1.5 at the air-to-glass boundary.
+    assert_allclose(rays.M / rays.N / y, [-1 / 150], rtol=1e-7, atol=1e-12)
+
+
+@pytest.mark.parametrize("kind,coefficient", [("ASR", 2), ("ARA", 3), ("ASX", 6)])
+def test_higher_order_aspheres_remain_strictly_supported(lens_file, kind, coefficient):
+    load_oslo_file(
+        lens_file(surface=f"ASP {kind} 6\nAS{coefficient} .001"), strict=True
+    )

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -437,3 +437,58 @@ def test_rotated_drawing_aperture_roundtrip_scale_and_clipping(set_test_backend)
     assert_allclose(rays.i, [1, 1])
     restored.aperture.clip(rays)
     assert_allclose(rays.i, [1, 0])
+
+
+@pytest.mark.parametrize("name", ['lens "A"', '"', '"quoted"', 'path\\"'])
+def test_quoted_name_and_note_preserve_trailing_quote(lens_file, name):
+    model = OsloDataParser(lens_file()).parse()
+    model.name = name
+    model.notes["SNO1"] = name
+    path = lens_file()
+    path.write_text(OsloDataFormatter(model).format(), encoding="utf-8")
+    restored = OsloDataParser(path, strict=True).parse()
+    assert restored.name == name
+    assert restored.notes["SNO1"] == name
+
+
+def test_quoted_direct_glass_name(lens_file, set_test_backend):
+    optic = load_oslo_file(
+        lens_file(surface='GLA "test glass" 1.6 1.62 1.58'), strict=True
+    )
+    material = optic.surfaces[1].material_post
+    assert material.name == "test glass"
+    assert_allclose(material.n(0.48613), 1.62)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "AP 1 ignored",
+        "AP CHK 1 ignored",
+        "BEN OFF",
+        "RCO 0 1",
+        "AIR ignored",
+        "AST ignored",
+        "ATD ignored",
+        "ASP ASR 1 ignored",
+        "ASP ASR -1",
+        "GLA MOD G1",
+    ],
+)
+def test_optical_commands_do_not_silently_discard_arguments(lens_file, command):
+    with pytest.raises(ValueError):
+        load_oslo_file(lens_file(surface=command), strict=True)
+
+
+@pytest.mark.parametrize("next_block", ["CFG NEW", 'LEN NEW "second" 1 1'])
+def test_additional_configuration_cannot_replace_first_field_table(
+    lens_file, next_block
+):
+    first = "RST NEW\nF 1 .5 0 0 0 0 -1 1 -1 1 1\nEND\n"
+    second = "RST NEW\nF 1 1 0 0 0 0 -1 1 -1 1 1\nEND\n"
+    path = lens_file(
+        system="OBH 4", distance="100", footer=f"{first}{next_block}\nEND\n{second}"
+    )
+    with pytest.warns(UserWarning, match="additional configurations"):
+        optic = load_oslo_file(path)
+    assert_allclose(optic.fields.y_fields, [2])

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -15,6 +15,7 @@ from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
 from optiland.fileio.oslo.reader.coordinates import surface_coordinates
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
+from optiland.fileio.oslo.writer.encoder import OpticToOsloEncoder
 from optiland.fileio.oslo.writer.formatter import OsloDataFormatter
 from optiland.materials import AbbeMaterial, TabulatedMaterial
 from optiland.physical_apertures import (
@@ -525,3 +526,54 @@ def test_tilt_and_bend_requires_a_reflector(lens_file):
 def test_tilt_pickup_rejects_target_reference_flags(lens_file, coordinate):
     with pytest.raises(ValueError, match="global/return/bend"):
         load_oslo_file(lens_file(second=f"{coordinate}\nPK TD 1"), strict=True)
+
+
+def test_telecentric_export_preserves_chief_ray(lens_file, tmp_path, set_test_backend):
+    optic = load_oslo_file(
+        lens_file(system="OBH 2\nTELE ON", distance="100"), strict=True
+    )
+    expected = optic.paraxial.chief_ray()
+    target = tmp_path / "telecentric.len"
+    save_oslo_file(optic, target)
+    restored = load_oslo_file(target, strict=True)
+    assert restored.obj_space_telecentric
+    for actual, original in zip(restored.paraxial.chief_ray(), expected):
+        assert_allclose(actual, original)
+
+
+def test_custom_export_field_definition_preserves_destination(lens_file, tmp_path):
+    optic = load_oslo_file(lens_file(), strict=True)
+
+    class CustomField(type(optic.fields.field_definition)):
+        pass
+
+    optic.fields.field_definition = CustomField()
+    target = tmp_path / "custom.len"
+    target.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="field definition"):
+        save_oslo_file(optic, target)
+    assert target.read_text() == "saved design"
+
+
+def test_encoder_reuse_does_not_retain_old_prescription(lens_file):
+    optic = load_oslo_file(lens_file(), strict=True)
+    encoder = OpticToOsloEncoder(optic)
+    original = encoder.encode()
+    optic.set_aperture("objectNA", 0.1)
+    optic.surfaces.remove(2)
+    updated = encoder.encode()
+    assert updated.aperture == {"NAO": 0.1}
+    assert set(updated.surfaces) == {0, 1, 2}
+    assert original.aperture == {"EPD": 4}
+    assert len(original.surfaces) == 4
+
+
+@pytest.mark.parametrize("name", ["first\nsecond", "first\rsecond", "trailing\n"])
+def test_multiline_export_name_preserves_destination(lens_file, tmp_path, name):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.name = name
+    target = tmp_path / "multiline.len"
+    target.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="single line"):
+        save_oslo_file(optic, target)
+    assert target.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -1001,3 +1001,21 @@ def test_higher_order_aspheres_remain_strictly_supported(lens_file, kind, coeffi
     load_oslo_file(
         lens_file(surface=f"ASP {kind} 6\nAS{coefficient} .001"), strict=True
     )
+
+
+@pytest.mark.parametrize("index", [1.0000004, 1.573123456789])
+def test_ideal_material_export_preserves_optical_path(
+    lens_file, tmp_path, set_test_backend, index
+):
+    from optiland.materials import IdealMaterial
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[1].material_post = IdealMaterial(index)
+    optic.updater.set_thickness(1000, 1)
+    path = tmp_path / "index-precision.len"
+    save_oslo_file(optic, path)
+    restored = load_oslo_file(path, strict=True)
+    exported_index = float(restored.surfaces[1].material_post.n(0.55).item())
+    # One meter through the medium must retain its optical-path excess over
+    # vacuum; near-unity indices are still refracting media, not exactly air.
+    assert (exported_index - 1) * 1000 == pytest.approx((index - 1) * 1000, abs=1e-10)

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -492,3 +492,36 @@ def test_additional_configuration_cannot_replace_first_field_table(
     with pytest.warns(UserWarning, match="additional configurations"):
         optic = load_oslo_file(path)
     assert_allclose(optic.fields.y_fields, [2])
+
+
+def test_failed_pickup_rebuild_restores_converter_data(lens_file, set_test_backend):
+    path = lens_file(system="NAP .1", surface="PU 0", second="PK CV 1")
+    converter = OsloToOpticConverter(OsloDataParser(path).parse())
+    with pytest.warns(UserWarning, match="afocal.*retained saved prescription"):
+        optic = converter.convert()
+    # The saved pickup produces equal radii; solving both to infinity makes
+    # NAP undefined. Rollback must restore the model as well as the optic.
+    for index in (1, 2):
+        assert_allclose(optic.surfaces[index].geometry.radius, 20)
+        assert converter.data.surfaces[index]["RD"] == 20
+
+
+def test_coupled_solve_cannot_silently_change_image_na(lens_file, set_test_backend):
+    path = lens_file(system="NAP .1", surface="PU -.05")
+    with pytest.warns(UserWarning, match="retained saved prescription"):
+        optic = load_oslo_file(path)
+    assert_allclose(abs(optic.paraxial.marginal_ray()[1][-2]), 0.1)
+    assert_allclose(optic.surfaces[1].geometry.radius, 20)
+    with pytest.raises(ValueError, match="target"):
+        load_oslo_file(path, strict=True)
+
+
+def test_tilt_and_bend_requires_a_reflector(lens_file):
+    with pytest.raises(ValueError, match="BEN.*reflect"):
+        load_oslo_file(lens_file(surface="TLA 20\nBEN"), strict=True)
+
+
+@pytest.mark.parametrize("coordinate", ["GC 1", "RCO", "BEN"])
+def test_tilt_pickup_rejects_target_reference_flags(lens_file, coordinate):
+    with pytest.raises(ValueError, match="global/return/bend"):
+        load_oslo_file(lens_file(second=f"{coordinate}\nPK TD 1"), strict=True)

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -623,3 +623,45 @@ def test_deferred_asphere_diagnostic_points_to_coefficient(lens_file):
     with pytest.raises(ValueError) as error:
         OsloDataParser(path, strict=True).parse()
     assert f"{path}:{source_line}:" in str(error.value)
+
+
+@pytest.mark.parametrize("aperture, radius", [("EBR 2", 2), ("", 1)])
+def test_finite_entrance_beam_radius_is_measured_at_surface_one(
+    lens_file, set_test_backend, aperture, radius
+):
+    optic = load_oslo_file(
+        lens_file(distance="100", second="AST", aperture=aperture), strict=True
+    )
+    # OSLO EBR=2 specifies the beam at the first surface, even when its
+    # entrance pupil is displaced by refraction ahead of an internal stop.
+    assert_allclose(optic.paraxial.marginal_ray()[0][1], [radius])
+
+
+@pytest.mark.parametrize(
+    "aperture_type,value", [("EPD", 4), ("imageFNO", 8), ("float_by_stop_size", 3)]
+)
+def test_export_entrance_beam_matches_finite_conjugate_ray(
+    lens_file, tmp_path, set_test_backend, aperture_type, value
+):
+    from optiland.physical_apertures import RadialAperture
+
+    optic = load_oslo_file(lens_file(distance="100", second="AST"), strict=True)
+    optic.surfaces[2].aperture = RadialAperture(value)
+    optic.set_aperture(aperture_type, value)
+    expected = float(optic.paraxial.marginal_ray()[0][1].item())
+    path = tmp_path / "finite-beam.len"
+    save_oslo_file(optic, path)
+    command = next(
+        line for line in path.read_text().splitlines() if line.startswith("EBR ")
+    )
+    assert float(command.split()[1]) == pytest.approx(expected, rel=1e-6)
+    restored = load_oslo_file(path, strict=True)
+    assert_allclose(restored.paraxial.marginal_ray()[0][1], [expected], rtol=1e-6)
+
+
+def test_diverging_fno_uses_a_positive_entrance_pupil(lens_file, set_test_backend):
+    optic = load_oslo_file(
+        lens_file(aperture="FNO 5", surface="RD -20", second="RD 20"), strict=True
+    )
+    assert float(optic.paraxial.EPD()) > 0
+    assert_allclose(abs(optic.paraxial.marginal_ray()[1][-2]), [0.1])

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -1,0 +1,439 @@
+"""OSLO boundary validation, fallback behavior and less common round trips."""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+import optiland.backend as be
+from optiland.fileio import load_oslo_file, save_oslo_file
+from optiland.fileio.oslo.model import OsloDataModel
+from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
+from optiland.fileio.oslo.reader.coordinates import surface_coordinates
+from optiland.fileio.oslo.reader.parser import OsloDataParser
+from optiland.fileio.oslo.reader.pickups import resolve_pickups
+from optiland.fileio.oslo.writer.formatter import OsloDataFormatter
+from optiland.materials import AbbeMaterial, TabulatedMaterial
+from optiland.physical_apertures import (
+    BaseAperture,
+    RectangularAperture,
+    RotatedAperture,
+    UnclippedAperture,
+)
+from optiland.rays import RealRays
+from tests.utils import assert_allclose
+
+
+@pytest.fixture
+def lens_file(tmp_path):
+    """Write an original, small prescription with independently known power."""
+
+    def write(
+        *,
+        system="",
+        surface="",
+        second="",
+        image="",
+        footer="",
+        aperture="EBR 2",
+        distance="1e20",
+    ):
+        path = tmp_path / "edge.len"
+        path.write_text(
+            'LEN NEW "edge cases" 50 3\n'
+            f"{aperture}\nANG 0\n{system}\nTH {distance}\nNXT\n"
+            f"GLA 1.5\nRD 20\nTH 2\nAP 3\n{surface}\nNXT\n"
+            f"AIR\nRD -20\nTH 20\n{second}\nNXT\nAIR\n{image}\n"
+            f"END 3\n{footer}",
+            encoding="utf-8",
+        )
+        return path
+
+    return write
+
+
+@pytest.mark.parametrize(
+    "command,message",
+    [
+        ("WW 0 0 0", "weights cannot all be zero"),
+        ("TELE MAYBE", "TELE expects"),
+        ("APCK MAYBE", "APCK expects"),
+        ("AP -1", "radius must be nonnegative"),
+        ("APN -1", "APN count"),
+        ("APN 257", "APN count"),
+        ("AX1 A", "aperture identifier and value"),
+        ("AVX1 A 1 2", "aperture identifier and value"),
+        ("ATP A 1.5", "ATP requires an integer"),
+        ("AS1", "one coefficient"),
+        ("WV1002 .55", "bounded wavelength index"),
+        ("WV2 .55 .6", "one value"),
+        ("WV5 .55", "undefined wavelength slots"),
+        ("GTO -1", "outside the declared lens"),
+        ("GTO 4", "outside the declared lens"),
+        ("END 2", "count differs from LEN"),
+        ("PK AP 0 1", "invalid number of arguments"),
+        ("APK A 0", "APK expects"),
+    ],
+)
+def test_parser_rejects_invalid_boundaries_with_source(lens_file, command, message):
+    with pytest.raises(ValueError, match=message) as error:
+        OsloDataParser(lens_file(surface=command), strict=True).parse()
+    assert "edge.len:" in str(error.value)
+
+
+@pytest.mark.parametrize("count", [0, 10001])
+def test_surface_count_limit(tmp_path, count):
+    path = tmp_path / "count.len"
+    path.write_text(f'LEN NEW "invalid count" 1 {count}\n')
+    with pytest.raises(ValueError, match="LEN surface count"):
+        OsloDataParser(path).parse()
+
+
+def test_nxt_cannot_append_beyond_declared_image(lens_file):
+    with pytest.raises(ValueError, match="NXT exceeds LEN"):
+        OsloDataParser(lens_file(image="NXT")).parse()
+
+
+@pytest.mark.parametrize(
+    "record,message",
+    [
+        ("F 1 0 0", "ten field-table values"),
+        ("F 0 0 0 0 0 0 -1 1 -1 1 1", "positive index"),
+        ("F 1 0 0 0 0 0 -1 1 -1 1 -1", "nonnegative weight"),
+        ("F 1 0 0 0 0 0 1 -1 -1 1 1", "bounds must be increasing"),
+        ("F 1 0 0 0 0 0 -1 1 0 0 1", "bounds must be increasing"),
+    ],
+)
+def test_invalid_field_table(lens_file, record, message):
+    with pytest.raises(ValueError, match=message):
+        OsloDataParser(lens_file(footer=f"RST NEW\n{record}\nEND\n")).parse()
+
+
+def test_asymmetric_field_pupil_warns_and_retains_field(lens_file, set_test_backend):
+    path = lens_file(
+        system="OBH 4",
+        distance="100",
+        footer=("RST NEW\nF 1 -.5 .25 0 0 0 -.5 1 -1 1 2\nEND\n"),
+    )
+    with pytest.warns(UserWarning, match="asymmetric field pupil"):
+        optic = load_oslo_file(path)
+    assert_allclose([optic.fields[0].x, optic.fields[0].y], [1, -2])
+    assert_allclose([optic.fields[0].vx, optic.fields[0].vy], [0, 0])
+    assert optic.fields[0].weight == 2
+    with pytest.raises(ValueError, match="asymmetric field pupil"):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize(
+    "command,message",
+    [
+        ("LMO NSS", "non-sequential groups"),
+        ("ASP ZER 4", "asphere type ZER"),
+        ("PK UNSUPPORTED 0", "pickup type UNSUPPORTED"),
+        ("AAC A 1", "undeviated hole"),
+    ],
+)
+def test_unsupported_prescriptions_warn_or_reject(lens_file, command, message):
+    path = lens_file(surface=command)
+    with pytest.warns(UserWarning, match=message):
+        model = OsloDataParser(path).parse()
+    assert model.diagnostics[0].command == command.split()[0]
+    with pytest.raises(ValueError, match=message):
+        load_oslo_file(path, strict=True)
+    # A warned unsupported pickup must not be executed by the converter.
+    with pytest.warns(UserWarning, match=message):
+        optic = load_oslo_file(path)
+    assert_allclose(optic.surfaces[1].geometry.radius, 20)
+
+
+@pytest.mark.parametrize(
+    "command,message",
+    [
+        ("GLA 0", "positive refractive indices"),
+        ("GLA 1.5 1.6", "index/wavelength counts differ"),
+        ("GSP -1", "positive spacing"),
+        ("GOR 1", "positive spacing"),
+        ("ATP A 5", "aperture type 5"),
+        ("ATP A 1\nAX1 A 2\nAX2 A 1", "increasing bounds"),
+        ("ASP ASR 1\nAS257 .001", "limit 256"),
+        ("ASP ASR 1\nAS0 .001", "offset sag"),
+        ("ASP ARA 1\nAS0 .001", "offset sag"),
+        ("ASP ASX 1\nCVX .01", "even YZ asphere"),
+        ("GC 2", "preceding surface"),
+        ("RCO 2", "unavailable surface"),
+        ("TLA 10\nTLB 20\nBEN", "single-axis local mirror"),
+        ("DCY 1\nTH 1e20", "infinite thickness"),
+    ],
+)
+def test_converter_rejects_invalid_optical_data(lens_file, command, message):
+    with pytest.raises(ValueError, match=message):
+        load_oslo_file(lens_file(surface=command), strict=True)
+
+
+def test_coordinate_model_rejects_invalid_transform_order():
+    # Models can be supplied independently of the text parser.
+    with pytest.raises(ValueError, match="OSLO DT must be"):
+        surface_coordinates({0: {"TH": 100}, 1: {"DT": 0}}, 1)
+
+
+@pytest.mark.parametrize("radius", [0, 40])
+def test_rdx_maps_toric_x_radius(lens_file, set_test_backend, radius):
+    optic = load_oslo_file(lens_file(surface=f"RDX {radius}"), strict=True)
+    sag = optic.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0]))
+    expected = 0 if radius == 0 else 40 - math.sqrt(40**2 - 2**2)
+    assert_allclose(sag, [expected])
+
+
+def test_default_aperture_uses_lens_units(lens_file, set_test_backend):
+    optic = load_oslo_file(lens_file(aperture="", system="UNI 10"), strict=True)
+    assert optic.aperture.ap_type == "EPD"
+    assert_allclose(optic.aperture.value, 20)
+
+
+def test_image_na_rejects_afocal_system(lens_file):
+    with pytest.raises(ValueError, match="afocal system"):
+        load_oslo_file(
+            lens_file(system="NAP .1", surface="RD 0", second="RD 0"), strict=True
+        )
+
+
+@pytest.mark.parametrize("scale", [1, 10])
+def test_finite_gaussian_image_height_has_expected_magnification(
+    lens_file, set_test_backend, scale
+):
+    optic = load_oslo_file(
+        lens_file(system=f"UNI {scale}\nGIH 2", distance="100"), strict=True
+    )
+    # Unit-height marginal ray: u0=.01, u1=-.01, y2=.98, u2=-.0395.
+    # The Gaussian magnification is u0/u2=-20/79, hence |OBH|=7.9.
+    assert optic.fields.field_definition.__class__.__name__ == "ObjectHeightField"
+    assert_allclose(optic.fields[-1].y, 7.9 * scale)
+
+
+def test_model_glass_approximation_is_explicit(lens_file, set_test_backend):
+    path = lens_file(surface="GLA MOD 1.6 50")
+    with pytest.warns(UserWarning, match="Buchdahl model"):
+        optic = load_oslo_file(path)
+    material = optic.surfaces[1].material_post
+    assert isinstance(material, AbbeMaterial)
+    assert_allclose(material.n(0.5875618), 1.6, atol=1e-6)
+    with pytest.raises(ValueError, match="dispersion is approximate"):
+        load_oslo_file(path, strict=True)
+
+
+def test_prefixed_historical_glass_warns(lens_file, monkeypatch):
+    import optiland.fileio.oslo.reader.converter as converter
+
+    def missing_glass(name):
+        raise ValueError(name)
+
+    monkeypatch.setattr(converter, "Material", missing_glass)
+    path = lens_file(surface="GLA H_BAF13")
+    with pytest.warns(UserWarning, match="historical Abbe dispersion"):
+        optic = load_oslo_file(path)
+    assert isinstance(optic.surfaces[1].material_post, AbbeMaterial)
+    assert_allclose(optic.surfaces[1].material_post.n(0.5875618), 1.667, atol=1e-6)
+    with pytest.raises(ValueError, match="historical Abbe dispersion"):
+        load_oslo_file(path, strict=True)
+
+
+def test_perfect_lens_warns_and_scales_focal_length(lens_file, set_test_backend):
+    path = lens_file(system="UNI 10", surface="PFL 15")
+    with pytest.warns(UserWarning, match="paraxial thin lens"):
+        optic = load_oslo_file(path)
+    assert optic.surfaces[1].interaction_model.interaction_type == "thin_lens"
+    assert_allclose(optic.surfaces[1].interaction_model.f, 150)
+    with pytest.raises(ValueError, match="perfect imagery"):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize(
+    "pickup,message",
+    [
+        ("PK LN 1 1", "invalid length range"),
+        ("APK A 2 A", "preceding source"),
+        ("APK A 1 MISSING", "source aperture MISSING is undefined"),
+    ],
+)
+def test_invalid_pickup_references(lens_file, pickup, message):
+    with pytest.raises(ValueError, match=message):
+        load_oslo_file(lens_file(second=pickup), strict=True)
+
+
+@pytest.mark.parametrize(
+    "source,pickup,message",
+    [
+        ("RFL", "PK GLA 1", "cannot pick up a reflector"),
+        ("RCO", "PK TD 1", "global/return/bend"),
+        ("TLA 10\nBEN", "PK TDM 1", "global/return/bend"),
+    ],
+)
+def test_unsupported_pickup_sources(lens_file, source, pickup, message):
+    with pytest.raises(ValueError, match=message):
+        load_oslo_file(lens_file(surface=source, second=pickup), strict=True)
+
+
+def test_curvature_pickup_replaces_profile_without_mutating_source():
+    surfaces = {
+        0: {},
+        1: {"RD": 10, "CC": -1, "AD": 0.001},
+        2: {
+            "ASP": "ASR",
+            "AS1": 1,
+            "CVX": 2,
+            "AE": 3,
+            "pickups": [["CVM", "1", ".01"]],
+        },
+    }
+    original = deepcopy(surfaces)
+    resolved = resolve_pickups(surfaces)
+    assert surfaces == original
+    assert resolved[2]["RD"] == pytest.approx(-1 / 0.09)
+    assert resolved[2]["CC"] == -1
+    assert resolved[2]["AD"] == -0.001
+    assert not {"ASP", "AS1", "CVX", "AE"}.intersection(resolved[2])
+
+
+def test_model_pickup_rejects_unknown_type():
+    with pytest.raises(ValueError, match="PK UNSUPPORTED is unsupported"):
+        resolve_pickups({0: {}, 1: {"pickups": [["UNSUPPORTED", "0"]]}})
+
+
+@pytest.mark.parametrize(
+    "surface,image,message",
+    [
+        ("", "PY 1", "interior optical surface"),
+        ("EC -1", "", "nonnegative edge height"),
+        ("EC 21", "", "outside the surface's sag domain"),
+        ("AIR\nPY 1", "", "could not be reached"),
+    ],
+)
+def test_failed_solve_restores_saved_prescription(
+    lens_file, set_test_backend, surface, image, message
+):
+    path = lens_file(surface=surface, image=image)
+    model = OsloDataParser(path).parse()
+    original = model.to_dict()
+    with pytest.warns(UserWarning, match=message + ".*retained saved prescription"):
+        optic = OsloToOpticConverter(model).convert()
+    assert model.to_dict() == original
+    assert_allclose(optic.surfaces[1].thickness, 2)
+    assert_allclose(optic.surfaces[2].geometry.cs.z, 2)
+    assert_allclose(optic.surfaces[2].geometry.radius, -20)
+    with pytest.raises(ValueError, match=message):
+        OsloToOpticConverter(model, strict=True).convert()
+
+
+def test_failed_chief_slope_refinement_restores_curvature(
+    lens_file, set_test_backend, monkeypatch
+):
+    import optiland.fileio.oslo.reader.solves as solves
+
+    calls = []
+
+    def fail_refinement(residual, **kwargs):
+        calls.append(residual(0.2))  # Mimic a solver changing the optic before failure.
+        return SimpleNamespace(converged=False)
+
+    monkeypatch.setattr(solves, "root_scalar", fail_refinement)
+    path = lens_file(system="ANG 5", second="PUC .03")
+    with pytest.warns(UserWarning, match="refinement did not converge.*retained"):
+        optic = load_oslo_file(path)
+    assert len(calls) == 1
+    assert_allclose(optic.surfaces[2].geometry.radius, -20)
+
+
+@pytest.mark.parametrize("command,power", [("AS1 .001", 2), ("AS6 .001", 12)])
+def test_general_even_asphere_export_preserves_sag(
+    lens_file, tmp_path, set_test_backend, command, power
+):
+    optic = load_oslo_file(
+        lens_file(surface=f"RD 0\nASP ASR 1\n{command}"), strict=True
+    )
+    path = tmp_path / "general-asphere.len"
+    save_oslo_file(optic, path)
+    assert "ASP ASR" in path.read_text()
+    restored = load_oslo_file(path, strict=True)
+    assert_allclose(
+        restored.surfaces[1].geometry.sag(be.array([2.0]), be.array([0.0])),
+        [0.001 * 2**power],
+    )
+
+
+@pytest.mark.parametrize(
+    "field_type,y,message",
+    [
+        ("paraxial_image_height", 1, "field definition"),
+        ("real_image_height", 1, "field definition"),
+        ("angle", 90, "wide-angle field"),
+        ("angle", -91, "wide-angle field"),
+    ],
+)
+def test_unsupported_export_fields_preserve_destination(
+    lens_file, tmp_path, field_type, y, message
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.fields.set_type(field_type)
+    optic.fields.fields.clear()
+    optic.fields.add(y=y, x=0)
+    target = tmp_path / "existing.len"
+    target.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match=message):
+        save_oslo_file(optic, target)
+    assert target.read_text() == "saved design"
+
+
+def test_formatter_preserves_escaped_notes(lens_file):
+    model = OsloDataParser(lens_file()).parse()
+    note = 'A "quoted" note; // with a \\ path'
+    model.notes["SNO1"] = note
+    path = lens_file()
+    path.write_text(OsloDataFormatter(model).format(), encoding="utf-8")
+    assert OsloDataParser(path, strict=True).parse().notes["SNO1"] == note
+
+
+@pytest.mark.parametrize("value,expected", [(math.inf, 1e10), (-math.inf, -1e10)])
+def test_formatter_signed_infinity_sentinels(value, expected):
+    assert float(OsloDataFormatter(OsloDataModel())._fmt(value)) == expected
+
+
+@pytest.mark.parametrize(
+    "waves,indices,message",
+    [
+        ([], [], "at least two paired samples"),
+        ([0.5], [1.5], "at least two paired samples"),
+        ([0.5, 0.6], [1.5], "paired samples"),
+        ([0, 0.6], [1.5, 1.6], "finite and positive"),
+        ([0.5, 0.6], [-1, 1.6], "finite and positive"),
+        ([0.5, math.inf], [1.5, 1.6], "finite and positive"),
+        ([0.5, 0.6], [1.5, math.nan], "finite and positive"),
+    ],
+)
+def test_invalid_tabulated_material_samples(waves, indices, message):
+    with pytest.raises(ValueError, match=message):
+        TabulatedMaterial(waves, indices)
+
+
+def test_tabulated_material_is_nonabsorbing(set_test_backend):
+    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.5])
+    assert_allclose(material.k(0.5), 0)
+    assert_allclose(material.k(be.array([0.4, 0.6, 0.8])), [0, 0, 0])
+
+
+def test_rotated_drawing_aperture_roundtrip_scale_and_clipping(set_test_backend):
+    rotated = RotatedAperture(RectangularAperture(1, 3, -1, 1), math.pi / 2)
+    drawing = UnclippedAperture(rotated)
+    restored = BaseAperture.from_dict(drawing.to_dict())
+    restored.scale(2)
+    assert_allclose(restored.extent, [-2, 2, 2, 6])
+    assert_allclose(drawing.extent, [-1, 1, 1, 3])
+    x, y = be.array([0.0, 3.0]), be.array([4.0, 0.0])
+    assert_allclose(restored.contains(x, y), [True, False])
+    rays = RealRays(x, y, be.zeros(2), be.zeros(2), be.zeros(2), be.ones(2), 1, 0.55)
+    restored.clip(rays)
+    assert_allclose(rays.i, [1, 1])
+    restored.aperture.clip(rays)
+    assert_allclose(rays.i, [1, 0])

--- a/tests/test_fileio/test_oslo_edge_cases.py
+++ b/tests/test_fileio/test_oslo_edge_cases.py
@@ -18,7 +18,7 @@ from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.fileio.oslo.reader.pickups import resolve_pickups
 from optiland.fileio.oslo.writer.encoder import OpticToOsloEncoder
 from optiland.fileio.oslo.writer.formatter import OsloDataFormatter
-from optiland.materials import AbbeMaterial, TabulatedMaterial
+from optiland.materials import AbbeMaterial
 from optiland.physical_apertures import (
     BaseAperture,
     RectangularAperture,
@@ -374,29 +374,6 @@ def test_formatter_signed_infinity_sentinels(value, expected):
     assert float(OsloDataFormatter(OsloDataModel())._fmt(value)) == expected
 
 
-@pytest.mark.parametrize(
-    "waves,indices,message",
-    [
-        ([], [], "at least two paired samples"),
-        ([0.5], [1.5], "at least two paired samples"),
-        ([0.5, 0.6], [1.5], "paired samples"),
-        ([0, 0.6], [1.5, 1.6], "finite and positive"),
-        ([0.5, 0.6], [-1, 1.6], "finite and positive"),
-        ([0.5, math.inf], [1.5, 1.6], "finite and positive"),
-        ([0.5, 0.6], [1.5, math.nan], "finite and positive"),
-    ],
-)
-def test_invalid_tabulated_material_samples(waves, indices, message):
-    with pytest.raises(ValueError, match=message):
-        TabulatedMaterial(waves, indices)
-
-
-def test_tabulated_material_is_nonabsorbing(set_test_backend):
-    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.5])
-    assert_allclose(material.k(0.5), 0)
-    assert_allclose(material.k(be.array([0.4, 0.6, 0.8])), [0, 0, 0])
-
-
 def test_rotated_drawing_aperture_roundtrip_scale_and_clipping(set_test_backend):
     rotated = RotatedAperture(RectangularAperture(1, 3, -1, 1), math.pi / 2)
     drawing = UnclippedAperture(rotated)
@@ -510,7 +487,7 @@ def test_telecentric_export_preserves_chief_ray(lens_file, tmp_path, set_test_ba
     save_oslo_file(optic, target)
     restored = load_oslo_file(target, strict=True)
     assert restored.obj_space_telecentric
-    for actual, original in zip(restored.paraxial.chief_ray(), expected):
+    for actual, original in zip(restored.paraxial.chief_ray(), expected, strict=True):
         assert_allclose(actual, original)
 
 
@@ -751,14 +728,14 @@ def test_telecentric_entrance_beam_can_launch_real_rays(lens_file, set_test_back
     optic = load_oslo_file(
         lens_file(system="OBH 2\nTELE ON", distance="100"), strict=True
     )
-    x, y, z, l, m, n = ParaxialRayAimer(optic).aim_rays(
+    _, y, _, direction_x, direction_y, direction_z = ParaxialRayAimer(optic).aim_rays(
         (0, 1), optic.primary_wavelength, (be.zeros(2), be.array([0.0, 1.0]))
     )
     # The chief ray is parallel to z; the marginal ray advances 2 mm in y
     # across the 100 mm object distance. Both originate at the field point.
     assert_allclose(y, [2, 2])
-    assert_allclose(m / n, [0, 0.02])
-    assert_allclose(l, [0, 0])
+    assert_allclose(direction_y / direction_z, [0, 0.02])
+    assert_allclose(direction_x, [0, 0])
 
 
 def test_failed_solve_retains_telecentricity(lens_file, set_test_backend):

--- a/tests/test_fileio/test_oslo_fields.py
+++ b/tests/test_fileio/test_oslo_fields.py
@@ -7,7 +7,6 @@ import math
 import pytest
 
 from optiland.fileio import load_oslo_file
-from tests.test_fileio.test_oslo_edge_cases import lens_file
 
 
 @pytest.mark.parametrize("angle", [90, 100, -100])

--- a/tests/test_fileio/test_oslo_fields.py
+++ b/tests/test_fileio/test_oslo_fields.py
@@ -1,0 +1,52 @@
+"""Angular field tables must preserve the ray's direction and hemisphere."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.fileio import load_oslo_file
+from tests.test_fileio.test_oslo_edge_cases import lens_file
+
+
+@pytest.mark.parametrize("angle", [90, 100, -100])
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize("footer", ["", "RST NEW\nF 1 1 0 0 0 0 -1 1 -1 1 1"])
+def test_angular_reference_cannot_reach_or_cross_ninety_degrees(
+    lens_file, angle, strict, footer
+):
+    # tan(100 degrees) has the same value as tan(-80 degrees). Accepting it
+    # would silently put the full-field point in the opposite hemisphere.
+    with pytest.raises(ValueError, match="angular reference.*90"):
+        load_oslo_file(lens_file(system=f"ANG {angle}", footer=footer), strict=strict)
+
+
+@pytest.mark.parametrize("fraction", [-1, 0.5, 1, 2])
+def test_large_valid_field_table_preserves_direction_tangent(
+    lens_file, set_test_backend, fraction
+):
+    optic = load_oslo_file(
+        lens_file(
+            system="ANG 89",
+            footer=f"RST NEW\nF 1 {fraction} 0 0 0 0 -1 1 -1 1 1",
+        ),
+        strict=True,
+    )
+    field = optic.fields[0]
+    assert -90 < field.y < 90
+    assert math.tan(math.radians(field.y)) == pytest.approx(
+        fraction * math.tan(math.radians(89))
+    )
+
+
+def test_large_finite_object_height_is_not_an_angular_limit(lens_file):
+    optic = load_oslo_file(
+        lens_file(
+            distance="1000",
+            system="OBH 100",
+            footer="RST NEW\nF 1 1 0 0 0 0 -1 1 -1 1 1",
+        ),
+        strict=True,
+    )
+    assert optic.fields[0].y == 100

--- a/tests/test_fileio/test_oslo_focus.py
+++ b/tests/test_fileio/test_oslo_focus.py
@@ -10,7 +10,6 @@ import optiland.backend as be
 from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.rays import RealRays
-from tests.test_fileio.test_oslo_edge_cases import lens_file
 from tests.utils import assert_allclose
 
 

--- a/tests/test_fileio/test_oslo_focus.py
+++ b/tests/test_fileio/test_oslo_focus.py
@@ -1,0 +1,118 @@
+"""OSLO's image thickness is defocus added to the nominal image distance."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import optiland.backend as be
+from optiland.fileio import load_oslo_file, save_oslo_file
+from optiland.fileio.oslo.reader.parser import OsloDataParser
+from optiland.rays import RealRays
+from tests.test_fileio.test_oslo_edge_cases import lens_file
+from tests.utils import assert_allclose
+
+
+@pytest.mark.parametrize("shift", [-5, 5])
+@pytest.mark.parametrize("units", [1, 10])
+def test_image_defocus_moves_detector_and_ray_intercept(
+    lens_file, set_test_backend, shift, units
+):
+    optic = load_oslo_file(
+        lens_file(system=f"UNI {units}", image=f"TH {shift}"), strict=True
+    )
+    image = optic.surfaces[-1]
+    assert_allclose(image.geometry.cs.z, (22 + shift) * units)
+    assert_allclose(optic.surfaces[-2].thickness, (20 + shift) * units)
+    assert_allclose(image.thickness, 0)
+
+    # Propagate an independent ray through the final air gap. Its detector
+    # height must include the defocus term dy = shift * direction_y/direction_z.
+    zeros = be.zeros(1)
+    rays = RealRays(zeros, [1], [2 * units], zeros, [0.1], [math.sqrt(0.99)], 1, 0.55)
+    image.trace(rays)
+    assert_allclose(rays.y, [1 + (20 + shift) * units * 0.1 / math.sqrt(0.99)])
+
+
+def test_image_defocus_is_applied_after_nominal_focus_solve(
+    lens_file, set_test_backend
+):
+    optic = load_oslo_file(lens_file(second="PY 0", image="TH 5"), strict=True)
+    # Independent paraxial refractions for y1=2, n=1.5, R1=20, R2=-20:
+    # u1=-1/30; y2=29/15; u2=-59/600; nominal image gap=-y2/u2=1160/59.
+    # The saved image TH deliberately defocuses that PY=0 solution by 5 mm.
+    assert_allclose(optic.surfaces[-2].thickness, 1160 / 59 + 5)
+    assert_allclose(optic.paraxial.marginal_ray()[0][-1], -59 / 120)
+    assert_allclose(optic.surfaces[-1].thickness, 0)
+
+
+def test_image_focus_pickup_uses_the_solved_nominal_thickness(
+    lens_file, set_test_backend
+):
+    optic = load_oslo_file(lens_file(second="PY 0", image="PK TH 2 1"), strict=True)
+    # TH pickup adds a constant. The image shift is nominal TH2+1, so the
+    # physical final gap is TH2 + (TH2+1), with neither offset applied twice.
+    assert_allclose(optic.surfaces[-2].thickness, 2 * 1160 / 59 + 1)
+    assert_allclose(optic.surfaces[-1].thickness, 0)
+
+
+def test_defocus_follows_the_local_image_leg(lens_file, set_test_backend):
+    optic = load_oslo_file(lens_file(surface="TLA 30", image="TH 5"), strict=True)
+    position, _ = optic.surfaces[-1].geometry.cs.get_effective_transform()
+    # Intrinsic OSLO TLA rotates about -x: the following +z leg is
+    # (0, sin(30 degrees), cos(30 degrees)), over 2+20+5 lens units.
+    assert_allclose(position, [0, 27 / 2, 27 * math.sqrt(3) / 2])
+    assert_allclose(optic.surfaces[-2].thickness, 25)
+
+
+def test_image_global_reference_with_defocus_is_explicitly_rejected(lens_file):
+    # GC overrides the preceding distance. Mapping an independent focus shift
+    # onto that reference requires a separate verified coordinate convention.
+    with pytest.raises(ValueError, match="focus shift.*global reference"):
+        load_oslo_file(lens_file(image="GC 1\nDCZ 22\nTH 5"), strict=True)
+
+
+def test_image_focus_without_an_interior_surface_is_explicitly_rejected(tmp_path):
+    path = tmp_path / "no-interior.len"
+    path.write_text(
+        'LEN NEW "empty" 50 1\nEBR 2\nTH 1e20\nNXT\nTH 5\nEND 1',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="focus shift requires an interior surface"):
+        load_oslo_file(path, strict=True)
+
+
+def test_finite_entrance_beam_stays_fixed_when_the_image_stop_moves(
+    lens_file, set_test_backend
+):
+    optic = load_oslo_file(lens_file(distance="100", image="AST\nTH 5"), strict=True)
+    # EBR specifies the radius at surface 1. Moving an image-plane stop moves
+    # its entrance pupil; the equivalent native EPD must be recalculated.
+    assert_allclose(abs(optic.paraxial.marginal_ray()[0][1]), 2)
+
+
+def test_defocus_survives_export_without_being_applied_twice(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(image="TH 5"), strict=True)
+    output = tmp_path / "defocused.len"
+    save_oslo_file(optic, output)
+    model = OsloDataParser(output).parse()
+    assert model.surfaces[2]["TH"] == 25
+    assert model.surfaces[3]["TH"] == 0
+    restored = load_oslo_file(output, strict=True)
+    assert_allclose(restored.surfaces[-1].geometry.cs.z, 27)
+
+
+def test_native_unused_image_thickness_does_not_become_oslo_defocus(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[-1].thickness = 5
+    # Native thickness advances the next surface, so this final value does not
+    # move the existing detector. OSLO would instead move it if TH 5 were saved.
+    output = tmp_path / "native-image-thickness.len"
+    save_oslo_file(optic, output)
+    assert OsloDataParser(output).parse().surfaces[3]["TH"] == 0
+    assert_allclose(load_oslo_file(output, strict=True).surfaces[-1].geometry.cs.z, 22)

--- a/tests/test_fileio/test_oslo_positions.py
+++ b/tests/test_fileio/test_oslo_positions.py
@@ -1,0 +1,102 @@
+"""Export the physical axial prescription, including absolute-coordinate lenses."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.fileio import load_oslo_file, save_oslo_file
+from optiland.materials import IdealMaterial
+from optiland.optic import Optic
+from optiland.rays import RealRays
+from tests.utils import assert_allclose
+
+
+def trace_axial_bundle(optic):
+    """Launch identical rays relative to the first physical surface."""
+    first_z = float(optic.surfaces[1].geometry.cs.z.item())
+    rays = RealRays([0, 0], [0, 1], [first_z - 1] * 2, [0, 0], [0, 0], [1, 1], 1, 0.55)
+    optic.surfaces.trace(rays, skip=1)
+    return rays
+
+
+@pytest.mark.parametrize("origin", [0, 13])
+@pytest.mark.parametrize("distance", [100, -100, math.inf, -math.inf])
+def test_absolute_axial_positions_survive_export(
+    tmp_path, set_test_backend, origin, distance
+):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=origin - distance)
+    optic.surfaces.add(
+        index=1, z=origin, radius=20, material=IdealMaterial(1.5), is_stop=True
+    )
+    optic.surfaces.add(index=2, z=origin + 5, radius=-20)
+    optic.surfaces.add(index=3, z=origin + 25)
+    optic.set_aperture("EPD", 4)
+    optic.fields.set_type("angle" if math.isinf(distance) else "object_height")
+    optic.fields.add(y=0)
+    optic.wavelengths.add(0.55, is_primary=True)
+    before = trace_axial_bundle(optic)
+
+    output = tmp_path / "absolute-coordinates.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    after = trace_axial_bundle(restored)
+
+    # OSLO anchors the first surface at zero; the physical gaps and ray
+    # intersections must be unchanged by removing a common axial translation.
+    assert_allclose(restored.surfaces.global_z_positions.ravel(), [-distance, 0, 5, 25])
+    assert_allclose([s.thickness for s in restored.surfaces], [distance, 5, 20, 0])
+    for component in ("x", "y", "L", "M", "N", "i", "opd"):
+        assert_allclose(
+            getattr(after, component), getattr(before, component), atol=1e-10
+        )
+    assert_allclose(after.z, before.z - origin)
+    assert all(s.thickness == 0 for s in optic.surfaces)
+
+
+def test_export_uses_detector_pose_after_direct_coordinate_edit(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    image_cs = optic.surfaces[-1].geometry.cs
+    image_cs.z = image_cs.z + 7
+    before = trace_axial_bundle(optic)
+    output = tmp_path / "moved-detector.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    after = trace_axial_bundle(restored)
+    assert_allclose(restored.surfaces[-1].geometry.cs.z, 29)
+    assert_allclose(restored.surfaces[-2].thickness, 27)
+    assert_allclose(after.y, before.y)
+    assert_allclose(after.opd, before.opd)
+
+
+@pytest.mark.parametrize("gap", [9.9e9, -9.9e9])
+def test_export_rejects_finite_interior_spacing_at_oslo_infinity_cutoff(
+    lens_file, tmp_path, set_test_backend, gap
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.updater.set_thickness(gap, 2)
+    with pytest.raises(NotImplementedError, match="finite.*spacing"):
+        save_oslo_file(optic, tmp_path / "finite-gap.len")
+
+
+def test_finite_interior_spacing_below_cutoff_stays_finite(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    gap = 9.9e9 - 1
+    optic.updater.set_thickness(gap, 2)
+    output = tmp_path / "finite-gap.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    assert float(restored.surfaces[2].thickness) == gap
+
+
+def test_export_rejects_undefined_axial_spacing(lens_file, tmp_path, set_test_backend):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[-1].geometry.cs.z = math.nan
+    with pytest.raises(ValueError, match="defined axial surface spacings"):
+        save_oslo_file(optic, tmp_path / "undefined-gap.len")

--- a/tests/test_fileio/test_oslo_precision.py
+++ b/tests/test_fileio/test_oslo_precision.py
@@ -1,0 +1,72 @@
+"""Export must not round valid optical data across physical boundaries."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.fileio import load_oslo_file, save_oslo_file
+from optiland.materials import TabulatedMaterial
+
+
+def test_export_preserves_an_angular_reference_just_below_ninety(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.fields.fields.clear()
+    optic.fields.add(y=89.999999)
+    optic.fields.add(y=1)
+    output = tmp_path / "near-right-angle.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    assert restored.fields[0].y == optic.fields[0].y
+    assert math.tan(math.radians(restored.fields[1].y)) == pytest.approx(
+        math.tan(math.radians(1)), rel=1e-12
+    )
+
+
+@pytest.mark.parametrize("medium,index", [("AIR", 1.0), ("GLA 1.5", 1.5)])
+def test_export_preserves_na_below_the_object_medium_index(
+    lens_file, tmp_path, set_test_backend, medium, index
+):
+    optic = load_oslo_file(lens_file(distance="100", system=medium), strict=True)
+    value = index - 1e-8
+    optic.set_aperture("objectNA", value)
+    output = tmp_path / "near-hemisphere.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    assert restored.aperture.value == value
+
+
+def test_export_preserves_distinct_sampled_wavelengths(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    wavelengths = [0.50000000000001, 0.50000000000002]
+    while optic.wavelengths:
+        optic.wavelengths.remove(0)
+    for index, wavelength in enumerate(wavelengths):
+        optic.wavelengths.add(wavelength, is_primary=index == 0)
+    optic.surfaces[1].material_post = TabulatedMaterial(wavelengths, [1.5, 1.500001])
+    output = tmp_path / "nearby-wavelengths.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    assert [wave.value for wave in restored.wavelengths] == wavelengths
+    assert restored.surfaces[1].material_post.wavelengths == wavelengths
+
+
+def test_export_retains_small_sampled_dispersion_and_its_optical_path(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(system="WV .5 .6"), strict=True)
+    indices = [1.0000000000001, 1.0000000000002]
+    optic.surfaces[1].material_post = TabulatedMaterial([0.5, 0.6], indices)
+    output = tmp_path / "small-dispersion.len"
+    save_oslo_file(optic, output)
+    restored = load_oslo_file(output, strict=True)
+    material = restored.surfaces[1].material_post
+    # The index difference is small but nonzero: collapsing both samples to
+    # unity removes dispersion and their optical-path excess over vacuum.
+    for wavelength, index in zip([0.5, 0.6], indices, strict=True):
+        assert float(material.n(wavelength).item()) == index

--- a/tests/test_fileio/test_oslo_reader.py
+++ b/tests/test_fileio/test_oslo_reader.py
@@ -29,10 +29,10 @@ class TestOsloDataParser:
         assert parser.data_model.scaling == 1.0
         assert parser.data_model.num_surfaces == 5
 
-    def test_read_ebr(self):
-        parser = OsloDataParser("dummy")
-        parser._read_ebr(["EBR", "5.0"])
-        assert parser.data_model.aperture["EPD"] == 10.0
+    def test_read_ebr(self, tmp_path):
+        path = tmp_path / "aperture.len"
+        path.write_text('LEN NEW "test" 1 1\nEBR 5\nNXT\nEND 1\n', encoding="utf-8")
+        assert OsloDataParser(path).parse().aperture["EPD"] == 10.0
 
     def test_read_rd(self):
         parser = OsloDataParser("dummy")
@@ -40,10 +40,12 @@ class TestOsloDataParser:
         assert parser._current_surf_data["RD"] == 50.0
 
     # ISSUE-P1: DES command stored in notes (quotes are stripped by implementation)
-    def test_issue_p1_des_stored_in_notes(self):
-        parser = OsloDataParser("dummy")
-        parser._read_des(["DES", '"OpticDesigner"'])
-        assert parser.data_model.notes["DES"] == "OpticDesigner"
+    def test_issue_p1_des_stored_in_notes(self, tmp_path):
+        path = tmp_path / "designer.len"
+        path.write_text(
+            'LEN NEW "test" 1 1\nDES "OpticDesigner"\nNXT\nEND 1\n', encoding="utf-8"
+        )
+        assert OsloDataParser(path).parse().notes["DES"] == "OpticDesigner"
 
     def test_issue_p1_des_in_dispatch_table(self):
         parser = OsloDataParser("dummy")
@@ -118,9 +120,7 @@ class TestGlassFallback:
             nd = float(mat.n(0.58756).item())
             # None of the glass surfaces (1, 2, 4) should resolve to n=1.0 (air)
             if i in (1, 2, 4):
-                assert nd > 1.1, (
-                    f"Surface {i} glass silently became air (n={nd:.4f})"
-                )
+                assert nd > 1.1, f"Surface {i} glass silently became air (n={nd:.4f})"
 
 
 if __name__ == "__main__":

--- a/tests/test_fileio/test_oslo_roundtrip.py
+++ b/tests/test_fileio/test_oslo_roundtrip.py
@@ -32,7 +32,7 @@ def test_oslo_roundtrip_fno(tmp_path):
 def test_oslo_roundtrip_nao(tmp_path):
     # Setup optic with objectNA
     optic = Optic(name="NAO_Test")
-    optic.add_surface(index=0, radius=be.inf, thickness=be.inf)
+    optic.add_surface(index=0, radius=be.inf, thickness=100)
     optic.add_surface(index=1, radius=10.0, thickness=5.0, material="N-BK7", is_stop=True)
     optic.add_surface(index=2, radius=-10.0, thickness=20.0)
     optic.add_surface(index=3)
@@ -49,5 +49,5 @@ def test_oslo_roundtrip_nao(tmp_path):
     assert reloaded_optic.aperture.ap_type == "objectNA"
     assert np.isclose(reloaded_optic.aperture.value, 0.1)
     
-    # Verify infinity
-    assert be.isinf(reloaded_optic.surfaces[0].thickness)
+    # Object NA describes a cone from a finite object.
+    assert np.isclose(reloaded_optic.surfaces[0].thickness, 100)

--- a/tests/test_fileio/test_oslo_roundtrip.py
+++ b/tests/test_fileio/test_oslo_roundtrip.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import numpy as np
-import pytest
+
 import optiland.backend as be
 from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.optic import Optic
@@ -9,22 +11,24 @@ def test_oslo_roundtrip_fno(tmp_path):
     # Setup optic with imageFNO
     optic = Optic(name="FNO_Test")
     optic.add_surface(index=0, radius=be.inf, thickness=be.inf)
-    optic.add_surface(index=1, radius=10.0, thickness=5.0, material="N-BK7", is_stop=True)
+    optic.add_surface(
+        index=1, radius=10.0, thickness=5.0, material="N-BK7", is_stop=True
+    )
     optic.add_surface(index=2, radius=-10.0, thickness=20.0)
     optic.add_surface(index=3)
     optic.set_aperture(aperture_type="imageFNO", value=8.0)
-    
+
     # Save to OSLO
     oslo_file = tmp_path / "fno_test.len"
     save_oslo_file(optic, str(oslo_file))
-    
+
     # Reload from OSLO
     reloaded_optic = load_oslo_file(str(oslo_file))
-    
+
     # Verify aperture
     assert reloaded_optic.aperture.ap_type == "imageFNO"
     assert np.isclose(reloaded_optic.aperture.value, 8.0)
-    
+
     # Verify infinity
     assert be.isinf(reloaded_optic.surfaces[0].thickness)
 
@@ -33,21 +37,23 @@ def test_oslo_roundtrip_nao(tmp_path):
     # Setup optic with objectNA
     optic = Optic(name="NAO_Test")
     optic.add_surface(index=0, radius=be.inf, thickness=100)
-    optic.add_surface(index=1, radius=10.0, thickness=5.0, material="N-BK7", is_stop=True)
+    optic.add_surface(
+        index=1, radius=10.0, thickness=5.0, material="N-BK7", is_stop=True
+    )
     optic.add_surface(index=2, radius=-10.0, thickness=20.0)
     optic.add_surface(index=3)
     optic.set_aperture(aperture_type="objectNA", value=0.1)
-    
+
     # Save to OSLO
     oslo_file = tmp_path / "nao_test.len"
     save_oslo_file(optic, str(oslo_file))
-    
+
     # Reload from OSLO
     reloaded_optic = load_oslo_file(str(oslo_file))
-    
+
     # Verify aperture
     assert reloaded_optic.aperture.ap_type == "objectNA"
     assert np.isclose(reloaded_optic.aperture.value, 0.1)
-    
+
     # Object NA describes a cone from a finite object.
     assert np.isclose(reloaded_optic.surfaces[0].thickness, 100)

--- a/tests/test_fileio/test_oslo_solves.py
+++ b/tests/test_fileio/test_oslo_solves.py
@@ -6,6 +6,7 @@ import math
 
 import pytest
 
+import optiland.backend as be
 from optiland.fileio import load_oslo_file
 from tests.utils import assert_allclose
 
@@ -71,3 +72,31 @@ def test_common_surface_frame_preserves_physical_edge_contact(
         )
     assert_allclose(optic.surfaces[1].thickness, 2 * sag, atol=1e-10)
     assert_allclose(edge_points[0], edge_points[1], atol=1e-10)
+
+
+@pytest.mark.parametrize("origin", [0, 100])
+@pytest.mark.parametrize("gap", [0, 0.001])
+def test_edge_contact_distinguishes_single_precision_roundoff_from_separation(
+    lens_file, set_test_backend, origin, gap
+):
+    # These radii and edge height come from the official dblgauss2.len demo.
+    # Its valid EC solve exposed float32 cancellation in the positioned check.
+    is_torch = be.get_backend() == "torch"
+    if is_torch:
+        be.set_precision("float32")
+    try:
+        path = lens_file(
+            surface=f"RD 46.2463056440498\nDCZ {origin}\nEC 23",
+            second=f"RD 766.6798051599121\nDCZ {gap}",
+        )
+        if gap:
+            with pytest.raises(ValueError, match="EC at surface 1"):
+                load_oslo_file(path, strict=True)
+        else:
+            optic = load_oslo_file(path, strict=True)
+            sag1 = 46.2463056440498 - math.sqrt(46.2463056440498**2 - 23**2)
+            sag2 = 766.6798051599121 - math.sqrt(766.6798051599121**2 - 23**2)
+            assert_allclose(optic.surfaces[1].thickness, sag1 - sag2, atol=2e-6)
+    finally:
+        if is_torch:
+            be.set_precision("float64")

--- a/tests/test_fileio/test_oslo_solves.py
+++ b/tests/test_fileio/test_oslo_solves.py
@@ -1,0 +1,73 @@
+"""Validate OSLO edge-contact solves against the positioned physical surfaces."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.fileio import load_oslo_file
+from tests.utils import assert_allclose
+
+
+@pytest.mark.parametrize(
+    "surface,second",
+    [
+        ("", "DCX 1"),
+        ("", "DCY 1"),
+        ("", "DCZ 3"),
+        ("", "TLA 10"),
+        ("", "GC 1"),
+        ("DCY 1\nRCO", ""),
+    ],
+)
+def test_edge_contact_must_survive_relative_coordinate_transforms(
+    lens_file, set_test_backend, surface, second
+):
+    baseline = load_oslo_file(lens_file(surface=surface, second=second), strict=True)
+    path = lens_file(surface=surface + "\nEC 2", second=second)
+    with pytest.warns(
+        UserWarning, match="EC at surface 1.*retained saved prescription"
+    ):
+        optic = load_oslo_file(path)
+    assert optic.to_dict() == baseline.to_dict()
+    with pytest.raises(ValueError, match="EC at surface 1"):
+        load_oslo_file(path, strict=True)
+
+
+@pytest.mark.parametrize("tilt", [0, 30])
+@pytest.mark.parametrize("units", [1, 10])
+@pytest.mark.parametrize("second", ["", "TLC 90"])
+def test_common_surface_frame_preserves_physical_edge_contact(
+    lens_file, set_test_backend, tilt, units, second
+):
+    optic = load_oslo_file(
+        lens_file(
+            system=f"UNI {units}",
+            surface=f"DCX 1\nDCY 2\nDCZ 3\nTLA {tilt}\nEC 2",
+            second=second,
+        ),
+        strict=True,
+    )
+    # Two spheres of radii +/-20 meet at local height 2 when their
+    # vertex separation is twice the positive spherical sag. A common
+    # rigid transform must carry the two contact points to the same place.
+    # Rolling either sphere around its own axis leaves its shape unchanged.
+    sag = (20 - math.sqrt(20**2 - 2**2)) * units
+    angle = math.radians(-tilt)  # OSLO tilts around -x.
+    edge_points = []
+    for index, local_sag in [(1, sag), (2, -sag)]:
+        cs = optic.surfaces[index].geometry.cs
+        edge_points.append(
+            [
+                float(cs.x.item()),
+                float(cs.y.item())
+                + 2 * units * math.cos(angle)
+                - local_sag * math.sin(angle),
+                float(cs.z.item())
+                + 2 * units * math.sin(angle)
+                + local_sag * math.cos(angle),
+            ]
+        )
+    assert_allclose(optic.surfaces[1].thickness, 2 * sag, atol=1e-10)
+    assert_allclose(edge_points[0], edge_points[1], atol=1e-10)

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -15,7 +15,6 @@ from optiland.geometries import EvenAsphere, OddAsphere, StandardGeometry
 from optiland.interactions import RefractiveReflectiveModel
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.rays import RealRays
-from tests.test_fileio.test_oslo_edge_cases import lens_file
 from tests.utils import assert_allclose
 
 

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -12,7 +12,7 @@ from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.geometries import EvenAsphere, OddAsphere, StandardGeometry
-from optiland.interactions import RefractiveReflectiveModel
+from optiland.interactions import RefractiveReflectiveModel, ThinLensInteractionModel
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.rays import RealRays
 from tests.utils import assert_allclose
@@ -165,5 +165,25 @@ def test_export_checks_geometry_instead_of_trusting_the_surface_label(
     output = tmp_path / "mismatched-geometry.len"
     output.write_text("saved design", encoding="utf-8")
     with pytest.raises(NotImplementedError, match="geometry"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"
+
+
+@pytest.mark.parametrize("surface_type", ["standard", "paraxial"])
+def test_thin_lens_export_does_not_silently_claim_perfect_imaging(
+    lens_file, tmp_path, set_test_backend, surface_type
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    surface = optic.surfaces[1]
+    surface.interaction_model = ThinLensInteractionModel(
+        surface, is_reflective=False, focal_length=20
+    )
+    surface.surface_type = surface_type
+    output = tmp_path / "thin-lens.len"
+    output.write_text("saved design", encoding="utf-8")
+    # OSLO PFL is an exact perfect-imaging model, not the same off-axis
+    # interaction as the native thin-lens phase. Import already diagnoses this
+    # approximation; export must not silently describe it as equivalent either.
+    with pytest.raises(NotImplementedError, match="thin-lens.*perfect-imaging"):
         save_oslo_file(optic, output)
     assert output.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -1,0 +1,86 @@
+"""OSLO boundary cases preserve destinations and reject undefined ray launches."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.aperture import EPDAperture
+from optiland.fileio import load_oslo_file, save_oslo_file
+from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
+from optiland.fileio.oslo.reader.parser import OsloDataParser
+from tests.test_fileio.test_oslo_edge_cases import lens_file
+
+
+def test_export_without_system_aperture_omits_aperture_command(lens_file, tmp_path):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.aperture = None
+    output = tmp_path / "no-aperture.len"
+    save_oslo_file(optic, output)
+    assert OsloDataParser(output).parse().aperture == {}
+
+
+def test_export_rejects_custom_system_aperture_before_overwriting(lens_file, tmp_path):
+    class CustomAperture(EPDAperture):
+        @property
+        def ap_type(self):
+            return "custom"
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.aperture = CustomAperture(4)
+    output = tmp_path / "custom-aperture.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="system aperture"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"
+
+
+@pytest.mark.parametrize("diameter", [0, -1, math.inf, math.nan])
+def test_export_rejects_invalid_entrance_beam_without_overwriting(
+    lens_file, tmp_path, set_test_backend, diameter
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.set_aperture("EPD", diameter)
+    output = tmp_path / "invalid-beam.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="finite positive entrance beam"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"
+
+
+@pytest.mark.parametrize(
+    "aperture_type,distance",
+    [("EPD", "1e20"), ("float_by_stop_size", "1e20"), ("imageFNO", "100")],
+)
+def test_export_preserves_aperture_calculation_error_and_destination(
+    lens_file, tmp_path, set_test_backend, aperture_type, distance
+):
+    optic = load_oslo_file(lens_file(distance=distance), strict=True)
+    optic.set_aperture(aperture_type, 4)
+    while optic.wavelengths:
+        optic.wavelengths.remove(0)
+    output = tmp_path / "missing-spectrum.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="No primary wavelength"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"
+
+
+def test_model_conversion_rejects_empty_modeled_glass(lens_file):
+    # OsloToOpticConverter also accepts models constructed outside the parser.
+    model = OsloDataParser(lens_file()).parse()
+    model.surfaces[1]["material"] = "GLA MOD"
+    with pytest.raises(ValueError, match="GLA MOD requires refractive-index data"):
+        OsloToOpticConverter(model, strict=True).convert()
+
+
+def test_finite_object_on_first_surface_cannot_define_nonzero_beam(
+    lens_file, set_test_backend
+):
+    # An axial point at surface 1 has zero height there, even with a later stop.
+    # No finite cone from this point can have the requested EBR=2 at surface 1.
+    with pytest.raises(ValueError, match="finite nonzero beam at surface 1"):
+        load_oslo_file(
+            lens_file(distance="0", surface="AIR\nRD 0", second="AST"), strict=True
+        )

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -6,11 +6,15 @@ import math
 
 import pytest
 
+import optiland.backend as be
 from optiland.aperture import EPDAperture
 from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
 from optiland.fileio.oslo.reader.parser import OsloDataParser
+from optiland.interactions import RefractiveReflectiveModel
+from optiland.rays import RealRays
 from tests.test_fileio.test_oslo_edge_cases import lens_file
+from tests.utils import assert_allclose
 
 
 def test_export_without_system_aperture_omits_aperture_command(lens_file, tmp_path):
@@ -84,3 +88,28 @@ def test_finite_object_on_first_surface_cannot_define_nonzero_beam(
         load_oslo_file(
             lens_file(distance="0", surface="AIR\nRD 0", second="AST"), strict=True
         )
+
+
+def test_export_cannot_discard_custom_ray_interactions(
+    lens_file, tmp_path, set_test_backend
+):
+    class AttenuatingInteraction(RefractiveReflectiveModel):
+        def interact_real_rays(self, rays):
+            rays = super().interact_real_rays(rays)
+            rays.i *= 0.25
+            return rays
+
+    optic = load_oslo_file(lens_file(), strict=True)
+    surface = optic.surfaces[1]
+    surface.interaction_model = AttenuatingInteraction(surface, is_reflective=False)
+    zeros = be.zeros(1)
+    rays = RealRays(zeros, zeros, zeros, zeros, zeros, be.ones(1), 1, 0.55)
+    surface.interaction_model.interact_real_rays(rays)
+    # This model inherits the standard interaction_type string, but changes
+    # transmitted power. Exporting only its GLA record would lose that physics.
+    assert_allclose(rays.i, [0.25])
+    output = tmp_path / "custom-interaction.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="interaction model"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -11,6 +11,7 @@ from optiland.aperture import EPDAperture
 from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
 from optiland.fileio.oslo.reader.parser import OsloDataParser
+from optiland.geometries import EvenAsphere, OddAsphere, StandardGeometry
 from optiland.interactions import RefractiveReflectiveModel
 from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.rays import RealRays
@@ -144,3 +145,26 @@ def test_export_cannot_turn_a_zero_radius_clip_into_an_open_aperture(
     # aperture really blocks off-axis rays, so the writer must reject the loss.
     with pytest.raises(ValueError, match="finite positive surface aperture radius"):
         save_oslo_file(optic, tmp_path / "zero-radius.len")
+
+
+@pytest.mark.parametrize(
+    "geometry_type,surface_type,sag_excess",
+    [(EvenAsphere, "standard", 0.04), (OddAsphere, "even_asphere", 0.02)],
+)
+def test_export_checks_geometry_instead_of_trusting_the_surface_label(
+    lens_file, tmp_path, set_test_backend, geometry_type, surface_type, sag_excess
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    surface = optic.surfaces[1]
+    base = StandardGeometry(surface.geometry.cs, 20)
+    surface.geometry = geometry_type(surface.geometry.cs, 20, coefficients=[0.01])
+    surface.surface_type = surface_type
+    x, y = be.zeros(1), be.array([2.0])
+    assert_allclose(surface.geometry.sag(x, y) - base.sag(x, y), [sag_excess])
+    # A mutable surface label cannot establish the sag equation. The standard
+    # handler would drop this term; the even handler would change its power.
+    output = tmp_path / "mismatched-geometry.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(NotImplementedError, match="geometry"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"

--- a/tests/test_fileio/test_oslo_validation.py
+++ b/tests/test_fileio/test_oslo_validation.py
@@ -12,6 +12,7 @@ from optiland.fileio import load_oslo_file, save_oslo_file
 from optiland.fileio.oslo.reader.converter import OsloToOpticConverter
 from optiland.fileio.oslo.reader.parser import OsloDataParser
 from optiland.interactions import RefractiveReflectiveModel
+from optiland.physical_apertures import RadialAperture, UnclippedAperture
 from optiland.rays import RealRays
 from tests.test_fileio.test_oslo_edge_cases import lens_file
 from tests.utils import assert_allclose
@@ -113,3 +114,33 @@ def test_export_cannot_discard_custom_ray_interactions(
     with pytest.raises(NotImplementedError, match="interaction model"):
         save_oslo_file(optic, output)
     assert output.read_text() == "saved design"
+
+
+@pytest.mark.parametrize("radius", [0, -1, math.inf, math.nan])
+@pytest.mark.parametrize("checked", [True, False])
+def test_export_rejects_unrepresentable_surface_radius_without_overwriting(
+    lens_file, tmp_path, radius, checked
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    aperture = RadialAperture(radius)
+    optic.surfaces[1].aperture = aperture if checked else UnclippedAperture(aperture)
+    output = tmp_path / "invalid-surface-radius.len"
+    output.write_text("saved design", encoding="utf-8")
+    with pytest.raises(ValueError, match="finite positive surface aperture radius"):
+        save_oslo_file(optic, output)
+    assert output.read_text() == "saved design"
+
+
+def test_export_cannot_turn_a_zero_radius_clip_into_an_open_aperture(
+    lens_file, tmp_path, set_test_backend
+):
+    optic = load_oslo_file(lens_file(), strict=True)
+    optic.surfaces[1].aperture = RadialAperture(0)
+    zeros = be.zeros(2)
+    rays = RealRays(zeros, [0, 1], zeros, zeros, zeros, be.ones(2), [1, 1], 0.55)
+    optic.surfaces[1].aperture.clip(rays)
+    assert_allclose(rays.i, [1, 0])
+    # AP CHK 0 has no explicit radius in the importer. A native zero-radius
+    # aperture really blocks off-axis rays, so the writer must reject the loss.
+    with pytest.raises(ValueError, match="finite positive surface aperture radius"):
+        save_oslo_file(optic, tmp_path / "zero-radius.len")

--- a/tests/test_fileio/test_oslo_writer.py
+++ b/tests/test_fileio/test_oslo_writer.py
@@ -27,7 +27,7 @@ def _make_simple_optic(name: str = "Test", fields: list[float] | None = None) ->
     optic.wavelengths.add(0.55)
     for y in (fields if fields is not None else [0.0, 14.0, 20.0]):
         optic.fields.add(y=y, x=0.0)
-    optic.surfaces.add(index=0, radius=0, thickness=1e10)
+    optic.surfaces.add(index=0, radius=0, thickness=be.inf)
     optic.surfaces.add(index=1, radius=100.0, thickness=5.0, material="N-BK7", is_stop=True)
     optic.surfaces.add(index=2, radius=-100.0, thickness=50.0)
     optic.surfaces.add(index=3)
@@ -170,7 +170,7 @@ class TestOsloWriter:
         optic.wavelengths.add(0.55)
         optic.fields.add(y=0)
 
-        optic.surfaces.add(index=0, radius=0, thickness=1e10)
+        optic.surfaces.add(index=0, radius=0, thickness=be.inf)
         optic.surfaces.add(index=1, radius=100.0, thickness=5.0, material="N-BK7", is_stop=True)
         optic.surfaces.add(index=2, radius=-100.0, thickness=50.0)
         optic.surfaces.add(index=3)

--- a/tests/test_tabulated_material.py
+++ b/tests/test_tabulated_material.py
@@ -1,0 +1,77 @@
+"""Validation, interpolation and numerical limits of sampled optical materials."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import optiland.backend as be
+from optiland.materials import BaseMaterial, TabulatedMaterial
+from tests.utils import assert_allclose
+
+
+@pytest.mark.parametrize(
+    "waves,indices,message",
+    [
+        ([], [], "at least two paired samples"),
+        ([0.5], [1.5], "at least two paired samples"),
+        ([0.5, 0.6], [1.5], "paired samples"),
+        ([0, 0.6], [1.5, 1.6], "finite and positive"),
+        ([0.5, 0.6], [-1, 1.6], "finite and positive"),
+        ([0.5, math.inf], [1.5, 1.6], "finite and positive"),
+        ([0.5, 0.6], [1.5, math.nan], "finite and positive"),
+        ([0.5, 0.5], [1.5, 1.6], "distinct"),
+    ],
+)
+def test_invalid_samples(waves, indices, message):
+    with pytest.raises(ValueError, match=message):
+        TabulatedMaterial(waves, indices)
+
+
+def test_interpolation_and_serialization(set_test_backend):
+    material = TabulatedMaterial([0.6, 0.4, 0.8], [1.5, 1.6, 1.4], name="example")
+    assert_allclose(
+        material.n(be.array([0.4, 0.5, 0.6, 0.7, 0.8])), [1.6, 1.55, 1.5, 1.45, 1.4]
+    )
+    assert_allclose(BaseMaterial.from_dict(material.to_dict()).n(0.5), 1.55)
+    with pytest.raises(ValueError, match="range"):
+        material.n(0.9)
+
+
+def test_nonabsorbing_samples(set_test_backend):
+    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.5])
+    assert_allclose(material.k(0.5), 0)
+    assert_allclose(material.k(be.array([0.4, 0.6, 0.8])), [0, 0, 0])
+
+
+def test_nonfinite_query(set_test_backend):
+    material = TabulatedMaterial([0.4, 0.8], [1.6, 1.4])
+    with pytest.raises(ValueError, match="finite"):
+        material.n(math.nan)
+
+
+@pytest.mark.parametrize("array_query", [False, True])
+def test_samples_must_remain_distinct_in_the_active_precision(
+    set_test_backend, array_query
+):
+    is_torch = be.get_backend() == "torch"
+    if is_torch:
+        be.set_precision("float32")
+    try:
+        waves = [0.50000000000001, 0.50000000000002]
+        material = TabulatedMaterial(waves, [1.5, 1.6])
+        query = be.array(waves) if array_query else waves[0]
+        if is_torch:
+            # Both wavelengths round to 0.5 in float32. Interpolating across
+            # this zero-width interval used to silently return NaN indices.
+            with pytest.raises(ValueError, match="distinct.*backend precision"):
+                material.n(query)
+        else:
+            assert_allclose(material.n(query), [1.5, 1.6] if array_query else [1.5])
+
+        ordinary = TabulatedMaterial([0.5, 0.7], [1.6, 1.5])
+        assert_allclose(ordinary.n(be.array([0.5, 0.6, 0.7])), [1.6, 1.55, 1.5])
+    finally:
+        if is_torch:
+            be.set_precision("float64")


### PR DESCRIPTION
> **Superseded by [PR #800: Validate OSLO sequential import and loss-aware export](https://github.com/optiland/optiland/pull/800).**
>
> Closing this combined draft in favor of focused PRs following the maintainer discussion below. #800 delivers the standalone I/O portion first. Native materials, physical apertures, polarization, glass catalogs and GUI support will follow separately, with each dependent import/export mapping kept alongside its required native functionality.
>
> The original draft description below is retained as historical context; current scope and validation are documented in #800.

---

OSLO imports previously discarded unrecognized optical commands, ignored lens units, misaligned asphere powers and reduced every PY solve to final-image autofocus. This expands sequential `.len` import with documented command mappings, source-located diagnostics and an opt-in `strict=True` mode that rejects unsupported commands and known approximations.

The implementation covers units and indexed spectra; sampled glass indices; conic, general asphere and toroidal geometry; checked and special apertures; OSLO coordinate conventions and local mirror bends; static pickups; targeted paraxial/edge-contact solves; explicit field tables; image-space setup; and ruled gratings. Small reusable additions are `TabulatedMaterial`, `RotatedAperture` and `UnclippedAperture`. Coupled writer fixes preserve supported spectra, fields and aperture flags and reject unsupported exports before opening the output file.

The [support matrix](https://github.com/BrunoChevalier/optiland/blob/codex/oslo-import-support/docs/oslo_import.rst) links primary Lambda Research manuals and describes deferred features. This remains a sequential snapshot importer: exact OSLO perfect imagery, general GRIN/non-sequential execution, user surfaces, advanced field aiming and multi-configuration execution are outside this change.

Validation:

- Test-driven increments, followed by two separate review-and-fix rounds. The reviews added failing regressions for constraint propagation, malformed input, serialization and export loss before fixing them.
- **757 passed, 1 skipped**, covering all file-I/O tests, physical apertures, materials, native solves and golden snapshots. OSLO coverage increases from 26 to 187 cases, including independent sag, ray, aperture and coordinate assertions on NumPy and Torch.
- Full `ruff check optiland` and `ruff format --check optiland` pass (523 source files); the audit script passes Ruff. Sphinx is unavailable locally, so the documentation site was not rebuilt.
- The offline `scripts/audit_oslo_examples.py` records hashes and per-file outcomes for the separately downloaded official 101-lens demo ZIP. Both backends import all 101 permissively (5 clean, 96 warned); 10 pass strict import. On-axis smoke checks transmit finite rays in 80 files, none in 20, and fail in 1 because of an existing unsupported finite object-height/off-axis-entry combination. These checks do not certify agreement with OSLO ray intercepts. The proprietary archive is not vendored.

The work is split into 14 focused commits with detailed mapping rationale, limitations and validation in their messages.

