### PR TITLE
fix: account for object index in telecentric NA launches

### DIFF
--- a/optiland/aperture/base.py
+++ b/optiland/aperture/base.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from optiland._types import ScalarOrArray
     from optiland.paraxial import Paraxial
 
 
@@ -53,7 +54,7 @@ class BaseSystemAperture(ABC):
 
     @property
     @abstractmethod
-    def value(self) -> float:
+    def value(self) -> ScalarOrArray:
         """Raw aperture value as supplied by the user."""
 
     # ── Capability flags ───────────────────────────────────────────────────

--- a/optiland/aperture/object_na.py
+++ b/optiland/aperture/object_na.py
@@ -11,6 +11,8 @@ import optiland.backend as be
 from optiland.aperture.base import BaseSystemAperture
 
 if TYPE_CHECKING:
+    from optiland._types import BEArray, ScalarOrArray
+    from optiland.optic import Optic
     from optiland.paraxial import Paraxial
 
 
@@ -28,7 +30,7 @@ class ObjectNAAperture(BaseSystemAperture):
 
     _ap_type_key = "objectNA"
 
-    def __init__(self, value: float) -> None:
+    def __init__(self, value: ScalarOrArray) -> None:
         self._value = value
 
     @property
@@ -36,7 +38,7 @@ class ObjectNAAperture(BaseSystemAperture):
         return "objectNA"
 
     @property
-    def value(self) -> float:
+    def value(self) -> ScalarOrArray:
         return self._value
 
     @property
@@ -46,6 +48,68 @@ class ObjectNAAperture(BaseSystemAperture):
     @property
     def is_scalable(self) -> bool:
         return False
+
+    def object_space_sine(
+        self, optic: Optic, wavelength: float | None = None
+    ) -> BEArray:
+        """Convert NA to a launch sine in the actual object medium.
+
+        Args:
+            optic: Optical system providing the object material.
+            wavelength: Reference wavelength; defaults to the primary wavelength,
+                independently of the wavelengths of the rays being aimed.
+
+        Returns:
+            Scalar backend-valued sine, retaining NA and refractive-index
+            gradients. Single-element arrays of any shape are normalized.
+            Floating input precision is preserved; untyped values use a floating
+            counterpart's dtype, or the configured precision if neither has one.
+
+        Raises:
+            ValueError: If the object is missing, NA or index is not a single
+                value, the index is not finite and positive, or NA lies outside
+                ``0 <= NA < n``. Zero defines a chief-only cone; a grazing cone
+                has no finite forward slope.
+        """
+        if optic.object_surface is None:
+            raise ValueError("objectNA aperture requires a defined object surface.")
+        if wavelength is None:
+            wavelength = optic.primary_wavelength
+        # Preserve input precision: rounding to the backend default can turn
+        # a valid NA < n into NA == n before validation.
+        values = [optic.object_surface.material_post.n(wavelength), self._value]
+        for i, value in enumerate(values):
+            if hasattr(value, "dtype") and not be.is_torch_tensor(value):
+                # Keep floating precision; other host dtypes retain the usual
+                # backend conversion (some Torch integer types lack comparisons).
+                values[i] = (
+                    be.asarray(value, dtype=None)
+                    if getattr(value.dtype, "kind", None) == "f"
+                    else be.array(value)
+                )
+        for i, value in enumerate(values):
+            if hasattr(value, "dtype"):
+                continue
+            dtype = getattr(values[1 - i], "dtype", None)
+            values[i] = (
+                be.asarray(value, dtype=dtype)
+                if getattr(dtype, "kind", None) == "f"
+                or getattr(dtype, "is_floating_point", False)
+                else be.array(value)
+            )
+        index, na = values
+        if be.size(index) != 1:
+            raise ValueError("Object refractive index must contain exactly one value.")
+        index = index.reshape(())
+        if not bool(be.all(be.isfinite(index) & (index > 0))):
+            raise ValueError("Object refractive index must be finite and positive.")
+        if be.size(na) != 1:
+            raise ValueError("Object NA must contain exactly one value.")
+        na = na.reshape(())
+        if not bool(be.all(be.isfinite(na) & (na >= 0) & (na < index))):
+            raise ValueError("Object NA must be finite and satisfy 0 <= NA < n.")
+        sine = na / index
+        return sine if be.is_torch_tensor(sine) else be.asarray(sine, dtype=sine.dtype)
 
     def compute_epd(self, paraxial: Paraxial, wavelength: float | None = None) -> float:
         """Compute EPD from object-space NA.
@@ -60,18 +124,13 @@ class ObjectNAAperture(BaseSystemAperture):
             Entrance pupil diameter.
 
         Raises:
-            ValueError: If the object surface is not defined.
+            ValueError: If the object surface is missing, its refractive index
+                is invalid, or NA lies outside ``0 <= NA < n``.
 
         """
