### PR TITLE
fix: make cached ray launches field- and autograd-safe

### DIFF
--- a/optiland/rays/ray_aiming/cached.py
+++ b/optiland/rays/ray_aiming/cached.py
@@ -1,8 +1,8 @@
 """Cached Ray Aiming Module
 
 This module implements a caching wrapper for ray aiming algorithms.
-It stores previous results to speed up repetitive calculations, especially
-during optimization or tolerance analysis where system changes might be small.
+It stores previous results to speed up repetitive calculations when the inputs
+and optical system remain unchanged.
 
 Retained for backward compatibility (explicit ``cache=True``) but no longer
 the default warm-start mechanism for ``"robust"``, which has its own
@@ -18,6 +18,7 @@ import hashlib
 import pickle
 from typing import TYPE_CHECKING, Any
 
+import optiland.backend as be
 from optiland.rays.ray_aiming.base import BaseRayAimer
 
 if TYPE_CHECKING:
@@ -29,16 +30,22 @@ class CachedRayAimer(BaseRayAimer):
 
     This class wraps another ray aimer and caches its results. It checks
     if the inputs and the optical system state have changed. If they match
-    a cached entry, the result is returned immediately. If the system has
-    changed but inputs match, the previous result is used as a starting guess.
+    a cached entry in the same numerical execution context, the result is
+    returned immediately. Otherwise, the wrapped aimer computes a fresh result
+    without an automatic initial guess. Explicit caller guesses bypass caching.
 
     Coordinate-frame note: cached entries are full launch states in global
     coordinates. The system hash covers every surface, so any rigid pose
-    change (translation, fold reorientation) misses the exact-reuse path
-    and the stale state is only ever passed as an ``initial_guess`` to the
-    wrapped aimer, which re-solves (and, for the robust aimer, falls back
-    to a fresh entry-frame calibration if the stale guess fails). A stale
-    global-coordinate state can therefore cost time but never correctness.
+    change (translation, fold reorientation) misses the exact-reuse path.
+    After a system change, a cached launch is not used as a starting guess:
+    its fixed field-dependent components may no longer represent the requested
+    field, even if the ray still satisfies the stop constraint.
+
+    Torch calls clear and bypass this cache whenever either backend gradient
+    tracking or ambient autograd is enabled, so computation graphs are never
+    reused. Backend, precision, device, and Torch inference-mode changes also
+    clear numerical entries.
+    The wrapped robust aimer's detached pupil-map seed cache is independent.
 
     Attributes:
         optic (Optic): The optical system being traced.
@@ -65,6 +72,7 @@ class CachedRayAimer(BaseRayAimer):
         self.wrapped_aimer = wrapped_aimer
         self.max_cache_size = max_cache_size
         self._cache: dict[str, tuple[str, tuple]] = {}
+        self._cache_context: tuple[str, int, str | None, bool] | None = None
 
     def aim_rays(
         self,
@@ -84,11 +92,44 @@ class CachedRayAimer(BaseRayAimer):
         Returns:
             tuple: Ray parameters (x, y, z, L, M, N).
         """
+        # Invalidate before any early return, including explicit caller guesses,
+        # so a bypass cannot leave incompatible entries for subsequent calls.
+        backend = be.get_backend()
+        bypass_cache = False
+        if backend == "torch":
+            import torch
+
+            # Either Optiland's gradient control or ambient Torch autograd can
+            # require a fresh graph. Equal numerical values do not identify
+            # its lifetime or the parameter leaves to which it is attached.
+            bypass_cache = be.grad_mode.requires_grad or torch.is_grad_enabled()
+
+        if bypass_cache:
+            # Discard earlier entries too, so returning to numerical execution
+            # starts a new cache rather than reviving pre-gradient results.
+            self.clear_cache()
+        else:
+            # Results must match the active backend, precision and device.
+            # Inference mode also differs from no_grad: inference tensors cannot
+            # be mutated outside inference mode or saved for backward.
+            context = (
+                backend,
+                be.get_precision(),
+                be.get_device() if backend == "torch" else None,
+                torch.is_inference_mode_enabled() if backend == "torch" else False,
+            )
+            if context != self._cache_context:
+                self.clear_cache()
+                self._cache_context = context
+
         # If an explicit initial guess is provided, we skip the cache check
         if initial_guess is not None:
             return self.wrapped_aimer.aim_rays(
-                fields, wavelengths, pupil_coords, initial_guess
+                fields, wavelengths, pupil_coords, initial_guess=initial_guess
             )
+        if bypass_cache:
+            # Do not hash, read or store results in a differentiable call.
+            return self.wrapped_aimer.aim_rays(fields, wavelengths, pupil_coords)
 
         # 1. Generate Input Hash
         input_key = self._get_input_hash(fields, wavelengths, pupil_coords)
@@ -98,21 +139,19 @@ class CachedRayAimer(BaseRayAimer):
 
         # 3. Check Cache
         cached_entry = self._cache.get(input_key)
-
-        guess = None
-        if cached_entry:
+        if cached_entry is not None:
             cached_sys_hash, cached_result = cached_entry
             if cached_sys_hash == current_sys_hash:
                 # Exact match: inputs same, system same
                 return cached_result
-            else:
-                # System changed, but inputs same. Use cached result as guess.
-                guess = cached_result
 
         # 4. Delegate to wrapped aimer
