### PR TITLE
fix: JOSS review issues #766, #767, #769, #770

### DIFF
--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -160,9 +160,9 @@ New to these concepts? See the :ref:`glossary` first.
 
 .. code-block:: python
 
-   from optiland.wavefront import Wavefront, ZernikeOPD
+   from optiland.wavefront import OPD, ZernikeOPD
 
-   wf = Wavefront(lens, field=(0, 0), wavelength="primary")
+   wf = OPD(lens, field=(0, 0), wavelength="primary")
    wf.view()
 
    zfit = ZernikeOPD(lens, field=(0, 0), wavelength="primary", num_terms=37)

--- a/docs/gallery/wavefront/fft_vectorial_psf_2d.ipynb
+++ b/docs/gallery/wavefront/fft_vectorial_psf_2d.ipynb
@@ -12,6 +12,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": "**Method:** For each ray, Optiland propagates the incident polarization state through the ray's 3x3 polarization ray-trace (PRT) matrix to obtain the exit-pupil electric field, expressed in Cartesian (Ex, Ey, Ez) components. Each component is treated as an independent scalar pupil (same OPD-derived phase, different amplitude), 2D-FFT'd separately, and the resulting intensities are summed incoherently: |FFT(Ex)|² + |FFT(Ey)|² + |FFT(Ez)|². For unpolarized light, this sum also includes two orthogonal, incoherently superimposed input states. This is the discrete Fourier-optics analogue of the vectorial Debye-Wolf diffraction integral.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {

--- a/docs/gallery/wavefront/huygens_psf_2d.ipynb
+++ b/docs/gallery/wavefront/huygens_psf_2d.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Huygens PSF - 2D"
-   ]
+   "source": "# Huygens PSF - 2D\n\n**Method:** a direct Huygens-Fresnel summation — each pupil sample contributes a spherical wavelet `exp(ikR)/R` (phased by its OPD) to every image point, weighted by an obliquity factor `0.5*(1+cos θ)`."
   },
   {
    "cell_type": "code",

--- a/docs/gallery/wavefront/vectorial_huygens_psf_2d.ipynb
+++ b/docs/gallery/wavefront/vectorial_huygens_psf_2d.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Vectorial Huygens PSF - 2D\n\nThis example demonstrates how to use the `VectorialHuygensPSF` class, obtained via the `HuygensPSF` factory, to calculate the 2D PSF of an optical system.\n\n**Note:** Vectorial PSF calculations are automatically performed when polarization is enabled in the optical system. This accounts for the vectorial nature of the electric field at the exit pupil."
+   "source": "# Vectorial Huygens PSF - 2D\n\nThis example demonstrates how to use the `VectorialHuygensPSF` class, obtained via the `HuygensPSF` factory, to calculate the 2D PSF of an optical system.\n\n**Note:** Vectorial PSF calculations are automatically performed when polarization is enabled in the optical system. This accounts for the vectorial nature of the electric field at the exit pupil.\n\n**Method:** same spherical-wavelet Huygens-Fresnel summation as the scalar PSF, applied independently to each Cartesian component (Ex, Ey, Ez) of the exit-pupil field (from the ray-wise polarization ray-trace matrix). The resulting per-component intensities are summed incoherently, plus over both incoherent input states for unpolarized light."
   },
   {
    "cell_type": "code",

--- a/optiland/optic/optic.py
+++ b/optiland/optic/optic.py
@@ -625,6 +625,7 @@ class Optic:
         reference: ReferenceRay | None = None,
         projection: Literal["XY", "XZ", "YZ"] = "YZ",
         ax: Axes | None = None,
+        show: bool = True,
     ) -> tuple[Figure, Axes]:
         """Draw a 2D representation of the optical system.
 
@@ -656,6 +657,9 @@ class Optic:
                 plane. Defaults to "YZ".
             ax (matplotlib.axes.Axes, optional): The axes to plot on.
                 If None, a new figure and axes are created. Defaults to None.
+            show (bool, optional): If True (default), calls plt.show(). Set
+                False for headless use (e.g. saving to file, CI environments)
+                or when embedding in an existing figure via ``ax``.
 
         Returns:
             tuple[Figure, Axes]: A tuple containing the matplotlib Figure and
@@ -679,6 +683,7 @@ class Optic:
             reference=reference,
             projection=projection,
             ax=ax,
+            show=show,
         )
         return fig, ax
 

--- a/optiland/visualization/system/optic_viewer.py
+++ b/optiland/visualization/system/optic_viewer.py
@@ -63,6 +63,7 @@ class OpticViewer(BaseViewer2D):
         projection="YZ",
         ax=None,
         theme=None,
+        show=True,
     ):
         """Visualizes the optical system.
 