-        if paraxial.optic.object_surface is None:
-            raise ValueError("objectNA aperture requires a defined object surface.")
-
-        if wavelength is None:
-            wavelength = paraxial.optic.primary_wavelength
-
+        sine = self.object_space_sine(paraxial.optic, wavelength)
         obj_z = paraxial.optic.object_surface.geometry.cs.z
-        n0 = paraxial.optic.object_surface.material_post.n(wavelength)
-        u0 = be.arcsin(self._value / n0)
+        u0 = be.arcsin(sine)
         z = paraxial.entrance_pupil_axial_position() - obj_z
         return 2 * z * be.tan(u0)
 

--- a/optiland/rays/ray_aiming/paraxial.py
+++ b/optiland/rays/ray_aiming/paraxial.py
@@ -109,12 +109,9 @@ class ParaxialRayAimer(BaseRayAimer):
                     "ray tracing remains available."
                 )
             if isinstance(self.optic.aperture, ObjectNAAperture):
-                # NA = n*sin(theta), using the object medium at the primary
-                # wavelength, as in ObjectNAAperture.compute_epd.
-                index = self.optic.object_surface.material_post.n(
-                    self.optic.primary_wavelength
-                )
-                sine = self.optic.aperture.value / index
+                # Share the aperture's NA = n*sin(theta) conversion, reference
+                # wavelength and validation with its EPD calculation.
+                sine = self.optic.aperture.object_space_sine(self.optic)
                 # Work directly with directions to avoid a target at 1/sine.
                 # Normalization retains the existing slope-based pupil sampling.
                 L = Px * vx * sine

--- a/optiland/rays/ray_aiming/paraxial.py
+++ b/optiland/rays/ray_aiming/paraxial.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import optiland.backend as be
+from optiland.aperture import ObjectNAAperture
 from optiland.fields.field_types import AngleField
 from optiland.paraxial_path import (
     UnsupportedParaxialGeometryError,
@@ -94,8 +95,8 @@ class ParaxialRayAimer(BaseRayAimer):
 
         if self.optic.obj_space_telecentric:
             self._check_telecentric_compatibility()
-            # The telecentric launch construction below displaces along
-            # global z and lays pupil offsets in global x/y; it is only
+            # The telecentric launches below use global +z as their axis
+            # and global x/y for pupil offsets; this construction is only
             # valid while the beam enters along +z. Reject other entries
             # rather than silently constructing invalid targets.
             path = self.optic.surfaces.build_paraxial_path()
@@ -107,6 +108,21 @@ class ParaxialRayAimer(BaseRayAimer):
                     "telecentric construction is not yet implemented. Real "
                     "ray tracing remains available."
                 )
+            if isinstance(self.optic.aperture, ObjectNAAperture):
+                # NA = n*sin(theta), using the object medium at the primary
+                # wavelength, as in ObjectNAAperture.compute_epd.
+                index = self.optic.object_surface.material_post.n(
+                    self.optic.primary_wavelength
+                )
+                sine = self.optic.aperture.value / index
+                # Work directly with directions to avoid a target at 1/sine.
+                # Normalization retains the existing slope-based pupil sampling.
+                L = Px * vx * sine
+                M = Py * vy * sine
+                N = be.ones_like(Px) * be.sqrt(1 - sine**2)
+                norm = be.sqrt(L**2 + M**2 + N**2)
+                return x0, y0, z0, L / norm, M / norm, N / norm
+
             sin = self.optic.aperture.value
             z = be.sqrt(1 - sin**2) / sin + z0
             z1 = be.full_like(Px, z)

--- a/tests/test_telecentric_object_na.py
+++ b/tests/test_telecentric_object_na.py
@@ -1,7 +1,8 @@
 """Focused object-space telecentric NA regressions for issue #797."""
 
 import math
-from typing import TYPE_CHECKING
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Literal
 from unittest.mock import Mock
 
 import numpy as np
@@ -15,6 +16,16 @@ from tests.utils import assert_allclose
 
 if TYPE_CHECKING:
     from optiland._types import ScalarOrArray