-        result = self.wrapped_aimer.aim_rays(
-            fields, wavelengths, pupil_coords, initial_guess=guess
-        )
+        # A full launch fixes the object point for finite conjugates or the
+        # incident direction for infinite conjugates. The old launch can still
+        # satisfy the stop constraint after a field edit, so do not use it as
+        # an automatic initial guess. Omitting the keyword also supports aimers
+        # whose public interface accepts only the three required arguments.
+        result = self.wrapped_aimer.aim_rays(fields, wavelengths, pupil_coords)
 
         # 5. Update Cache
         self._cache[input_key] = (current_sys_hash, result)
@@ -157,4 +196,7 @@ class CachedRayAimer(BaseRayAimer):
             self.optic.aperture.to_dict() if self.optic.aperture else None,
             self.optic.ray_tracer.ray_aiming_config,
         )
-        return hashlib.md5(str(data).encode("utf-8")).hexdigest()
+        # Array and tensor display formatting rounds values, so str(data) can
+        # hide small field or aperture changes and produce a stale exact hit.
+        # Serialize the numeric contents instead; no pickle payload is loaded.
+        return hashlib.md5(pickle.dumps(data)).hexdigest()

--- a/tests/test_cached_aimer.py
+++ b/tests/test_cached_aimer.py
@@ -1,13 +1,43 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import optiland.backend as be
 from optiland.optic import Optic
 from optiland.rays.ray_aiming.base import BaseRayAimer
 from optiland.rays.ray_aiming.cached import CachedRayAimer
 from optiland.rays.ray_aiming.robust import RobustRayAimer
+
+from .utils import assert_allclose
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def numerical_backend(set_test_backend: None) -> Iterator[None]:
+    """Disable both Torch gradient controls locally for numerical cache tests."""
+    backend = be.get_backend()
+    precision = be.get_precision()
+    with ExitStack() as stack:
+        if backend == "torch":
+            import torch
+
+            grad_mode = be.grad_mode
+            requires_grad = grad_mode.requires_grad
+            stack.callback(setattr, grad_mode, "requires_grad", requires_grad)
+            grad_mode.disable()
+            stack.enter_context(torch.no_grad())
+        try:
+            be.set_precision("float64")
+            yield
+        finally:
+            be.set_backend(backend)
+            be.set_precision(f"float{precision}")
 
 
 @pytest.fixture
@@ -37,7 +67,7 @@ def mock_dependencies():
     return optic, wrapped_aimer
 
 
-def test_cache_miss_calls_wrapped(set_test_backend, mock_dependencies):
+def test_cache_miss_calls_wrapped(numerical_backend, mock_dependencies):
     """Test that the wrapped aimer is called on a cache miss."""
     optic, wrapped_aimer = mock_dependencies
     cached_aimer = CachedRayAimer(optic, wrapped_aimer)
@@ -49,15 +79,24 @@ def test_cache_miss_calls_wrapped(set_test_backend, mock_dependencies):
     result = cached_aimer.aim_rays(*inputs)
 
     assert result == expected_result
-    wrapped_aimer.aim_rays.assert_called_once()
+    wrapped_aimer.aim_rays.assert_called_once_with(*inputs)
 
 
-def test_cache_hit_skips_wrapped(set_test_backend, mock_dependencies):
+@pytest.mark.parametrize("array_inputs", [False, True])
+def test_cache_hit_skips_wrapped(
+    numerical_backend, mock_dependencies, array_inputs: bool
+) -> None:
     """Test that the wrapped aimer is NOT called on a cache hit."""
     optic, wrapped_aimer = mock_dependencies
     cached_aimer = CachedRayAimer(optic, wrapped_aimer)
 
     inputs = ((0.0,), 0.55, (0.0, 0.0))
+    if array_inputs:
+        inputs = (
+            (be.array([0.0]), be.array([1.0])),
+            be.array([0.55]),
+            (be.array([0.0]), be.array([0.0])),
+        )
     expected_result = (1, 2, 3, 4, 5, 6)
     wrapped_aimer.aim_rays.return_value = expected_result
 
@@ -72,8 +111,8 @@ def test_cache_hit_skips_wrapped(set_test_backend, mock_dependencies):
     wrapped_aimer.aim_rays.assert_not_called()
 
 
-def test_system_change_uses_cached_as_guess(set_test_backend, mock_dependencies):
-    """Test that a system change uses the cached result as a starting guess."""
+def test_system_change_delegates_fresh(numerical_backend, mock_dependencies):
+    """A system change must not reuse fixed components of an old launch."""
     optic, wrapped_aimer = mock_dependencies
     cached_aimer = CachedRayAimer(optic, wrapped_aimer)
 
@@ -94,18 +133,15 @@ def test_system_change_uses_cached_as_guess(set_test_backend, mock_dependencies)
     final_result = cached_aimer.aim_rays(*inputs)
 
     assert final_result == result2
