### PR TITLE
fix: unify object-space telecentric state

### DIFF
--- a/optiland/fields/field_group.py
+++ b/optiland/fields/field_group.py
@@ -37,7 +37,7 @@ class FieldGroup:
     def __init__(self):
         self.fields = []
         self.field_definition: BaseFieldDefinition | None = None
-        self.telecentric = False
+        self.telecentric: bool = False
 
     def require_definition(self) -> BaseFieldDefinition:
         """Return the field definition, or raise if none has been set.
@@ -231,12 +231,11 @@ class FieldGroup:
         """
         self.fields.pop(field_number)
 
-    def set_telecentric(self, is_telecentric):
-        """Specify whether the system is telecentric in object space.
+    def set_telecentric(self, is_telecentric: bool) -> None:
+        """Set the object-space telecentric state stored by this group.
 
         Args:
-            is_telecentric (bool): Whether the system is telecentric in object
-                space.
+            is_telecentric: Whether the system is telecentric in object space.
 
         """
         self.telecentric = is_telecentric

--- a/optiland/optic/optic.py
+++ b/optiland/optic/optic.py
@@ -104,7 +104,7 @@ class Optic:
         solves (SolveManager): Manages solves, which automatically adjust
             surface properties to meet certain constraints.
         obj_space_telecentric (bool): If True, the system is object-space
-            telecentric. Defaults to False.
+            telecentric. Alias for ``fields.telecentric``. Defaults to False.
 
 
     """
@@ -137,9 +137,22 @@ class Optic:
         self.apodization: BaseApodization | None = None
         self.pickups: PickupManager = PickupManager(self)
         self.solves: SolveManager = SolveManager(self)
-        self.obj_space_telecentric: bool = False
         self.updater: OpticUpdater = OpticUpdater(self)
         self.sequences: dict[str, SequencedOptic] = {}
+
+    @property
+    def obj_space_telecentric(self) -> bool:
+        """Whether object space is telecentric, as stored in the current field group."""
+        return self.fields.telecentric
+
+    @obj_space_telecentric.setter
+    def obj_space_telecentric(self, is_telecentric: bool) -> None:
+        """Set object-space telecentricity on the current field group.
+
+        Args:
+            is_telecentric: Whether the system is telecentric in object space.
+        """
+        self.fields.set_telecentric(is_telecentric)
 
     @property
     def surface_group(self) -> SurfaceGroup:

--- a/optiland/optic/optic_serializer.py
+++ b/optiland/optic/optic_serializer.py
@@ -97,7 +97,6 @@ class OpticSerializer:
             optic.fields.set_type(data["fields"]["field_type"])
         else:
             optic.fields.field_definition = None
-        optic.obj_space_telecentric = data["fields"]["telecentric"]
 
         optic.paraxial = Paraxial(optic)
         optic.aberrations = Aberrations(optic)

