### PR TITLE
Exclude test files from coverage reports at every directory depth

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,7 +26,7 @@ coverage:
         base: auto
 
 ignore:
-  - "tests/*"  # Ignore test files
+  - "tests/**/*"  # Ignore test files at every directory depth
   - "optiland/database/generate_csv_database.py"
   - "optiland_gui/*"  # Ignore GUI files
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 omit =
-    tests/gui/*
+    tests/**
     optiland_gui/*


### PR DESCRIPTION
Nested test files currently contribute to coverage results despite the intended `tests/*` Codecov exclusion. For example, the [report for #786 at d2b4be4](https://app.codecov.io/gh/optiland/optiland/pull/786/blob/tests/test_fileio/test_oslo_edge_cases.py) flags three uncalled methods on test doubles as uncovered code, although the tests correctly verify that export rejects those custom types before invoking the methods.

Use `tests/**/*` in `.codecov.yml` to exclude test files at every directory depth, following [Codecov's documented matching rules](https://docs.codecov.com/docs/ignoring-paths). Also omit `tests/**` in `.coveragerc` so coverage.py excludes test code during collection and produces consistent local and uploaded XML reports. The collection change is optional for Codecov's processing fix, but prevents test scaffolding from contributing to the raw coverage totals as well.

This PR is limited to the two coverage configuration files. Coverage thresholds and the existing CI upload workflow remain unchanged.

Validation:

- On this branch, `pytest tests/test_wavelength.py tests/test_fileio/test_oslo_reader.py -q --cov --cov-report=xml --cov-report=json`: **62 passed**, covering top-level and nested test modules.
- Checked both generated reports: no `tests/` paths are present, and measured application code such as `optiland/wavelength.py` remains included.
- Verified the diff against current upstream `master` contains only `.codecov.yml` and `.coveragerc`; `git diff --check` passes.