-    # Check that wrapped aimer was called with initial_guess=result1
-    wrapped_aimer.aim_rays.assert_called_with(
-        inputs[0], inputs[1], inputs[2], initial_guess=result1
-    )
+    assert wrapped_aimer.aim_rays.call_count == 2
+    wrapped_aimer.aim_rays.assert_called_with(*inputs)
+    wrapped_aimer.aim_rays.reset_mock()
+    assert cached_aimer.aim_rays(*inputs) is result2
+    wrapped_aimer.aim_rays.assert_not_called()
 
 
-def test_robust_aimer_integration_with_cache(set_test_backend, request):
-    """Regression test for RobustRayAimer integration with caching.
-
-    Ensures that RobustRayAimer accepts initial_guess passed by CachedRayAimer.
-    """
-    import optiland.backend as be
+def test_robust_aimer_integration_with_cache(numerical_backend, request):
+    """System changes recalibrate; only caller guesses use the direct solve."""
     from optiland.aperture import FloatByStopAperture
     from optiland.rays.ray_aiming.pupil_map import PupilMapCache
 
@@ -128,6 +164,7 @@ def test_robust_aimer_integration_with_cache(set_test_backend, request):
     optic.surfaces = surface_group_mock
     optic.fields = MagicMock()
     optic.fields.to_dict.return_value = {}
+    optic.fields.get_vig_factor.return_value = (0.0, 0.0)
     optic.wavelengths = MagicMock()
     optic.wavelengths.to_dict.return_value = {}
     optic.aperture = MagicMock(spec=FloatByStopAperture)
@@ -200,8 +237,6 @@ def test_robust_aimer_integration_with_cache(set_test_backend, request):
 
     # The launch parameterization is built from the optic's entry frame,
     # which the MagicMock optic cannot provide; supply the canonical +z one.