--- a/tests/test_telecentric_state.py
+++ b/tests/test_telecentric_state.py
@@ -1,0 +1,235 @@
+"""Regression tests for canonical object-space telecentric state."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import optiland.backend as be
+from optiland.fields import FieldGroup
+from optiland.fileio import load_optiland_file, save_optiland_file
+from optiland.materials import IdealMaterial
+from optiland.optic import Optic
+from optiland.rays import RealRays
+from tests.utils import assert_allclose
+
+
+@pytest.fixture
+def finite_optic(set_test_backend: None) -> Optic:
+    """Build a finite system whose ordinary chief ray is not axial."""
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=32.0, material=IdealMaterial(n=1.0))
+    optic.surfaces.add(
+        index=1, radius=16.0, thickness=16.0, material=IdealMaterial(n=2.0)
+    )
+    optic.surfaces.add(
+        index=2, thickness=48.0, is_stop=True, material=IdealMaterial(n=2.0)
+    )
+    optic.surfaces.add(index=3, material=IdealMaterial(n=2.0))
+    optic.fields.set_type("object_height")
+    optic.fields.add(y=0.25)
+    optic.set_aperture("objectNA", 0.05)
+    optic.wavelengths.add(0.55, is_primary=True)
+    return optic
+
+
+def _generate_rays(optic: Optic) -> RealRays:
+    """Generate a chief ray and two off-axis pupil rays without tracing."""
+    return optic.ray_tracer.ray_generator.generate_rays(
+        be.zeros(3),
+        be.ones(3),
+        be.array([0.0, 0.5, -0.5]),
+        be.array([0.0, -0.5, 0.5]),
+        optic.primary_wavelength,
+    )
+
+
+def _assert_state(optic: Optic, telecentric: bool) -> RealRays:
+    """Check both public views and the resulting chief-ray launch."""
+    assert optic.obj_space_telecentric is telecentric
+    assert optic.fields.telecentric is telecentric
+    rays = _generate_rays(optic)
+    assert_allclose(rays.x, 0.0, rtol=0.0, atol=1e-12)
+    assert_allclose(rays.y, 0.25, rtol=0.0, atol=1e-12)
+    assert_allclose(rays.z, -32.0, rtol=0.0, atol=1e-12)
+    # The ordinary entrance pupil is at z=16, 48 units from the object.
+    slope = 0.0 if telecentric else -0.25 / 48.0
+    assert_allclose(rays.M[0] / rays.N[0], slope, rtol=0.0, atol=1e-12)
+    assert_allclose(rays.L[0], 0.0, rtol=0.0, atol=1e-12)
+    return rays
+
+
+def test_unconfigured_optic(set_test_backend: None) -> None:
+    optic = Optic()
+    assert optic.obj_space_telecentric is False
+    assert optic.fields.telecentric is False
+
+    optic.obj_space_telecentric = True
+    assert optic.fields.telecentric is True
+    optic.fields.set_telecentric(False)
+    assert optic.obj_space_telecentric is False
+    optic.fields.set_telecentric(True)
+    assert optic.obj_space_telecentric is True
+    optic.obj_space_telecentric = False
+    assert optic.fields.telecentric is False
+
+    assert optic.aperture is None
+    assert optic.fields.field_definition is None
+    assert len(optic.surfaces) == 0
+    assert len(optic.wavelengths) == 0
+    assert "obj_space_telecentric" not in vars(optic)
+
+
+@pytest.mark.parametrize("via_fields", [False, True])
+def test_last_write_wins_with_warmed_generator(
+    finite_optic: Optic, via_fields: bool
+) -> None:
+    optic = finite_optic
+    _assert_state(optic, False)
+    generator = optic.ray_tracer.ray_generator
+    aimer = generator.aimer
+
+    for telecentric in (True, False, True, False):
+        if via_fields:
+            optic.fields.set_telecentric(telecentric)
+        else:
+            optic.obj_space_telecentric = telecentric
+        _assert_state(optic, telecentric)
+        assert optic.ray_tracer.ray_generator is generator
+        assert generator.aimer is aimer
+        via_fields = not via_fields
+
+
+@pytest.mark.parametrize("via_fields", [False, True])
+@pytest.mark.parametrize("telecentric", [False, True])
+@pytest.mark.parametrize("use_json", [False, True], ids=["dict", "json"])
+def test_ray_preserving_roundtrip(
+    finite_optic: Optic,
+    tmp_path: Path,
+    via_fields: bool,
+    telecentric: bool,
+    use_json: bool,
+) -> None:
+    optic = finite_optic
+    _assert_state(optic, False)
+    if via_fields:
+        optic.obj_space_telecentric = not telecentric
+        optic.fields.set_telecentric(telecentric)
+    else:
+        optic.fields.set_telecentric(not telecentric)
+        optic.obj_space_telecentric = telecentric
+    launch = _assert_state(optic, telecentric)
+    traced = optic.trace_generic(
+        0.0,
+        1.0,
+        be.array([0.0, 0.5, -0.5]),
+        be.array([0.0, -0.5, 0.5]),
+        optic.primary_wavelength,
+    )
+    data = optic.to_dict()
+    assert data["version"] == 1.0
+    assert data["fields"]["telecentric"] is telecentric
+    assert "obj_space_telecentric" not in data
+
+    if use_json:
+        filepath = tmp_path / "telecentric.json"
+        save_optiland_file(optic, filepath)
+        restored = load_optiland_file(filepath)
+    else:
+        restored = Optic.from_dict(data)
+
+    restored_launch = _assert_state(restored, telecentric)
+    restored_traced = restored.trace_generic(
+        0.0,
+        1.0,
+        be.array([0.0, 0.5, -0.5]),
+        be.array([0.0, -0.5, 0.5]),
+        restored.primary_wavelength,
+    )
+    assert restored.to_dict()["fields"] == data["fields"]
+    for actual, expected in ((restored_launch, launch), (restored_traced, traced)):
+        for attribute in ("x", "y", "z", "L", "M", "N", "i", "w", "opd"):
+            assert_allclose(
+                getattr(actual, attribute),
+                getattr(expected, attribute),
+                rtol=0.0,
+                atol=1e-12,
+            )
+
+
+def test_reset_detaches_old_group(finite_optic: Optic) -> None:
+    optic = finite_optic
+    optic.obj_space_telecentric = True
+    _assert_state(optic, True)
+    old_fields = optic.fields
+
+    optic.reset()
+    assert optic.fields is not old_fields
+    assert optic.obj_space_telecentric is False
+    assert optic.fields.telecentric is False
+    assert old_fields.telecentric is True
+    for telecentric in (False, True):
+        old_fields.set_telecentric(telecentric)
+        assert optic.obj_space_telecentric is False
+    optic.obj_space_telecentric = True
+    assert optic.fields.telecentric is True
+    optic.obj_space_telecentric = False
+    assert old_fields.telecentric is True
+
+
+@pytest.mark.parametrize("telecentric", [False, True])
+def test_field_group_replacement(finite_optic: Optic, telecentric: bool) -> None:
+    optic = finite_optic
+    optic.obj_space_telecentric = not telecentric
+    _assert_state(optic, not telecentric)
+    generator = optic.ray_tracer.ray_generator
+    aimer = generator.aimer
+    old_fields = optic.fields
+    replacement = FieldGroup.from_dict(old_fields.to_dict())
+    replacement.set_telecentric(telecentric)
+
+    optic.fields = replacement
+    _assert_state(optic, telecentric)
+    for old_state in (True, False):
+        old_fields.set_telecentric(old_state)
+        _assert_state(optic, telecentric)
+    optic.obj_space_telecentric = not telecentric
+    _assert_state(optic, not telecentric)
+    assert old_fields.telecentric is False
+    replacement.set_telecentric(telecentric)
+    _assert_state(optic, telecentric)
+    assert optic.ray_tracer.ray_generator is generator
+    assert generator.aimer is aimer
+
+
+def test_deepcopy_independence(finite_optic: Optic) -> None:
+    optic = finite_optic
+    optic.obj_space_telecentric = True
+    _assert_state(optic, True)
+
+    copied = deepcopy(optic)
+    assert copied.fields is not optic.fields
+    assert copied.ray_tracer.ray_generator.optic is copied
+    assert copied.ray_tracer.ray_generator.aimer.optic is copied
+    _assert_state(copied, True)
+    copied.fields.set_telecentric(False)
+    _assert_state(copied, False)
+    _assert_state(optic, True)
+    copied.obj_space_telecentric = True
+    optic.fields.set_telecentric(False)
+    _assert_state(copied, True)
+    _assert_state(optic, False)
+
+
+def test_standalone_field_group(set_test_backend: None) -> None:
+    fields = FieldGroup()
+    assert fields.telecentric is False
+    for telecentric in (True, False):
+        fields.set_telecentric(telecentric)
+        assert fields.telecentric is telecentric
+        data = fields.to_dict()
+        assert data["telecentric"] is telecentric
+        restored = FieldGroup.from_dict(data)
+        assert restored.telecentric is telecentric
+        restored.set_telecentric(not telecentric)
+        assert fields.telecentric is telecentric


### PR DESCRIPTION
Fixes https://github.com/optiland/optiland/issues/795

**Problem**
`Optic.obj_space_telecentric` and `FieldGroup.telecentric` store independent
values for the same setting. Paraxial aiming reads the Optic value, while
native serialization stores only the field-group value. Loading reconciles
them using the saved flag, which can enable or disable the Optic setting.

The complete dictionaries can compare equal even though the runtime setting
changed. The minimal assertion in #795 demonstrates this on a bare `Optic()`;
no optical prescription or ray calculation is needed.

**Changes**
- Keep `FieldGroup.telecentric` as the single stored value.
- Retain `Optic.obj_space_telecentric` as a typed read/write property delegating
  to the current field group and its public setter.
- Remove independent flag initialization and redundant reconciliation during
  deserialization.
- Document the alias and cover both entry points and their lifecycle behavior.

Both entry points now agree immediately, with the last write determining the
setting. Replacing the field group adopts its value, detached groups cannot
change the optic, reset restores `False`, and deepcopy remains independent.
No owner callbacks, eager optical validation, or tracing are introduced.

**Compatibility And Scope**
The existing `fields.telecentric` key, file version `1.0`, and both public
entry points are preserved. There is no schema migration or new missing-key
policy. Values omitted from older files cannot be recovered automatically.

The flag is now a property rather than a separate `vars(optic)` entry. Native
dictionary/JSON compatibility is not a promise about arbitrary legacy pickles
or direct `__dict__` restoration. Subclasses must initialize the field group
before assigning the property; the existing sample already does so.

This is a standalone four-file patch based on upstream `master` at
`7df37590c2d561d95403dc264e27b8b9a77ee879`. It does not depend on #780, #791,
or #793. Launch equations, aperture compatibility, ray-aiming cache policy,
and interchange-format support are unchanged. Canonical field metadata does
not by itself establish the safety of cached complete launch guesses.

**Validation**
```text
python -m pytest -q tests/test_telecentric_state.py tests/test_optic.py tests/test_fields.py tests/test_fileio/test_optiland_handler.py
174 passed, 1 skipped

python -m ruff check .
python -m ruff format --check .
git diff --cached --check
```

- The new module contributes **32 passing cases**. Nearby modules give
  **142 passed, 1 skipped** on both upstream and patched source.
- The exact minimal issue assertion fails upstream (`False != True`) and
  passes with the patch (`True == True`).
- Independent state-matrix execution covers both setters, both values,
  dictionary/native JSON, and NumPy/Torch: all 16 upstream cases change the
  Optic state on load despite equal dictionaries; all 16 patched cases
  preserve the requested state.
- Regression tests cover unconfigured optics, warmed default generators,
  full launch/trace roundtrips, reset, field-group replacement, detached
  groups, deepcopy independence, and standalone field groups.
- Numerical controls distinguish ordinary chief slope `-0.25/48` from
  telecentric slope zero; no mathematical tolerances were relaxed.
- Ruff, formatting, and whitespace checks pass. The skip is a NumPy variant
  of a Torch-only test; existing material/Torch warnings remain visible.

Environment: Windows, Python 3.14.2, NumPy 2.5.3, Torch 2.13.0 CPU.
The global suite and accelerator execution were not tested.