+
+
+@pytest.fixture
+def restore_backend_precision(set_test_backend: None) -> Iterator[None]:
+    """Restore precision before the backend fixture resets the active backend."""
+    precision = "float32" if be.get_precision() == 32 else "float64"
+    try:
+        yield
+    finally:
+        be.set_precision(precision)
 
 
 def _plane_optic(
@@ -213,6 +224,253 @@ def test_float_by_stop_retains_legacy_telecentric_slope(
     assert_allclose(L**2 + M**2 + N**2, 1.0)
     assert_allclose(L[2], 0.6)
     assert_allclose(N[2], 0.8)
+
+
+INVALID_APERTURE_DATA = {
+    "negative-na": (-0.1, "(?i)NA"),
+    "nan-na": (np.nan, "(?i)NA"),
+    "infinite-na": (np.inf, "(?i)NA"),
+    "grazing-na": (1.5, "(?i)NA"),
+    "supercritical-na": (1.6, "(?i)NA"),
+    "empty-na": ([], "(?i)(one|single) value"),
+    "multiple-na": ([0.6, 0.9], "(?i)(one|single) value"),
+}
+INVALID_OBJECT_INDEX = {
+    "zero-index": (0.0, "(?i)index"),
+    "negative-index": (-1.5, "(?i)index"),
+    "nan-index": (np.nan, "(?i)index"),
+    "infinite-index": (np.inf, "(?i)index"),
+    "empty-index": ([], "(?i)(one|single) value"),
+    "multiple-index": ([1.5, 1.6], "(?i)(one|single) value"),
+}
+
+
+@pytest.mark.parametrize("case", sorted(INVALID_APERTURE_DATA))
+def test_invalid_object_na_is_rejected_by_every_conversion(
+    set_test_backend: None, case: str
+) -> None:
+    """Out-of-domain NA raises instead of reaching a sqrt, arcsin, or division."""
+    value, match = INVALID_APERTURE_DATA[case]
+    optic = _plane_optic(IdealMaterial(1.5))
+    optic.set_aperture("objectNA", be.array(value))
+
+    with pytest.raises(ValueError, match=match):
+        optic.aperture.object_space_sine(optic)
+    with pytest.raises(ValueError, match=match):
+        optic.aperture.compute_epd(optic.paraxial)
+    with pytest.raises(ValueError, match=match):
+        ParaxialRayAimer(optic).aim_rays((0.0, 0.0), 0.55, (0.0, 1.0))
+
+
+@pytest.mark.parametrize("case", sorted(INVALID_OBJECT_INDEX))
+def test_invalid_object_index_is_rejected_by_every_conversion(
+    set_test_backend: None, case: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unusable object medium is a configuration error, not a NaN launch."""
+    value, match = INVALID_OBJECT_INDEX[case]
+    optic = _plane_optic(IdealMaterial(1.5))
+    monkeypatch.setattr(
+        optic.object_surface.material_post,
+        "n",
+        Mock(return_value=be.array(value)),
+    )
+
+    with pytest.raises(ValueError, match=match):
+        optic.aperture.object_space_sine(optic)
+    with pytest.raises(ValueError, match=match):
+        optic.aperture.compute_epd(optic.paraxial)
+    with pytest.raises(ValueError, match=match):
+        ParaxialRayAimer(optic).aim_rays((0.0, 0.0), 0.55, (0.0, 1.0))
+
+
+def test_missing_object_is_rejected_by_helper_and_epd(set_test_backend: None) -> None:
+    """Both conversion entry points report the absent object before using geometry."""
+    optic = Optic()
+    optic.set_aperture("objectNA", 0.6)
+
+    with pytest.raises(ValueError, match="defined object surface"):
+        optic.aperture.object_space_sine(optic)
+    with pytest.raises(ValueError, match="defined object surface"):
+        optic.aperture.compute_epd(optic.paraxial)
+
+
+@pytest.mark.parametrize(
+    "na_shape,index_shape",
+    [((1,), ()), ((1, 1), ()), ((), (1, 1)), ((1, 1), (1,))],
+)
+def test_singleton_aperture_shapes_yield_one_scalar_sine(
+    set_test_backend: None,
+    monkeypatch: pytest.MonkeyPatch,
+    na_shape: tuple[int, ...],
+    index_shape: tuple[int, ...],
+) -> None:
+    """A single value of any shape is accepted without adding a ray axis."""
+    material = IdealMaterial(1.5)
+    monkeypatch.setattr(material, "n", Mock(return_value=be.full(index_shape, 1.5)))
+    optic = _plane_optic(material, be.full(na_shape, 0.6))
+    sine = optic.aperture.object_space_sine(optic)
+    assert sine.shape == ()
+    if be.get_backend() == "numpy":
+        assert isinstance(sine, np.ndarray)
+    else:
+        import torch
+
+        assert isinstance(sine, torch.Tensor)
+    assert_allclose(sine, 0.4)
+
+    epd = optic.aperture.compute_epd(optic.paraxial)
+    assert epd.shape == ()
+    assert_allclose(epd, 20.0 * 0.4 / math.sqrt(1 - 0.4**2))
+
+    _, _, _, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.zeros(2), be.zeros(2)),
+        be.full(2, 0.55),
+        (be.zeros(2), be.array([0.5, 1.0])),
+    )
+    for component in (L, M, N):
+        assert component.shape == (2,)
+    assert_allclose(M / N, np.array([0.5, 1.0]) * 0.4 / math.sqrt(1 - 0.4**2))
+
+
+@pytest.mark.parametrize(
+    "typed_operand,na,index",
+    [
+        ("index", 0.6, 1.5),
+        ("index", 1.4999, 1.5),
+        ("index", 1.49999999, 1.5),
+        ("na", 1.5, 1.50000001),
+    ],
+)
+def test_float64_operand_preserves_python_partner_at_float32_precision(
+    restore_backend_precision: None,
+    monkeypatch: pytest.MonkeyPatch,
+    typed_operand: Literal["na", "index"],
+    na: float,
+    index: float,
+) -> None:
+    """Backend precision must not round a valid mixed-precision cone to grazing."""
+    be.set_precision("float64")
+    material = IdealMaterial(index)
+    # Install the parameter before any lookup, rather than replacing cached data.
+    material.index = be.array([index])
+    aperture_value = be.array(na) if typed_operand == "na" else na
+    if typed_operand == "na":
+        monkeypatch.setattr(material, "n", Mock(return_value=index))
+
+    be.set_precision("float32")
+    optic = _plane_optic(material, aperture_value)
+    original_sine = aperture_value / material.n(optic.primary_wavelength)
+    original_epd = 20.0 * be.tan(be.arcsin(original_sine))
+    expected_sine = na / index
+    expected_epd = 20.0 * math.tan(math.asin(expected_sine))
+
+    sine = optic.aperture.object_space_sine(optic)
+    epd = optic.aperture.compute_epd(optic.paraxial)
+    for value in (sine, epd):
+        assert value.shape == ()
+        assert be.to_numpy(value).dtype == np.dtype("float64")
+        assert np.isfinite(be.to_numpy(value)).all()
+    assert_allclose(sine, expected_sine, rtol=1e-12, atol=1e-12)
+    assert_allclose(epd, expected_epd, rtol=1e-10, atol=1e-12)
+    assert_allclose(epd, original_epd, rtol=1e-12, atol=1e-12)
+
+    if be.get_backend() == "torch":
+        import torch
+
+        parameter = material.index if typed_operand == "index" else aperture_value
+        expected_gradient = -na / index**2 if typed_operand == "index" else 1 / index
+        (gradient,) = torch.autograd.grad(sine, parameter)
+        assert_allclose(gradient, expected_gradient, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("host_unsigned", [False, True])
+def test_integer_index_preserves_fractional_python_na(
+    set_test_backend: None, monkeypatch: pytest.MonkeyPatch, host_unsigned: bool
+) -> None:
+    """An integer-valued material index must not truncate the fractional NA."""
+    if host_unsigned:
+        index = np.array([2], dtype=np.uint64)
+    elif be.get_backend() == "numpy":
+        index = np.array([2], dtype=np.int64)
+    else:
+        import torch
+
+        index = torch.tensor([2], dtype=torch.int64)
+    material = IdealMaterial(2.0)
+    monkeypatch.setattr(material, "n", Mock(return_value=index))
+    optic = _plane_optic(material, 0.6)
+
+    sine = optic.aperture.object_space_sine(optic)
+    assert np.issubdtype(be.to_numpy(sine).dtype, np.floating)
+    assert_allclose(sine, 0.3, rtol=1e-10, atol=1e-12)
+    assert_allclose(
+        optic.aperture.compute_epd(optic.paraxial),
+        20.0 * math.tan(math.asin(0.3)),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+def test_reference_wavelength_defaults_to_primary_and_accepts_override(
+    set_test_backend: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both conversions share one reference-wavelength convention."""
+
+    def refractive_index(wavelength: "ScalarOrArray") -> "ScalarOrArray":
+        """Give the primary and requested wavelengths distinct indices."""
+        return 1.5 + 2.0 * (be.array(wavelength) - 0.55)
+
+    optic = _plane_optic(IdealMaterial(1.5))
+    monkeypatch.setattr(
+        optic.object_surface.material_post, "n", Mock(side_effect=refractive_index)
+    )
+
+    assert_allclose(optic.aperture.object_space_sine(optic), 0.6 / 1.5)
+    assert_allclose(optic.aperture.object_space_sine(optic, 0.45), 0.6 / 1.3)
+    # The entrance pupil is 10 mm from the object in this homogeneous system.
+    for wavelength, index in ((None, 1.5), (0.45, 1.3)):
+        sine = 0.6 / index
+        expected = 2 * 10.0 * sine / math.sqrt(1 - sine**2)
+        assert_allclose(
+            optic.aperture.compute_epd(optic.paraxial, wavelength), expected
+        )
+
+
+@pytest.mark.parametrize("na", [0.6, 1.2])
+def test_shared_conversion_keeps_epd_and_launch_consistent(
+    set_test_backend: None, na: float
+) -> None:
+    """The launch angle and the reported entrance pupil describe one cone."""
+    optic = _plane_optic(IdealMaterial(1.5), na)
+    sine = na / 1.5
+    slope = sine / math.sqrt(1 - sine**2)
+
+    assert_allclose(optic.aperture.compute_epd(optic.paraxial), 2 * 10.0 * slope)
+    _, _, _, _, M, N = ParaxialRayAimer(optic).aim_rays((0.0, 0.0), 0.55, (0.0, 1.0))
+    assert_allclose(M / N, slope)
+
+
+@pytest.mark.parametrize("precision", ["float64", "float32"])
+def test_object_space_sine_retains_na_and_index_gradients(
+    restore_backend_precision: None, precision: Literal["float32", "float64"]
+) -> None:
+    """The shared conversion keeps both leaves differentiable: s = NA / n."""
+    if be.get_backend() != "torch":
+        pytest.skip("Autograd requires the torch backend.")
+    import torch
+
+    na = torch.tensor(0.6, dtype=torch.float64, requires_grad=True)
+    index = torch.tensor([1.5], dtype=torch.float64, requires_grad=True)
+    material = IdealMaterial(1.5)
+    material.index = index
+    be.set_precision(precision)
+    optic = _plane_optic(material, na)
+
+    sine = optic.aperture.object_space_sine(optic)
+    assert_allclose(sine, 0.4)
+    grad_na, grad_index = torch.autograd.grad(sine, (na, index))
+    assert_allclose(grad_na, 1 / 1.5)
+    assert_allclose(grad_index, -0.6 / 1.5**2)
 
 
 def test_zero_object_na_launches_finite_axial_rays(set_test_backend: None) -> None:

--- a/tests/test_telecentric_object_na.py
+++ b/tests/test_telecentric_object_na.py
@@ -1,0 +1,233 @@
+"""Focused object-space telecentric NA regressions for issue #797."""
+
+import math
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.materials.ideal import IdealMaterial
+from optiland.optic import Optic
+from optiland.rays.ray_aiming.paraxial import ParaxialRayAimer
+from tests.utils import assert_allclose
+
+if TYPE_CHECKING:
+    from optiland._types import ScalarOrArray
+
+
+def _plane_optic(
+    material: IdealMaterial,
+    aperture_value: "ScalarOrArray" = 0.6,
+    *,
+    telecentric: bool = True,
+) -> Optic:
+    """Build homogeneous planes with stop/image 10/15 mm from the object."""
+    optic = Optic()
+    optic.surfaces.add(index=0, thickness=10.0, material=material)
+    optic.surfaces.add(index=1, thickness=5.0, material=material, is_stop=True)
+    optic.surfaces.add(index=2, material=material)
+    optic.set_aperture("objectNA", aperture_value)
+    optic.fields.set_type("object_height")
+    optic.fields.add(y=0.0)
+    optic.fields.add(y=2.0)
+    optic.obj_space_telecentric = telecentric
+    optic.fields.set_telecentric(telecentric)
+    optic.wavelengths.add(0.45)
+    optic.wavelengths.add(0.55, is_primary=True)
+    optic.ray_tracer.set_aiming("paraxial")
+    return optic
+
+
+@pytest.mark.parametrize("index,na", [(1.0, 0.6), (1.5, 0.6), (1.5, 1.2)])
+@pytest.mark.parametrize("telecentric", [True, False], ids=["telecentric", "control"])
+def test_public_plane_trace_has_physical_na_and_heights(
+    set_test_backend: None, index: float, na: float, telecentric: bool
+) -> None:
+    """Public tracing obeys NA = n sin(theta) and free-propagation geometry."""
+    optic = _plane_optic(IdealMaterial(index), na, telecentric=telecentric)
+    px = be.array([0.0, 1.0, 0.0])
+    py = be.array([0.0, 0.0, -1.0])
+    rays = optic.trace_generic(be.zeros(3), be.zeros(3), px, py, 0.55)
+
+    sine = na / index
+    expected_l = np.array([0.0, sine, 0.0])
+    expected_m = np.array([0.0, 0.0, -sine])
+    expected_n = np.array([1.0, math.sqrt(1 - sine**2), math.sqrt(1 - sine**2)])
+    for actual, expected in zip(
+        (rays.L, rays.M, rays.N), (expected_l, expected_m, expected_n), strict=True
+    ):
+        assert np.isfinite(be.to_numpy(actual)).all()
+        assert_allclose(actual, expected, rtol=1e-10, atol=1e-12)
+    assert_allclose(index * be.sqrt(rays.L**2 + rays.M**2), [0.0, na, na])
+    assert_allclose(rays.L**2 + rays.M**2 + rays.N**2, 1.0)
+    assert_allclose(rays.i, 1.0)
+    for surface, distance in ((optic.surfaces[1], 10.0), (optic.surfaces[2], 15.0)):
+        assert_allclose(surface.x, distance * expected_l / expected_n)
+        assert_allclose(surface.y, distance * expected_m / expected_n)
+    assert_allclose(rays.x, 15.0 * expected_l / expected_n)
+    assert_allclose(rays.y, 15.0 * expected_m / expected_n)
+
+
+@pytest.mark.parametrize("index", [1.0, 1.5], ids=["air", "immersion"])
+@pytest.mark.parametrize("vignetted", [False, True])
+def test_pupil_sampling_and_vignetting_preserve_slopes(
+    set_test_backend: None, index: float, vignetted: bool
+) -> None:
+    """Chief, interior and cardinal pupils scale slope, not numerical aperture."""
+    na = 0.6
+    optic = _plane_optic(IdealMaterial(index), be.array([na]) if vignetted else na)
+    vx, vy = (0.2, 0.4) if vignetted else (0.0, 0.0)
+    for field in optic.fields:
+        field.vx, field.vy = vx, vy
+    px = np.array([0.0, 0.3, 1.0, -1.0, 0.0, 0.0])
+    py = np.array([0.0, -0.4, 0.0, 0.0, 1.0, -1.0])
+    x, y, z, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.full(6, 0.3), be.full(6, 0.4)),
+        be.full(6, 0.55),
+        (be.array(px), be.array(py)),
+    )
+
+    marginal_slope = math.tan(math.asin(na / index))
+    slope_x = px * (1 - vx) * marginal_slope
+    slope_y = py * (1 - vy) * marginal_slope
+    expected_n = 1 / np.sqrt(1 + slope_x**2 + slope_y**2)
+    assert_allclose(x, 0.6)
+    assert_allclose(y, 0.8)
+    assert_allclose(z, optic.object_surface.geometry.cs.z)
+    assert_allclose(L / N, slope_x, rtol=1e-10, atol=1e-12)
+    assert_allclose(M / N, slope_y, rtol=1e-10, atol=1e-12)
+    assert_allclose(L, slope_x * expected_n)
+    assert_allclose(M, slope_y * expected_n)
+    assert_allclose(N, expected_n)
+    assert_allclose(L**2 + M**2 + N**2, 1.0)
+    interior_na = index * be.sqrt(L[1] ** 2 + M[1] ** 2)
+    linear_na = na * math.hypot(px[1] * (1 - vx), py[1] * (1 - vy))
+    assert not np.isclose(be.to_numpy(interior_na), linear_na, rtol=1e-3)
+
+
+def test_launch_uses_object_medium_not_first_surface_post_medium(
+    set_test_backend: None,
+) -> None:
+    """Launch NA belongs to the incident object medium, before any refraction."""
+    optic = _plane_optic(IdealMaterial(1.5))
+    optic.updater.set_material(IdealMaterial(2.0), 1)
+    _, _, _, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.zeros(2), be.zeros(2)),
+        be.full(2, 0.55),
+        (be.array([1.0, 0.0]), be.array([0.0, -1.0])),
+    )
+
+    assert_allclose(optic.object_surface.material_post.n(0.55), 1.5)
+    assert_allclose(optic.surfaces[1].material_post.n(0.55), 2.0)
+    assert_allclose(L, [0.4, 0.0])
+    assert_allclose(M, [0.0, -0.4])
+    assert_allclose(N, math.sqrt(1 - 0.4**2))
+    assert_allclose(1.5 * be.sqrt(L**2 + M**2), 0.6)
+
+
+def test_launch_uses_primary_wavelength_not_requested_wavelength(
+    set_test_backend: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dispersive object medium defines launch NA at the primary wavelength."""
+    material = IdealMaterial(1.5)
+
+    def refractive_index(wavelength: "ScalarOrArray") -> "ScalarOrArray":
+        """Separate the primary index 1.5 from the requested-ray index 1.7."""
+        return 1.5 + 2.0 * (wavelength - 0.55)
+
+    index_lookup = Mock(side_effect=refractive_index)
+    monkeypatch.setattr(material, "n", index_lookup)
+    optic = _plane_optic(material)
+    _, _, _, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.zeros(2), be.zeros(2)),
+        be.full(2, 0.65),
+        (be.array([1.0, 0.0]), be.array([0.0, 1.0])),
+    )
+
+    index_lookup.assert_called_once_with(0.55)
+    assert_allclose(L, [0.4, 0.0])
+    assert_allclose(M, [0.0, 0.4])
+    assert_allclose(N, math.sqrt(1 - 0.4**2))
+    assert_allclose(1.5 * be.sqrt(L**2 + M**2), 0.6)
+
+
+def test_torch_na_and_index_gradients_for_chief_interior_and_marginal(
+    set_test_backend: None,
+) -> None:
+    """Fresh direct launches retain analytical NA/index derivatives in normal mode."""
+    if be.get_backend() != "torch":
+        pytest.skip("Autograd requires the torch backend.")
+    import torch
+
+    na = torch.tensor(0.6, dtype=torch.float64, requires_grad=True)
+    index = torch.tensor([1.5], dtype=torch.float64, requires_grad=True)
+    material = IdealMaterial(1.5)
+    # Install the parameter before the first material lookup, avoiding issue #794.
+    material.index = index
+    optic = _plane_optic(material, na)
+    aimer = ParaxialRayAimer(optic)
+    px = np.array([0.0, 0.3, 1.0])
+    py = np.array([0.0, -0.4, 0.0])
+
+    # Differentiate the unit vector (px*t, py*t, 1), t = NA/sqrt(n^2 - NA^2).
+    t = 0.6 / math.sqrt(1.5**2 - 0.6**2)
+    radius_squared = px**2 + py**2
+    denominator = (1 + radius_squared * t**2) ** 1.5
+    direction_dt = np.array([px, py, -radius_squared * t]) / denominator
+    dt_dna = 1.5**2 / (1.5**2 - 0.6**2) ** 1.5
+    dt_dn = -0.6 * 1.5 / (1.5**2 - 0.6**2) ** 1.5
+
+    for _ in range(2):
+        _, _, _, L, M, N = aimer.aim_rays(
+            (be.zeros(3), be.zeros(3)),
+            be.full(3, 0.55),
+            (be.array(px), be.array(py)),
+        )
+        components = torch.stack((L, M, N)).flatten()
+        for i, component in enumerate(components):
+            grad_na, grad_index = torch.autograd.grad(
+                component, (na, index), retain_graph=i < len(components) - 1
+            )
+            derivative = direction_dt.flat[i]
+            assert_allclose(grad_na, derivative * dt_dna, rtol=1e-10, atol=1e-12)
+            assert_allclose(grad_index, derivative * dt_dn, rtol=1e-10, atol=1e-12)
+
+
+def test_float_by_stop_retains_legacy_telecentric_slope(
+    set_test_backend: None,
+) -> None:
+    """Positive sub-unit FloatByStop values retain the legacy index-free slope."""
+    optic = _plane_optic(IdealMaterial(1.5))
+    optic.set_aperture("float_by_stop_size", 0.6)
+    px = be.array([0.0, 0.3, 1.0])
+    py = be.array([0.0, -0.4, 0.0])
+    _, _, _, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.zeros(3), be.zeros(3)), be.full(3, 0.55), (px, py)
+    )
+
+    legacy_slope = 0.6 / math.sqrt(1 - 0.6**2)
+    assert_allclose(L / N, px * legacy_slope)
+    assert_allclose(M / N, py * legacy_slope)
+    assert_allclose(L**2 + M**2 + N**2, 1.0)
+    assert_allclose(L[2], 0.6)
+    assert_allclose(N[2], 0.8)
+
+
+def test_zero_object_na_launches_finite_axial_rays(set_test_backend: None) -> None:
+    """Zero NA naturally collapses chief and nonchief pupils onto the +z axis."""
+    optic = _plane_optic(IdealMaterial(1.5), 0.0)
+    x, y, z, L, M, N = ParaxialRayAimer(optic).aim_rays(
+        (be.zeros(3), be.ones(3)),
+        be.full(3, 0.55),
+        (be.array([0.0, 0.3, 1.0]), be.array([0.0, -0.4, 0.0])),
+    )
+
+    for value in (x, y, z, L, M, N):
+        assert np.isfinite(be.to_numpy(value)).all()
+    assert_allclose(x, 0.0)
+    assert_allclose(y, 2.0)
+    assert_allclose(L, 0.0)
+    assert_allclose(M, 0.0)
+    assert_allclose(N, 1.0)


### PR DESCRIPTION
Fixes https://github.com/optiland/optiland/issues/797

**Problem**
The paraxial telecentric branch treats `objectNA` as `sin(theta)`, omitting
the object-medium index. At `n=1.5`, requested NA `0.6` produces physical NA
`0.9`; valid immersion NA `1.2` produces NaN launch directions. The ordinary
ObjectNA aperture conversion already includes the medium index.

**Correction**
`ObjectNAAperture.object_space_sine()` supplies the shared `NA / n_object`
conversion for EPD and telecentric launches, using the actual object-side
material at a reference wavelength defaulting to the primary one. For
`s = NA / n_object`, the launch normalizes:

```text
(Px * vx * s, Py * vy * s, sqrt(1 - s*s))
```

This preserves slope-based pupil sampling and vignetting without constructing
an artificial target at `1/s`. Zero NA naturally produces finite axial rays.

The helper requires a single finite positive index and a single finite NA
satisfying `0 <= NA < n`. Singleton shapes normalize to a zero-dimensional
backend array, preserving gradients. The abstract aperture `value` annotation
now accommodates ObjectNA's scalar-or-array values without changing its runtime
behavior or sibling aperture implementations.

Floating input precision is preserved before validation. An untyped value uses
its floating counterpart's dtype, or configured precision if neither provides
one. This prevents float32 configuration from rounding a valid NA up to a
float64 index. Native Torch tensors retain their device and autograd connection;
other host dtypes retain normal backend conversion.

**Compatibility**
Validation now also applies to ordinary EPD calculations: invalid parameters
raise `ValueError` instead of propagating unusable values. Aperture construction
remains lazy. Singleton EPD results can normalize from `(1,)` or `(1, 1)` to `()`.
The EPD formula, wavelength convention, serialization schema, and scaling
behavior are unchanged. Numerical parity was checked on the homogeneous
controls, mixed-precision cases, and the shipped `UVProjectionLens` sample;
this is not a blanket bit-identity claim for every dtype or geometry.

Existing field/aperture compatibility and +z-entry checks remain in place.
FloatByStop behavior is unchanged. No shared aiming-initialization machinery
or validation before every cached result/explicit guess is introduced.

**Coverage**
- Public air/immersion traces with physical-NA and analytic propagation checks.
- Chief, interior, cardinal, and vignetted pupils with slope-based sampling.
- Actual object-medium selection and default/overridden reference wavelengths.
- Invalid values, missing object, scalar and mixed singleton shapes.
- Float32 backend with float64 parameters, including valid near-grazing cones
  and both typed/untyped operand orderings; integer host input compatibility.
- Analytical NA/index derivatives through the helper and fresh direct launches.
- Zero NA and unchanged FloatByStop controls.

Both telecentric flags are explicitly synchronized in the tests. Trainable
material parameters are installed before the first lookup, avoiding dependency
on the separate state and material-cache fixes.

**Current Validation**
```text
python -m pytest -q --tb=short tests/test_telecentric_object_na.py
85 passed, 3 skipped

python -m pytest -q --tb=short tests/test_telecentric_object_na.py tests/test_aperture.py tests/test_rays.py tests/test_ray_aiming_initialization.py tests/test_paraxial.py tests/regression
2367 passed, 4 skipped

python -m pytest -q --tb=short tests/test_ray_aiming.py
188 passed, 1 skipped, 5 pre-existing failures

python -m ruff check --no-cache .
python -m ruff format --check --no-cache .
git diff --check
```

The five failures are NumPy 2.5.3 `float(array)` conversions at
`tests/test_ray_aiming.py:374` (two cases) and `:465` (three cases), raising
`TypeError: only 0-dimensional arrays can be converted to Python scalars`.
The same five failures were reproduced with the original upstream launch
method; this PR does not change those tests or the FloatByStop EPD path.

The exact issue reproducer passes on NumPy and Torch CPU. Golden fixtures and
mathematical tolerances are unchanged; existing material/Torch warnings remain
visible. Independent review exercised precision boundaries, gradient behavior,
sample EPD parity, and serialization.

**Scope**
Two commits: the launch correction, then shared conversion and validation.
Standalone on upstream `master` at
`7df37590c2d561d95403dc264e27b8b9a77ee879`, without other pending fixes.
Iterative/robust reference-radius initialization, FloatByStop dimensional
semantics, arbitrary entry frames, and validation ordering across guesses and
caches remain separate work. Gradient coverage concerns the shared conversion
and direct launches, not complete numerical-aimer differentiation.

Environment: Windows, Python 3.14.2, NumPy 2.5.3, Torch 2.13.0 CPU,
pytest 9.1.1. The global suite and accelerator execution were not tested.