-    from unittest.mock import patch
-
     from optiland.rays.ray_aiming.parameterization import LaunchParameterization
 
     legacy_param = LaunchParameterization(
@@ -215,8 +250,7 @@ def test_robust_aimer_integration_with_cache(set_test_backend, request):
     patcher.start()
     request.addfinalizer(patcher.stop)
 
-    # 1. First call (Cache Miss)
-    # This will call robust_aimer -> _solve -> iterative.aim_rays
+    # A cache miss runs robust calibration and the iterative core polish.
     res1 = cached_aimer.aim_rays(fields, wl, pupil)
 
     # Expectation: robust aimer uses iterative aimer result
@@ -230,34 +264,286 @@ def test_robust_aimer_integration_with_cache(set_test_backend, request):
     # 2. Perturb System
     optic.surfaces.to_dict.return_value = {"surfaces": ["changed"]}
 
-    # 3. Second call (System Change -> Pass cached result as initial_guess)
-    # This calls robust_aimer.aim_rays(..., initial_guess=expected_first_result)
-    # robust_aimer should call _iterative.aim_rays(...,
-    # initial_guess=expected_first_result)
-
-    # We update iterative mock return value to distinguish second call result
-    iterative_mock.aim_rays.return_value = (9, 9, 9, 8, 8, 8)
-
+    # A stale full launch must not select robust's direct initial-guess path.
+    iterative_mock._solve_core.reset_mock()
     res2 = cached_aimer.aim_rays(fields, wl, pupil)
+    assert to_floats(res2) == expected_first_result
+    assert iterative_mock._solve_core.called
+    iterative_mock.aim_rays.assert_not_called()
 
-    # Confirm result matches new iterative return value
-    assert res2 == (9, 9, 9, 8, 8, 8)
+    iterative_mock.aim_rays.return_value = (9, 9, 9, 8, 8, 8)
+    res3 = cached_aimer.aim_rays(fields, wl, pupil, initial_guess=res1)
+    assert res3 == (9, 9, 9, 8, 8, 8)
+    iterative_mock.aim_rays.assert_called_once_with(
+        fields, wl, pupil, initial_guess=res1
+    )
 
-    # Verify _iterative.aim_rays was called with initial_guess
-    # It might be called multiple times (first run, second run).
-    # We want to check the *last* call or ensure one of them had the kwarg.
 
-    # Get all calls
-    calls = iterative_mock.aim_rays.call_args_list
-    # Search for the call with initial_guess
-    found_guess = False
-    for c in calls:
-        if "initial_guess" in c.kwargs:
-            guess = c.kwargs["initial_guess"]
-            if to_floats(guess) == expected_first_result:
-                found_guess = True
-                break
-    assert found_guess, "Initial guess was not passed to iterative aimer on second call"
+def test_explicit_guess_bypasses_hashing_and_preserves_cache(
+    numerical_backend: None, mock_dependencies: tuple[Optic, MagicMock]
+) -> None:
+    optic, wrapped = mock_dependencies
+    aimer = CachedRayAimer(optic, wrapped)
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    wrapped.aim_rays.return_value = (1, 2, 3, 4, 5, 6)
+    numerical = aimer.aim_rays(*inputs)
+    guess = (6, 5, 4, 3, 2, 1)
+    with (
+        patch.object(aimer, "_get_input_hash", side_effect=AssertionError),
+        patch.object(aimer, "_get_system_hash", side_effect=AssertionError),
+    ):
+        aimer.aim_rays(*inputs, initial_guess=guess)
+    wrapped.aim_rays.assert_called_with(*inputs, initial_guess=guess)
+    wrapped.aim_rays.reset_mock()
+    assert aimer.aim_rays(*inputs) is numerical
+    wrapped.aim_rays.assert_not_called()
+
+
+class _NumericalAimer(BaseRayAimer):
+    """A three-argument public API with no initial-guess extension."""
+
+    def aim_rays(
+        self, fields: tuple, wavelengths: Any, pupil_coords: tuple
+    ) -> tuple:
+        return tuple(be.array([float(i)]) for i in range(6))
+
+
+def test_numerical_context_invalidates_all_entries(
+    numerical_backend: None, mock_dependencies: tuple[Optic, MagicMock]
+) -> None:
+    optic, _ = mock_dependencies
+    aimer = CachedRayAimer(optic, _NumericalAimer(optic))
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    other = ((0.0, 0.5), 0.55, (0.0, 0.0))
+    be.set_precision("float64")
+    original = aimer.aim_rays(*inputs)
+    aimer.aim_rays(*other)
+    assert len(aimer._cache) == 2
+    assert aimer.aim_rays(*inputs) is original
+
+    be.set_precision("float32")
+    changed = aimer.aim_rays(*inputs)
+    assert len(aimer._cache) == 1
+    assert changed is not original
+    assert changed[0].dtype == be.array([0.0]).dtype
+    assert changed[0].dtype != original[0].dtype
+    assert aimer.aim_rays(*inputs) is changed
+
+    be.set_precision("float64")
+    restored = aimer.aim_rays(*inputs)
+    assert restored is not original
+    assert restored is not changed
+    assert restored[0].dtype == original[0].dtype
+
+
+def test_backend_context_invalidates_before_explicit_guess(
+    numerical_backend: None, mock_dependencies: tuple[Optic, MagicMock]
+) -> None:
+    if be.get_backend() != "torch":
+        pytest.skip("Requires Torch and NumPy in one cache instance")
+    optic, wrapped = mock_dependencies
+    wrapped.aim_rays.side_effect = _NumericalAimer(optic).aim_rays
+    aimer = CachedRayAimer(optic, wrapped)
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    original = aimer.aim_rays(*inputs)
+
+    be.set_backend("numpy")
+    wrapped.aim_rays.side_effect = None
+    wrapped.aim_rays.return_value = (0, 0, 0, 0, 0, 1)
+    aimer.aim_rays(*inputs, initial_guess=original)
+    assert not aimer._cache
+    wrapped.aim_rays.assert_called_with(*inputs, initial_guess=original)
+    wrapped.aim_rays.side_effect = _NumericalAimer(optic).aim_rays
+    changed = aimer.aim_rays(*inputs)
+    assert type(changed[0]) is not type(original[0])
+    assert aimer.aim_rays(*inputs) is changed
+
+    be.set_backend("torch")
+    restored = aimer.aim_rays(*inputs)
+    assert type(restored[0]) is type(original[0])
+    assert restored is not original
+    assert len(aimer._cache) == 1
+
+
+def test_device_context_invalidates_cache(
+    numerical_backend: None, mock_dependencies: tuple[Optic, MagicMock]
+) -> None:
+    if be.get_backend() != "torch":
+        pytest.skip("Device context applies only to Torch")
+    optic, wrapped = mock_dependencies
+    aimer = CachedRayAimer(optic, wrapped)
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    aimer.aim_rays(*inputs)
+    wrapped.aim_rays.reset_mock()
+    # Exercise the device token on CPU-only machines without allocating on CUDA.
+    with patch.object(be, "get_device", return_value="cuda"):
+        aimer.aim_rays(*inputs)
+        wrapped.aim_rays.assert_called_once_with(*inputs)
+        aimer.aim_rays(*inputs)
+        wrapped.aim_rays.assert_called_once()
+    aimer.aim_rays(*inputs)
+    assert wrapped.aim_rays.call_count == 2
+
+
+@pytest.mark.parametrize("inference_first", [False, True])
+def test_inference_context_invalidates_cache(
+    numerical_backend: None,
+    mock_dependencies: tuple[Optic, MagicMock],
+    inference_first: bool,
+) -> None:
+    if be.get_backend() != "torch":
+        pytest.skip("Inference mode applies only to Torch")
+    import torch
+
+    optic, _ = mock_dependencies
+    aimer = CachedRayAimer(optic, _NumericalAimer(optic))
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    other = ((0.0, 0.5), 0.55, (0.0, 0.0))
+    with torch.inference_mode(inference_first), torch.no_grad():
+        original = aimer.aim_rays(*inputs)
+        aimer.aim_rays(*other)
+        assert len(aimer._cache) == 2
+        assert original[0].is_inference() is inference_first
+        assert aimer.aim_rays(*inputs) is original
+
+    with torch.inference_mode(not inference_first), torch.no_grad():
+        changed = aimer.aim_rays(*inputs)
+        assert changed is not original
+        assert len(aimer._cache) == 1
+        assert changed[0].is_inference() is not inference_first
+        assert aimer.aim_rays(*inputs) is changed
+
+    with torch.inference_mode(inference_first), torch.no_grad():
+        restored = aimer.aim_rays(*inputs)
+        assert restored is not original
+        assert restored is not changed
+        assert restored[0].is_inference() is inference_first
+        assert aimer.aim_rays(*inputs) is restored
+
+    # Unlike inference tensors, no-grad launches remain mutable outside inference.
+    numerical = changed if inference_first else restored
+    numerical[0].add_(1.0)
+    assert_allclose(numerical[0], [1.0])
+
+
+@pytest.mark.parametrize(
+    "backend_grad,ambient_grad", [(True, False), (False, True), (True, True)]
+)
+@pytest.mark.parametrize("explicit_guess", [False, True])
+def test_grad_bypass_precedes_all_cache_operations(
+    numerical_backend: None,
+    mock_dependencies: tuple[Optic, MagicMock],
+    backend_grad: bool,
+    ambient_grad: bool,
+    explicit_guess: bool,
+) -> None:
+    if be.get_backend() != "torch":
+        pytest.skip("Autograd is Torch-only")
+    import torch
+
+    optic, wrapped = mock_dependencies
+    aimer = CachedRayAimer(optic, wrapped)
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    wrapped.aim_rays.return_value = (1, 2, 3, 4, 5, 6)
+    numerical = aimer.aim_rays(*inputs)
+    entries = aimer._cache
+    guarded_cache = MagicMock(wraps=entries)
+    aimer._cache = guarded_cache
+    wrapped.aim_rays.reset_mock()
+    guess = (6, 5, 4, 3, 2, 1)
+    kwargs = {"initial_guess": guess} if explicit_guess else {}
+
+    def delegate(*args: Any, **kw: Any) -> tuple:
+        assert not entries
+        assert be.grad_mode.requires_grad is backend_grad
+        assert torch.is_grad_enabled() is ambient_grad
+        return (7, 8, 9, 10, 11, 12)
+
+    wrapped.aim_rays.side_effect = delegate
+    with (
+        patch.object(be.grad_mode, "requires_grad", backend_grad),
+        torch.set_grad_enabled(ambient_grad),
+        patch.object(aimer, "_get_input_hash", side_effect=AssertionError),
+        patch.object(aimer, "_get_system_hash", side_effect=AssertionError),
+        patch.object(be, "get_precision", side_effect=AssertionError),
+        patch.object(be, "get_device", side_effect=AssertionError),
+    ):
+        aimer.aim_rays(*inputs, **kwargs)
+        aimer.aim_rays(*inputs, **kwargs)
+    assert guarded_cache.clear.call_count == 2
+    guarded_cache.get.assert_not_called()
+    guarded_cache.__setitem__.assert_not_called()
+    assert wrapped.aim_rays.call_count == 2
+    wrapped.aim_rays.assert_called_with(*inputs, **kwargs)
+
+    aimer._cache = entries
+    wrapped.aim_rays.side_effect = None
+    wrapped.aim_rays.return_value = (7, 8, 9, 10, 11, 12)
+    resumed = aimer.aim_rays(*inputs)
+    assert resumed is not numerical
+    assert wrapped.aim_rays.call_count == 3
+    assert aimer.aim_rays(*inputs) is resumed
+    assert wrapped.aim_rays.call_count == 3
+
+
+class _NonlinearAimer(BaseRayAimer):
+    """Isolate wrapper graph lifetime from the physical solver's derivatives."""
+
+    def aim_rays(
+        self, fields: tuple, wavelengths: Any, pupil_coords: tuple
+    ) -> tuple:
+        radius = self.optic.surfaces[1].geometry.radius
+        return (radius**2,) * 6
+
+
+@pytest.mark.parametrize("replace_leaf", [False, True])
+@pytest.mark.parametrize("backend_grad", [False, True])
+def test_each_forward_builds_a_fresh_graph(
+    numerical_backend: None, replace_leaf: bool, backend_grad: bool
+) -> None:
+    if be.get_backend() != "torch":
+        pytest.skip("Autograd is Torch-only")
+    import torch
+
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=be.inf)
+    optic.surfaces.add(index=1, radius=2.0, is_stop=True)
+    radius = torch.tensor([2.0], dtype=torch.float64, requires_grad=True)
+    optic.surfaces[1].geometry.radius = radius
+    aimer = CachedRayAimer(optic, _NonlinearAimer(optic))
+    inputs = ((0.0, 1.0), 0.55, (0.0, 0.0))
+    numerical = aimer.aim_rays(*inputs)
+    assert not numerical[0].requires_grad
+    assert aimer.aim_rays(*inputs) is numerical
+
+    with (
+        patch.object(be.grad_mode, "requires_grad", backend_grad),
+        torch.enable_grad(),
+        patch.object(aimer, "_get_input_hash", side_effect=AssertionError),
+        patch.object(aimer, "_get_system_hash", side_effect=AssertionError),
+    ):
+        first = aimer.aim_rays(*inputs)
+        first[0].sum().backward()
+        assert_allclose(radius.grad, [4.0])
+        radius.grad = None
+
+        if replace_leaf:
+            new_radius = torch.tensor([2.0], dtype=torch.float64, requires_grad=True)
+            optic.surfaces[1].geometry.radius = new_radius
+        else:
+            new_radius = radius
+        second = aimer.aim_rays(*inputs)
+        assert second[0] is not first[0]
+        second[0].sum().backward()
+        assert_allclose(new_radius.grad, [4.0])
+        if replace_leaf:
+            assert radius.grad is None
+        assert not aimer._cache
+
+    resumed = aimer.aim_rays(*inputs)
+    assert resumed is not numerical
+    assert not resumed[0].requires_grad
+    assert aimer.aim_rays(*inputs) is resumed
 
 
 if __name__ == "__main__":