@@ -89,6 +90,9 @@ class OpticViewer(BaseViewer2D):
                 'XZ', or 'YZ'. Defaults to 'YZ'.
             ax (matplotlib.axes.Axes, optional): The axes to plot on.
                 If None, a new figure and axes are created. Defaults to None.
+            show (bool, optional): If True (default), calls plt.show(). Set
+                False for headless use (e.g. saving to file, CI environments)
+                or when embedding in an existing figure via ``ax``.
 
         """
         if projection not in ["XY", "XZ", "YZ"]:
@@ -102,6 +106,7 @@ class OpticViewer(BaseViewer2D):
             else:
                 distribution = "line_y"
 
+        is_gui_embedding = ax is not None
         theme = self._resolve_theme(theme)
         fig, ax = self._make_figure(theme, figsize, ax)
 
@@ -134,6 +139,11 @@ class OpticViewer(BaseViewer2D):
             ylim = ylim or auto_ylim
 
         self._apply_axes_style(ax, projection, theme, title=title, xlim=xlim, ylim=ylim)
+
+        if show and not is_gui_embedding:
+            import matplotlib.pyplot as plt
+
+            plt.show()
 
         # Return the figure, axes and interaction_manager
         return fig, ax, interaction_manager

--- a/tests/visualization/system/test_lens_overlap.py
+++ b/tests/visualization/system/test_lens_overlap.py
@@ -72,7 +72,7 @@ def test_valid_biconvex_lens_does_not_warn(set_test_backend):
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic.draw()
+        fig, ax = optic.draw(show=False)
         plt.close(fig)
 
 
@@ -92,7 +92,7 @@ def test_valid_meniscus_lens_does_not_warn(set_test_backend):
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic.draw()
+        fig, ax = optic.draw(show=False)
         plt.close(fig)
 
 
@@ -108,7 +108,7 @@ def test_plano_concave_lens_overlap_and_valid(set_test_backend):
     optic_valid = _create_singlet(r1=be.inf, r2=-50.0, thickness=1.5, epd=20.0)
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic_valid.draw()
+        fig, ax = optic_valid.draw(show=False)
         plt.close(fig)
 
 
@@ -124,7 +124,7 @@ def test_convex_plano_lens_overlap_and_valid(set_test_backend):
     optic_valid = _create_singlet(r1=50.0, r2=be.inf, thickness=1.5, epd=20.0)
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic_valid.draw()
+        fig, ax = optic_valid.draw(show=False)
         plt.close(fig)
 
 
@@ -150,7 +150,7 @@ def test_aspheric_lens_overlap_and_valid(set_test_backend):
     )
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic_valid.draw()
+        fig, ax = optic_valid.draw(show=False)
         plt.close(fig)
 
 
@@ -213,7 +213,7 @@ def test_surfaces_overlap_zero_extent(set_test_backend):
     optic_valid = _create_singlet(r1=50.0, r2=-50.0, thickness=2.0, epd=0.0)
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
-        fig, ax = optic_valid.draw()
+        fig, ax = optic_valid.draw(show=False)
         plt.close(fig)
 
     # Overlapping lens with epd=0 and thickness <= 0


### PR DESCRIPTION
Fixes #766, #767, #769, #770.

- `Optic.draw()` / `OpticViewer.view()` now accept `show: bool = True` and call
  `plt.show()` when not embedding into an existing `ax`, matching the convention
  already used by every `BaseAnalysis.view()` in the codebase. (#766)
- Cheat sheet step 12 instantiated `Wavefront(...).view()`, but `Wavefront` has no
  `view()` method -- only its `OPD`/`ZernikeOPD` subclasses do. (#767)
- Added a concise, code-verified methodology note to the FFT Vectorial PSF, Huygens
  PSF, and Vectorial Huygens PSF gallery notebooks, describing the polarization
  ray-trace (PRT) + FFT/Huygens-summation approach used under the hood. (#769, #770)

Also updated `tests/visualization/system/test_lens_overlap.py` to pass `show=False`
where tests assert no `UserWarning` is raised -- otherwise the new `plt.show()` call
trips matplotlib's "non-interactive backend" warning under the Agg backend used in CI.