--- a/tests/test_cached_field_state.py
+++ b/tests/test_cached_field_state.py
@@ -1,0 +1,111 @@
+"""Full-launch caches must not freeze field-dependent launch constraints."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.fields import FieldGroup
+from optiland.materials.ideal import IdealMaterial
+from optiland.optic import Optic
+from optiland.physical_apertures.radial import RadialAperture
+from optiland.rays import RealRays
+from optiland.rays.ray_aiming.cached import CachedRayAimer
+from optiland.rays.ray_aiming.iterative import IterativeRayAimer
+
+from .test_cached_aimer import numerical_backend  # noqa: F401
+from .utils import assert_allclose
+
+
+def _field_system(infinite: bool, field_type: str) -> Optic:
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=be.inf if infinite else 100.0)
+    optic.surfaces.add(
+        index=1, radius=50.0, thickness=5.0, material=IdealMaterial(1.5)
+    )
+    optic.surfaces.add(index=2, radius=-50.0, thickness=15.0)
+    optic.surfaces.add(index=3, thickness=40.0, is_stop=True)
+    optic.surfaces.add(index=4)
+    optic.surfaces[3].aperture = RadialAperture(r_max=4.0)
+    optic.set_aperture("float_by_stop_size", 8.0)
+    optic.fields.set_type(field_type)
+    optic.fields.add(y=0.0)
+    optic.fields.add(y=1.0)
+    optic.wavelengths.add(0.55, is_primary=True)
+    return optic
+
+
+def _assert_stop_target(optic: Optic, launch: tuple, pupil: tuple) -> None:
+    rays = RealRays(
+        *(be.copy(value) for value in launch), intensity=1.0, wavelength=0.55
+    )
+    start = 1 if optic.object_surface.is_infinite else 0
+    for index in range(start, optic.surfaces.stop_index + 1):
+        optic.surfaces[index].trace(rays)
+    optic.surfaces[optic.surfaces.stop_index].geometry.cs.localize(rays)
+    assert_allclose(rays.x, pupil[0] * 4.0, atol=1e-9, rtol=0.0)
+    assert_allclose(rays.y, pupil[1] * 4.0, atol=1e-9, rtol=0.0)
+    assert be.all(be.isfinite(rays.x))
+    assert be.all(rays.i > 0.0)
+
+
+@pytest.mark.parametrize("mode", ["iterative", "robust"])
+@pytest.mark.parametrize(
+    "infinite,field_type",
+    [(False, "object_height"), (False, "angle"), (True, "angle")],
+    ids=["finite-height", "finite-angle", "infinite-angle"],
+)
+@pytest.mark.parametrize("change", ["replace", "scale"])
+@pytest.mark.usefixtures("numerical_backend")
+def test_field_change_matches_cold_launch(
+    mode: str, infinite: bool, field_type: str, change: str
+) -> None:
+    optic = _field_system(infinite, field_type)
+    optic.ray_tracer.set_aiming(mode, cache=True, max_iter=30, tol=1e-10)
+    config = optic.ray_tracer.ray_aiming_config
+    generator = optic.ray_tracer.ray_generator
+    generator.set_ray_aiming(**config)
+    warm = generator.aimer
+    assert isinstance(warm, CachedRayAimer)
+    inputs = ((0.25, 1.0), 0.55, (0.2, -0.3))
+    original = warm.aim_rays(*inputs)
+    assert warm.aim_rays(*inputs) is original
+    _assert_stop_target(optic, original, inputs[2])
+
+    if change == "replace":
+        replacement = FieldGroup()
+        replacement.set_type(field_type)
+        replacement.add(y=0.0)
+        replacement.add(y=3.0)
+        optic.fields = replacement
+    else:
+        optic.fields[1].y *= 3.0
+
+    with patch.object(
+        warm.wrapped_aimer, "aim_rays", wraps=warm.wrapped_aimer.aim_rays
+    ) as delegate:
+        warmed = warm.aim_rays(*inputs)
+        delegate.assert_called_once_with(*inputs)
+        assert warm.aim_rays(*inputs) is warmed
+        delegate.assert_called_once()
+    assert warm.wrapped_aimer.last_report.converged
+    generator.set_ray_aiming(**config)
+    cold = generator.aimer
+    fresh = cold.aim_rays(*inputs)
+    assert cold.wrapped_aimer.last_report.converged
+    for actual, expected in zip(warmed, fresh, strict=True):
+        assert_allclose(actual, expected, atol=1e-8, rtol=1e-8)
+    _assert_stop_target(optic, warmed, inputs[2])
+    _assert_stop_target(optic, fresh, inputs[2])
+
+    # An old full launch still hits the stop, but encodes the previous field.
+    control = IterativeRayAimer(optic, max_iter=30, tol=1e-10)
+    stale = control.aim_rays(*inputs, initial_guess=original)
+    assert control.last_report.converged
+    _assert_stop_target(optic, stale, inputs[2])
+    fixed = slice(3, 6) if infinite else slice(0, 3)
+    assert any(
+        not np.allclose(be.to_numpy(old), be.to_numpy(new), atol=1e-6, rtol=0.0)
+        for old, new in zip(stale[fixed], fresh[fixed], strict=True)
+    )

--- a/tests/test_cached_snapshot_precision.py
+++ b/tests/test_cached_snapshot_precision.py
@@ -1,0 +1,156 @@
+"""Numerical launch caches must retain array-valued snapshot precision."""
+
+import pickle
+from collections.abc import Iterator
+from contextlib import ExitStack
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.materials import IdealMaterial
+from optiland.optic import Optic
+from optiland.rays.ray_aiming.cached import CachedRayAimer
+from optiland.rays.ray_aiming.iterative import IterativeRayAimer
+from optiland.rays.ray_aiming.paraxial import ParaxialRayAimer
+from optiland.rays.ray_aiming.robust import RobustRayAimer
+
+from .utils import assert_allclose
+
+
+@pytest.fixture
+def numerical_backend(set_test_backend: None) -> Iterator[None]:
+    """Exercise real numerical cache hits with both Torch gradient controls off."""
+    with ExitStack() as stack:
+        stack.callback(be.set_precision, f"float{be.get_precision()}")
+        be.set_precision("float64")
+        if be.get_backend() == "torch":
+            import torch
+
+            grad_mode = be.grad_mode
+            stack.callback(setattr, grad_mode, "requires_grad", grad_mode.requires_grad)
+            grad_mode.disable()
+            stack.enter_context(torch.no_grad())
+        yield
+
+
+def _plane_system() -> Optic:
+    """Use an air-space first stop so the launch and NA cone are analytic."""
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=100.0, material=IdealMaterial(1.0))
+    optic.surfaces.add(
+        index=1, thickness=10.0, material=IdealMaterial(1.0), is_stop=True
+    )
+    optic.surfaces.add(index=2, material=IdealMaterial(1.0))
+    optic.set_aperture("objectNA", be.array(0.05))
+    optic.fields.set_type("object_height")
+    optic.fields.add(y=be.array(2.125))
+    optic.wavelengths.add(0.55, is_primary=True)
+    return optic
+
+
+def _snapshot(optic: Optic) -> tuple:
+    return (
+        optic.surfaces.to_dict(),
+        optic.fields.to_dict(),
+        optic.wavelengths.to_dict(),
+        optic.aperture.to_dict(),
+        optic.ray_tracer.ray_aiming_config,
+    )
+
+
+def _assert_launch(launch: tuple, na: float, height: float, hy: float) -> None:
+    stop_y = 100.0 * na / np.sqrt(1.0 - na**2)
+    x, y, z, L, M, N = launch
+    assert_allclose(x - z * L / N, 0.0, rtol=0, atol=1e-12)
+    assert_allclose(y - z * M / N, stop_y, rtol=0, atol=1e-12)
+    origin_y = height * hy
+    direction = np.array([0.0, stop_y - origin_y, 100.0])
+    direction /= np.linalg.norm(direction)
+    for actual, expected in zip(
+        launch, (0.0, origin_y, -100.0, *direction), strict=True
+    ):
+        assert_allclose(actual, expected, rtol=0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "aimer_type", [ParaxialRayAimer, IterativeRayAimer, RobustRayAimer]
+)
+def test_unchanged_array_snapshot_is_an_exact_hit(
+    numerical_backend: None, aimer_type: type
+) -> None:
+    """Repeated snapshots and real solver calls retain exact numerical reuse."""
+    optic = _plane_system()
+    aimer = CachedRayAimer(optic, aimer_type(optic, tol=1e-12))
+    inputs = ((0.0, 0.7), 0.55, (0.0, 1.0))
+    snapshot = pickle.dumps(_snapshot(optic))
+    original = aimer.aim_rays(*inputs)
+    _assert_launch(original, 0.05, 2.125, 0.7)
+    assert pickle.dumps(_snapshot(optic)) == snapshot
+    assert aimer.aim_rays(*inputs) is original
+    assert pickle.dumps(_snapshot(optic)) == snapshot
+
+
+@pytest.mark.parametrize(
+    ("aimer_type", "dependency"),
+    [
+        (ParaxialRayAimer, "aperture"),
+        (IterativeRayAimer, "aperture"),
+        (RobustRayAimer, "aperture"),
+        # Robust field cases are excluded: its independent PupilMapCache still
+        # rounds field fingerprints, which is outside this wrapper's scope.
+        (ParaxialRayAimer, "field"),
+        (IterativeRayAimer, "field"),
+    ],
+)
+@pytest.mark.parametrize("in_place", [False, True], ids=["replace", "in_place"])
+def test_sub_repr_snapshot_change_matches_current_physical_launch(
+    numerical_backend: None, aimer_type: type, dependency: str, in_place: bool
+) -> None:
+    """Distinct array values with identical repr must not return an old launch."""
+    optic = _plane_system()
+    aimer = CachedRayAimer(optic, aimer_type(optic, tol=1e-12))
+    hy = 0.0 if dependency == "aperture" else 0.7
+    inputs = ((0.0, hy), 0.55, (0.0, 1.0))
+    original = aimer.aim_rays(*inputs)
+    assert aimer.aim_rays(*inputs) is original
+    _assert_launch(original, 0.05, 2.125, hy)
+    text = str(_snapshot(optic))
+    payload = pickle.dumps(_snapshot(optic))
+    assert pickle.dumps(_snapshot(optic)) == payload
+
+    delta = 1e-5 if be.get_backend() == "torch" else 1e-10
+    na, height = 0.05, 2.125
+    if dependency == "aperture":
+        na += delta
+        if in_place:
+            optic.aperture.value[...] += delta
+        else:
+            optic.set_aperture("objectNA", be.array(na))
+    else:
+        height += delta
+        if in_place:
+            optic.fields[0].y[...] += delta
+        else:
+            optic.fields[0].y = be.array(height)
+
+    assert str(_snapshot(optic)) == text
+    assert pickle.dumps(_snapshot(optic)) != payload
+    current_payload = pickle.dumps(_snapshot(optic))
+    assert pickle.dumps(_snapshot(optic)) == current_payload
+    fresh = aimer_type(optic, tol=1e-12).aim_rays(*inputs)
+    _assert_launch(fresh, na, height, hy)
+    changed_component = 4 if dependency == "aperture" else 1
+    assert not np.allclose(
+        be.to_numpy(original[changed_component]),
+        be.to_numpy(fresh[changed_component]),
+        rtol=0,
+        atol=1e-12,
+    )
+
+    current = aimer.aim_rays(*inputs)
+    _assert_launch(current, na, height, hy)
+    for actual, expected in zip(current, fresh, strict=True):
+        assert_allclose(actual, expected, rtol=0, atol=1e-12)
+    assert current is not original
+    assert aimer.aim_rays(*inputs) is current


### PR DESCRIPTION
Fixes https://github.com/optiland/optiland/issues/792

**Problem**
Ordinary `Optic.trace` with explicit `cache=True` can reuse a stale
finite-conjugate object point after a field-height edit. The system hash already
includes fields. The defect is using the previous full launch state as an
automatic `initial_guess` after the system hash changes.

The iterative solver keeps the supplied object point fixed and solves direction
to hit the stop. Robust aiming first tries that same initial-guess solve. The old
ray can therefore report convergence while representing the wrong field.

The synthetic singlet in #792 changes the object field from 1 mm to 3 mm while
retaining normalized inputs `(0, 1)`. Both upstream modes keep the 1 mm origin,
causing a **0.942054864024 mm image-height error**, even though the stale and
correct rays both satisfy the requested `1e-10` mm stop tolerance.

**Changes**
- Delegate without an automatic stale full-state guess when optical state changes.
  Preserve exact numerical hits for unchanged requests and state.
- Forward explicit caller guesses without caching. When none is supplied, do not
  inject an optional guess keyword into three-argument wrapped aimers.
- Clear and bypass the wrapper under either Optiland gradient tracking or ambient
  Torch autograd, preventing reuse of consumed graphs or old parameter leaves.
- Invalidate numerical entries when backend, precision, device, or Torch inference
  mode changes.
- Hash the raw serialized system snapshot rather than rounded display text, so
  nearby array-valued changes cannot falsely qualify as exact hits.

The additional guards enforce the same full-result reuse policy in this wrapper.
They are covered by separate tests; the issue's optical example demonstrates the
field-edit failure, not every cache-safety concern.

**Compatibility**
FIFO capacity and unchanged numerical cache hits remain supported. Automatic
full-launch warm starts after system changes are intentionally removed.
Torch numerical caching requires both gradient controls to be disabled; default
ambient autograd therefore intentionally reduces cache reuse.

Torch stays optional. Snapshot handling serializes data only and does not load
untrusted pickle payloads. Raw Torch serialization can include storage identity
and backing allocations, so equal-valued replacements may conservatively miss
and small views of large storage may be more expensive to fingerprint.

**Scope**
This standalone four-file patch changes only `CachedRayAimer` and three test
modules, based on upstream `master` at
`7df37590c2d561d95403dc264e27b8b9a77ee879`. It does not depend on #780 or #791.

The underlying solvers and robust aiming's independent `PupilMapCache` are not
modified. That map cache's rounded field-fingerprint limitation remains outside
this PR; this patch does not claim to fix all robust-cache precision issues.
It also does not establish full differentiation through detached field
calibration or already-converged robust seeds.

**Validation**
- `python -m pytest -q tests/test_cached_aimer.py tests/test_cached_field_state.py tests/test_cached_snapshot_precision.py`: **78 passed, 14 skipped**.
- Broader existing ray-aiming selection: **302 passed, 1 skipped, 11 baseline failures**.
  The 11 failures at `tests/test_ray_aiming.py:374`, `:465`, and
  `tests/test_ray_aiming_numerics.py:785` are array-to-scalar conversions on
  NumPy 2.5.3. All also reproduce with the upstream cache methods restored in
  memory. They are not fixed or hidden by this PR.
- Against the original cache methods, the focused selection gives **70 expected
  failures, 8 passes, 14 skips**. This includes delegation-contract checks as
  well as numerical regressions.
- The exact issue reproducer now agrees with uncached and fresh controls:
  iterative image difference **0 mm**, robust **4.8893111781467269e-11 mm**.
  Both modes satisfy the strengthened `1e-10` mm stop assertion.
- `python -m ruff check .`, `python -m ruff format --check .`, and whitespace
  checks pass. No mathematical tolerances were relaxed.

Tests cover field replacement/scaling, finite origins and infinite directions,
exact hits, explicit guesses, graph lifetime, equal-valued leaf replacement,
context transitions, and snapshot mutations hidden by display rounding.
Graph-lifetime controls use a nonlinear test aimer rather than a full physical
solver derivative check; device transitions are mocked.

Environment: Windows, Python 3.14.2, NumPy 2.5.3, SciPy 1.18.1,
Torch 2.13.0 CPU, pytest 9.1.1, Ruff 0.16.6. The global suite and real accelerator
execution were not tested.
