### PR TITLE
Keep material caches and Abbe predictions consistent with live parameters

### DIFF
--- a/docs/api/api_materials.rst
+++ b/docs/api/api_materials.rst
@@ -69,10 +69,44 @@ User YAML files must follow the `refractiveindex.info <https://refractiveindex.i
 format.  Files placed under ``~/.optiland/catalogs/<catalog_name>/`` are
 auto-discovered on the first registry access.
 
+Evaluation and Caching
+----------------------
+
+All optical material classes implement the
+:class:`~optiland.materials.base.BaseMaterial` property interface. Surface groups,
+interaction models, propagation, thin-film calculations and the nonsequential
+material adapter query ``n`` and ``k``. Those consumers retain responsibility for
+ray transport and attenuation; materials report optical properties.
+
+``BaseMaterial`` shares one evaluation/cache path between ``n`` and ``k``. Cache
+validity includes the wavelength values, shape and dtype, backend execution
+context, keyword arguments and optical state. Ideal and file/catalog materials
+track their live parameter arrays; changing a parameter invalidates old results.
+Their calculations convert parameters for the active backend without replacing
+the original arrays, preserving existing Torch parameter identity and gradients.
+
+Each concrete custom material opts into caching by implementing ``_cache_state``.
+An immutable model may return ``()``. A mutable model can use
+``self._state_key((self.parameter, ...))`` for all numerical state used by its
+calculations. Return ``None`` for untracked state or trainable parameters.
+Subclasses that add behavior must explicitly implement the hook even when their
+parent implements it. Without that hook, material evaluation remains supported
+and executes afresh. Keep the numerical implementation in ``_calculate_n/k``;
+do not duplicate cache handling in the public methods.
+
+Caller-owned wavelength buffers are inspected on every lookup. A NumPy alias can
+modify Torch storage without incrementing its version, and inference tensors can
+also be changed in place. Content checking is therefore O(N), including on cache
+hits. Uniform, non-trainable queries still evaluate one wavelength and return a
+broadcast result; trainable queries retain elementwise evaluation so every
+wavelength receives its own derivative. Cached constants are bypassed before
+lookup when an input or tracked parameter requires a fresh gradient graph.
+
 .. autosummary::
    :toctree: materials/
    :caption: Material Modules
 
+   materials.base
    materials.abbe
    materials.ideal
    materials.material_file

--- a/docs/api/api_materials.rst
+++ b/docs/api/api_materials.rst
@@ -22,6 +22,28 @@ This approach allows for accurate refractive index prediction across the visible
 
 For a detailed walkthrough of the model derivation and validation, please refer to the :doc:`Abbe Material Model Building <../references/AbbeMaterial_Model_Building>` notebook.
 
+Parameter Ownership
+~~~~~~~~~~~~~~~~~~~
+
+``AbbeMaterial`` selects the d-line polynomial or Buchdahl model;
+``AbbeMaterialE`` selects the e-line Buchdahl model. Importers and glass
+optimization workflows construct these wrappers when index/Abbe data is the
+available description. Tracing, plotting and native persistence use the same
+material interface as other optical materials.
+
+The selected model owns the live ``index`` and ``abbe`` arrays. The wrapper's
+properties expose those exact arrays, so assignment or in-place mutation through
+either object changes the same optical parameters. Serialization reads those
+parameters. A small internal mixin shares this delegation between the two
+wrappers; it implements no dispersion equations and is not a material type.
+
+The prediction models own the fitted equations and reference-line conventions.
+Each fresh prediction recomputes the small derived coefficient vector from the
+current parameters, retaining fresh Torch graphs after backward or a ``no_grad``
+query. The polynomial model loads its fixed fit matrix once on construction.
+The material cache tracks model inputs and fitted constants, rather than treating
+previously computed coefficients as independent optical inputs.
+
 Catalog-Scoped Lookup
 ---------------------
 
@@ -80,7 +102,7 @@ ray transport and attenuation; materials report optical properties.
 
 ``BaseMaterial`` shares one evaluation/cache path between ``n`` and ``k``. Cache
 validity includes the wavelength values, shape and dtype, backend execution
-context, keyword arguments and optical state. Ideal and file/catalog materials
+context, keyword arguments and optical state. Ideal, Abbe and file/catalog materials
 track their live parameter arrays; changing a parameter invalidates old results.
 Their calculations convert parameters for the active backend without replacing
 the original arrays, preserving existing Torch parameter identity and gradients.

--- a/docs/api/materials/materials.base.rst
+++ b/docs/api/materials/materials.base.rst
@@ -1,0 +1,10 @@
+materials.base
+==============
+
+.. automodule:: materials.base
+
+   .. rubric:: Classes
+
+   .. autosummary::
+
+      BaseMaterial

--- a/optiland/materials/abbe.py
+++ b/optiland/materials/abbe.py
@@ -17,6 +17,8 @@ import warnings
 from abc import ABC, abstractmethod
 from importlib import resources
 
+import numpy as np
+
 import optiland.backend as be
 from optiland.materials.base import BaseMaterial
 
@@ -45,13 +47,26 @@ class AbbePolynomialModel(AbbeModel):
     def __init__(self, index: float, abbe: float):
         self.index = be.array([index])
         self.abbe = be.array([abbe])
+        coefficients_file = resources.files("optiland.database").joinpath(
+            "glass_model_coefficients.npy"
+        )
+        self._fit_coefficients = np.load(str(coefficients_file))
         self._p = self._get_coefficients()
+
+    def _cache_state(self) -> tuple | None:
+        """Track the parameters and fixed polynomial fit used by the wrapper."""
+        return BaseMaterial._state_key(
+            ("polynomial", self.index, self.abbe, self._fit_coefficients)
+        )
 
     def predict_n(self, wavelength: float | be.ndarray) -> float | be.ndarray:
         wavelength = be.array(wavelength)
         if be.any(wavelength < 0.380) or be.any(wavelength > 0.750):
             # This legacy check is preserved
             raise ValueError("Wavelength out of range for this model.")
+        # Recompute the small coefficient vector from live parameters. A stored
+        # derived graph cannot be reused after backward or a parameter update.
+        self._p = self._get_coefficients()
         return be.atleast_1d(be.polyval(self._p, wavelength))
 
     def predict_k(self, wavelength: float | be.ndarray) -> float | be.ndarray:
@@ -59,25 +74,22 @@ class AbbePolynomialModel(AbbeModel):
 
     def _get_coefficients(self):
         # Polynomial fit to the refractive index data
+        index = BaseMaterial._as_backend_array(self.index)
+        abbe = BaseMaterial._as_backend_array(self.abbe)
         X_poly = be.ravel(
             be.array(
                 [
-                    self.index,
-                    self.abbe,
-                    self.index**2,
-                    self.abbe**2,
-                    self.index**3,
-                    self.abbe**3,
+                    index,
+                    abbe,
+                    index**2,
+                    abbe**2,
+                    index**3,
+                    abbe**3,
                 ]
             )
         )
 
-        coefficients_file = str(
-            resources.files("optiland.database").joinpath(
-                "glass_model_coefficients.npy",
-            ),
-        )
-        coefficients = be.load(coefficients_file)
+        coefficients = BaseMaterial._as_backend_array(self._fit_coefficients)
         return be.matmul(X_poly, coefficients)
 
 
@@ -90,6 +102,21 @@ class BuchdahlModel(AbbeModel):
         self.index = be.array([index])
         self.abbe = be.array([abbe])
         self.v1, self.v2, self.v3 = self._calculate_buchdahl_coefficients()
+
+    def _cache_state(self) -> tuple | None:
+        """Track reference convention, live inputs and configurable fitted constants."""
+        return BaseMaterial._state_key(
+            (
+                "buchdahl",
+                self.index,
+                self.abbe,
+                self.WAVE_REF,
+                self.ALPHA,
+                getattr(self, "V1_COEFFS", None),
+                getattr(self, "V2_COEFFS", None),
+                getattr(self, "V3_COEFFS", None),
+            )
+        )
 
     @property
     @abstractmethod
@@ -104,6 +131,7 @@ class BuchdahlModel(AbbeModel):
 
     def predict_n(self, wavelength: float | be.ndarray) -> float | be.ndarray:
         wavelength = be.array(wavelength)
+        self.v1, self.v2, self.v3 = self._calculate_buchdahl_coefficients()
 
         # Calculate Buchdahl coordinate omega
         # omega = (lambda - lambda_d) / (1 + alpha * (lambda - lambda_d))
@@ -112,7 +140,10 @@ class BuchdahlModel(AbbeModel):
 
         # Buchdahl polynomial: n = nd + v1*w + v2*w^2 + v3*w^3
         n_pred = (
-            self.index + self.v1 * omega + self.v2 * (omega**2) + self.v3 * (omega**3)
+            BaseMaterial._as_backend_array(self.index)
+            + self.v1 * omega
+            + self.v2 * (omega**2)
+            + self.v3 * (omega**3)
         )
 
         return be.atleast_1d(n_pred)
@@ -155,8 +186,8 @@ class BuchdahlDModel(BuchdahlModel):
     ]
 
     def _calculate_buchdahl_coefficients(self):
-        nd = self.index
-        vd = self.abbe
+        nd = BaseMaterial._as_backend_array(self.index)
+        vd = BaseMaterial._as_backend_array(self.abbe)
         inv_v = 1.0 / vd
         inv_v2 = 1.0 / (vd**2)
         nd_sq = nd**2
@@ -193,8 +224,8 @@ class BuchdahlEModel(BuchdahlModel):
     WAVE_REF = 0.546074
 
     def _calculate_buchdahl_coefficients(self):
-        ne = self.index
-        ve = self.abbe
+        ne = BaseMaterial._as_backend_array(self.index)
+        ve = BaseMaterial._as_backend_array(self.abbe)
 
         inv_v = 1.0 / ve
         inv_v2 = 1.0 / (ve**2)
@@ -229,7 +260,48 @@ class BuchdahlEModel(BuchdahlModel):
         return v1, v2, v3
 
 
-class AbbeMaterial(BaseMaterial):
+class _AbbeMaterialParameters:
+    """Expose model-owned parameters identically through both public wrappers."""
+
+    model: AbbeModel
+
+    @property
+    def index(self):
+        """The model's live reference-line refractive index."""
+        return self.model.index
+
+    @index.setter
+    def index(self, value):
+        self.model.index = value
+
+    @property
+    def abbe(self):
+        """The model's live Abbe number in its reference-line convention."""
+        return self.model.abbe
+
+    @abbe.setter
+    def abbe(self, value):
+        self.model.abbe = value
+
+    def _model_cache_state(self) -> tuple | None:
+        if type(self.model) not in (
+            AbbePolynomialModel,
+            BuchdahlDModel,
+            BuchdahlEModel,
+        ):
+            return None
+        return self.model._cache_state()
+
+    def _calculate_n(self, wavelength, **kwargs):
+        """Evaluate the selected model from its authoritative parameters."""
+        return self.model.predict_n(wavelength)
+
+    def _calculate_k(self, wavelength, **kwargs):
+        """Evaluate extinction through the existing Abbe model contract."""
+        return self.model.predict_k(wavelength)
+
+
+class AbbeMaterial(_AbbeMaterialParameters, BaseMaterial):
     """Represents a material based on the refractive index and Abbe number.
 
     This class serves as a wrapper around specific model implementations.
@@ -253,8 +325,6 @@ class AbbeMaterial(BaseMaterial):
 
     def __init__(self, n, abbe, model=None):
         super().__init__()
-        self.index = be.array([n])
-        self.abbe = be.array([abbe])
 
         if model is None:
             warnings.warn(
@@ -279,13 +349,9 @@ class AbbeMaterial(BaseMaterial):
                 f"Unknown model: {model}. Valid options: 'polynomial', 'buchdahl'"
             )
 
-    def _calculate_n(self, wavelength, **kwargs):
-        """Returns the refractive index of the material."""
-        return self.model.predict_n(wavelength)
-
-    def _calculate_k(self, wavelength, **kwargs):
-        """Returns the extinction coefficient of the material."""
-        return self.model.predict_k(wavelength)
+    def _cache_state(self) -> tuple | None:
+        """Track the selected d-line model's authoritative parameters."""
+        return self._model_cache_state()
 
     def to_dict(self):
         """Returns a dictionary representation of the material."""
@@ -311,7 +377,7 @@ class AbbeMaterial(BaseMaterial):
         return cls(data["index"], data["abbe"], model=model)
 
 
-class AbbeMaterialE(BaseMaterial):
+class AbbeMaterialE(_AbbeMaterialParameters, BaseMaterial):
     """Represents a material based on the refractive index and Abbe number at e-line.
 
     This class uses a Buchdahl 3-term model fitted to e-line (546.07 nm) data.
@@ -329,17 +395,11 @@ class AbbeMaterialE(BaseMaterial):
 
     def __init__(self, n, abbe):
         super().__init__()
-        self.index = be.array([n])
-        self.abbe = be.array([abbe])
         self.model = BuchdahlEModel(n, abbe)
 
-    def _calculate_n(self, wavelength, **kwargs):
-        """Returns the refractive index of the material."""
-        return self.model.predict_n(wavelength)
-
-    def _calculate_k(self, wavelength, **kwargs):
-        """Returns the extinction coefficient of the material."""
-        return self.model.predict_k(wavelength)
+    def _cache_state(self) -> tuple | None:
+        """Track the e-line model's authoritative parameters."""
+        return self._model_cache_state()
 
     def to_dict(self):
         """Returns a dictionary representation of the material."""

--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -2,8 +2,8 @@
 
 This module defines the base class for materials. The base class provides
 methods to calculate the refractive index, extinction coefficient, and Abbe
-number of a material. Subclasses of BaseMaterial should implement the `n` and
-`k` methods to provide specific material properties.
+number of a material. Subclasses implement `_calculate_n` and `_calculate_k`;
+the public methods manage evaluation and optional caching.
 
 Kramer Harrison, 2024
 """
@@ -11,7 +11,7 @@ Kramer Harrison, 2024
 from __future__ import annotations
 
 import hashlib
-import weakref
+import math
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -25,13 +25,6 @@ try:
     import torch
 except (ImportError, ModuleNotFoundError):
     torch = None
-
-# Maps id(array) -> (weakref, cache_key, version_token) so the O(N) content
-# inspection in BaseMaterial._array_metadata_key (uniformity probe or content
-# hash) runs once per array object and is reused on later lookups. The weakref
-# callback evicts the entry when the array is collected, so a later array
-# reusing the same id() never reads a stale key.
-_ARRAY_DIGEST_CACHE: dict[int, tuple] = {}
 
 
 def _array_content_key(value, digest: bytes) -> tuple:
@@ -80,7 +73,7 @@ def _uniform_scalar(value) -> float | None:
         if np.all(array == first):
             return float(first)
         return None
-    except (TypeError, ValueError, RuntimeError):
+    except (IndexError, TypeError, ValueError, RuntimeError):
         return None
 
 
@@ -91,8 +84,8 @@ class BaseMaterial(ABC):
     refractive index (n) and extinction coefficient (k). It also provides a
     method to calculate the Abbe number.
 
-    Subclasses of BaseMaterial should implement the abstract methods `n` and
-    `k` to provide specific material properties.
+    Subclasses implement `_calculate_n` and `_calculate_k`. Result caching is
+    optional: override `_cache_state` only when all optical state can be tracked.
 
     Attributes:
         propagation_model: The model used to propagate rays through this
@@ -122,6 +115,7 @@ class BaseMaterial(ABC):
         """
         self._n_cache = {}
         self._k_cache = {}
+        self._cache_context = None
 
         if propagation_model is None:
             self.propagation_model = HomogeneousPropagation(self)
@@ -144,7 +138,7 @@ class BaseMaterial(ABC):
             return None
 
         try:
-            return int(np.prod(shape, dtype=np.int64))
+            return math.prod(shape)
         except Exception:
             return None
 
@@ -160,35 +154,20 @@ class BaseMaterial(ABC):
         return the previous array's refractive index -- a silent
         cross-wavelength leak (issue #630).
 
-        Hashing the bytes is O(N), so the digest is memoized per array object in
-        ``_ARRAY_DIGEST_CACHE``; repeated lookups of the same array (e.g. one
-        wavelength bundle traced through every surface) are amortized O(1). A
-        weakref callback drops the entry when the array dies, so id() reuse can
-        never surface a stale digest.
-
-        NumPy exposes no in-place-write counter, so an array is treated as
-        immutable for its lifetime (optiland never mutates wavelength buffers in
-        place). Torch tensors carry ``_version``, folded into the memoization
-        token so in-place edits invalidate the cached key.
+        Inspect caller-owned storage on every lookup. NumPy has no mutation
+        counter, Torch inference tensors are mutable without a version counter,
+        and writes through a NumPy alias do not increment a Torch version.
+        Identity/version memoization therefore cannot guarantee correctness.
 
         Constant arrays -- the overwhelmingly common case, since a ray bundle
         traced at one wavelength repeats that wavelength per ray -- are detected
         first and keyed by their single value, skipping the device-to-host copy
         and O(N) hash entirely while remaining content-addressed.
         """
-        oid = id(value)
-        try:
-            token = int(getattr(value, "_version", 0))
-        except RuntimeError:
-            # Torch inference tensors track no version counter; they are
-            # immutable by construction, so a constant token is correct.
-            token = -1
-        cached = _ARRAY_DIGEST_CACHE.get(oid)
-        if cached is not None:
-            ref, key, cached_token = cached
-            if ref() is value and cached_token == token:
-                return key
-
+        # Lists and tuples have no shape/dtype attributes. Normalize only the
+        # key input so nested and flat sequences cannot share a fingerprint.
+        if isinstance(value, (list, tuple)):
+            value = np.asarray(value)
         scalar = _uniform_scalar(value)
         if scalar is not None:
             key = _array_uniform_key(value, scalar)
@@ -197,17 +176,9 @@ class BaseMaterial(ABC):
                 array = value.detach().cpu().contiguous().numpy()
             else:  # numpy ndarray, list, or tuple
                 array = np.ascontiguousarray(np.asarray(value))
-            digest = hashlib.blake2b(array.tobytes(), digest_size=16).digest()
+            digest = hashlib.sha256(memoryview(array)).digest()
             key = _array_content_key(value, digest)
 
-        try:
-            ref = weakref.ref(
-                value, lambda _ref, _oid=oid: _ARRAY_DIGEST_CACHE.pop(_oid, None)
-            )
-        except TypeError:
-            ref = None  # e.g. list/tuple cannot be weak-referenced; skip memo
-        if ref is not None:
-            _ARRAY_DIGEST_CACHE[oid] = (ref, key, token)
         return key
 
     def _create_cache_key(self, wavelength: float | be.ndarray, **kwargs) -> tuple:
@@ -215,12 +186,74 @@ class BaseMaterial(ABC):
         if be.is_array_like(wavelength):
             size = self._array_size(wavelength)
             if size is not None and size <= self._MAX_VALUE_KEY_ARRAY_SIZE:
-                wavelength_key = tuple(np.ravel(be.to_numpy(wavelength)))
+                wavelength_key = (
+                    "array-values",
+                    tuple(np.ravel(be.to_numpy(wavelength))),
+                    tuple(wavelength.shape),
+                    str(wavelength.dtype),
+                    str(getattr(wavelength, "device", None)),
+                )
             else:
                 wavelength_key = self._array_metadata_key(wavelength)
         else:
-            wavelength_key = wavelength
-        return (wavelength_key,) + tuple(sorted(kwargs.items()))
+            wavelength_key = (type(wavelength), wavelength)
+        return (wavelength_key, self._state_key(tuple(sorted(kwargs.items()))))
+
+    def _cache_state(self) -> tuple | None:
+        """Return a hashable optical-state token, or None to disable caching.
+
+        An immutable model can return an empty tuple. Mutable models must include
+        every parameter affecting n/k, and return None while parameters require
+        gradients. `_state_key` fingerprints ordinary numerical data safely,
+        including arrays mutated through aliases. Unknown custom state defaults
+        to uncached evaluation; subclasses need not opt in to remain usable.
+        Each concrete subclass must explicitly override this hook, including
+        subclasses of built-in materials that might add optical state.
+        """
+        return None
+
+    @classmethod
+    def _state_key(cls, value) -> tuple | None:
+        """Fingerprint numerical state; unsupported or trainable data disables reuse."""
+        if cls._requires_grad(value):
+            return None
+        if isinstance(value, (tuple, list)):
+            items = []
+            for item in value:
+                key = cls._state_key(item)
+                if key is None:
+                    return None
+                items.append(key)
+            return tuple(items)
+        if isinstance(value, (str, int, float, bool, type(None))):
+            return (type(value), value)
+        if isinstance(value, np.ndarray) or (
+            torch is not None and isinstance(value, torch.Tensor)
+        ):
+            if cls._array_size(value) <= cls._MAX_VALUE_KEY_ARRAY_SIZE:
+                # Small live parameter arrays need a snapshot, not a uniformity
+                # reduction or digest. Copy bytes so subsequent alias writes
+                # cannot alter the stored state token.
+                array = be.to_numpy(value)
+                return _array_content_key(value, array.tobytes())
+            return cls._array_metadata_key(value)
+        return None
+
+    @staticmethod
+    def _backend_context() -> tuple:
+        """Identify result type, precision, device and backend-created gradients."""
+        backend = be.get_backend()
+        device = be.get_device() if backend == "torch" else "cpu"
+        gradients = be.grad_mode.requires_grad if backend == "torch" else False
+        inference = torch.is_inference_mode_enabled() if backend == "torch" else False
+        return backend, be.get_precision(), device, gradients, inference
+
+    @staticmethod
+    def _as_backend_array(value):
+        """Use live parameters in the active backend without replacing their storage."""
+        if be.get_backend() == "numpy" and hasattr(value, "detach"):
+            value = value.detach().cpu().numpy()
+        return be.asarray(value)
 
     @staticmethod
     def _requires_grad(value) -> bool:
@@ -286,13 +319,44 @@ class BaseMaterial(ABC):
         The expansion allocates no memory (stride-0 view), so a property
         evaluated once per wavelength serves bundles of any size for free.
         """
-        if torch is not None and isinstance(wavelength, torch.Tensor):
-            if not isinstance(value, torch.Tensor):
-                value = torch.as_tensor(
-                    value, dtype=wavelength.dtype, device=wavelength.device
-                )
-            return value.reshape(1).expand(tuple(wavelength.shape))
+        if torch is not None and isinstance(value, torch.Tensor):
+            return value.reshape(1).expand(tuple(np.shape(wavelength)))
         return np.broadcast_to(np.asarray(value).reshape(1), np.shape(wavelength))
+
+    def _evaluate_property(self, property_name: str, wavelength, **kwargs):
+        """Evaluate n/k with one state-aware cache and fresh gradient graphs."""
+        calculate = getattr(self, f"_calculate_{property_name}")
+        if self._requires_grad(wavelength):
+            return self._compute_grad_aware(calculate, wavelength, **kwargs)
+        state = self._cache_state() if "_cache_state" in type(self).__dict__ else None
+        kwargs_state = self._state_key(tuple(sorted(kwargs.items())))
+        if state is None or kwargs_state is None:
+            self._n_cache.clear()
+            self._k_cache.clear()
+            self._cache_context = None
+            return self._compute_grad_aware(calculate, wavelength, **kwargs)
+
+        context = (self._backend_context(), state)
+        if context != self._cache_context:
+            self._n_cache.clear()
+            self._k_cache.clear()
+            self._cache_context = context
+
+        # Only non-trainable, tracked inputs reach cache lookup or reduction.
+        # Equal values do not imply equal derivatives for each query element.
+        cache = self._n_cache if property_name == "n" else self._k_cache
+        cache_key = self._create_cache_key(wavelength, **kwargs)
+        uniform = self._is_uniform_key(cache_key) and all(
+            value is None or np.isscalar(value) for value in kwargs.values()
+        )
+        if cache_key not in cache:
+            query = self._uniform_representative(wavelength) if uniform else wavelength
+            result = self._compute_grad_aware(calculate, query, **kwargs)
+            if self._requires_grad(result):
+                return self._broadcast_like(result, wavelength) if uniform else result
+            cache[cache_key] = self._detach_if_tensor(result)
+        result = cache[cache_key]
+        return self._broadcast_like(result, wavelength) if uniform else result
 
     def n(self, wavelength: float | be.ndarray, **kwargs) -> float | be.ndarray:
         """Calculates the refractive index at a given wavelength with caching.
@@ -305,32 +369,7 @@ class BaseMaterial(ABC):
         Returns:
             float | be.ndarray: The refractive index at the given wavelength(s).
         """
-        cache_key = self._create_cache_key(wavelength, **kwargs)
-        uniform = self._is_uniform_key(cache_key)
-
-        if cache_key in self._n_cache:
-            cached = self._n_cache[cache_key]
-            return self._broadcast_like(cached, wavelength) if uniform else cached
-
-        # A constant wavelength bundle is evaluated on a single element and
-        # broadcast back — the cache then holds one value per wavelength
-        # instead of one N-element array per bundle.
-        calc_wavelength = (
-            self._uniform_representative(wavelength) if uniform else wavelength
-        )
-        result = self._compute_grad_aware(self._calculate_n, calc_wavelength, **kwargs)
-
-        # If the result requires grad, it is connected to an optimization
-        # variable (e.g. the index itself is being optimized).  In that case
-        # we must NOT cache — every forward pass needs a fresh graph.
-        if self._requires_grad(result):
-            return self._broadcast_like(result, wavelength) if uniform else result
-
-        # Otherwise the value is a constant w.r.t. optimization variables.
-        # Detach before caching to avoid holding a stale computation graph.
-        self._n_cache[cache_key] = self._detach_if_tensor(result)
-        cached = self._n_cache[cache_key]
-        return self._broadcast_like(cached, wavelength) if uniform else cached
+        return self._evaluate_property("n", wavelength, **kwargs)
 
     def k(self, wavelength: float | be.ndarray, **kwargs) -> float | be.ndarray:
         """Calculates the extinction coefficient at a given wavelength with caching.
@@ -343,26 +382,7 @@ class BaseMaterial(ABC):
         Returns:
             float | be.ndarray: The extinction coefficient at the given wavelength(s).
         """
-        cache_key = self._create_cache_key(wavelength, **kwargs)
-        uniform = self._is_uniform_key(cache_key)
-
-        if cache_key in self._k_cache:
-            cached = self._k_cache[cache_key]
-            return self._broadcast_like(cached, wavelength) if uniform else cached
-
-        # Same constant-bundle strategy as n(): evaluate one element, cache
-        # the single value, broadcast a view to the bundle's shape.
-        calc_wavelength = (
-            self._uniform_representative(wavelength) if uniform else wavelength
-        )
-        result = self._compute_grad_aware(self._calculate_k, calc_wavelength, **kwargs)
-        # Same logic as n(): skip cache if result is differentiable.
-        if self._requires_grad(result):
-            return self._broadcast_like(result, wavelength) if uniform else result
-
-        self._k_cache[cache_key] = self._detach_if_tensor(result)
-        cached = self._k_cache[cache_key]
-        return self._broadcast_like(cached, wavelength) if uniform else cached
+        return self._evaluate_property("k", wavelength, **kwargs)
 
     @abstractmethod
     def _calculate_n(

--- a/optiland/materials/ideal.py
+++ b/optiland/materials/ideal.py
@@ -39,6 +39,10 @@ class IdealMaterial(BaseMaterial):
         self.index = be.array([n])
         self.absorp = be.array([k])
 
+    def _cache_state(self) -> tuple | None:
+        """Track live index/extinction values, including in-place writes."""
+        return self._state_key((self.index, self.absorp))
+
     def _calculate_n(self, wavelength, **kwargs):
         """Returns the refractive index of the material.
 
@@ -55,8 +59,8 @@ class IdealMaterial(BaseMaterial):
         if be.is_array_like(wavelength) and be.size(wavelength) > 1:
             # ``be.full_like(w, value)`` reads the value out as a scalar and
             # detaches it; broadcasting keeps a trainable index attached.
-            return be.ones_like(wavelength) * self.index[0]
-        return self.index[0]
+            return be.ones_like(wavelength) * self._as_backend_array(self.index)[0]
+        return self._as_backend_array(self.index)[0]
 
     def _calculate_k(self, wavelength, **kwargs):
         """Returns the extinction coefficient of the material.
@@ -74,8 +78,8 @@ class IdealMaterial(BaseMaterial):
         if be.is_array_like(wavelength) and be.size(wavelength) > 1:
             # Broadcast (rather than full_like) to keep a trainable extinction
             # coefficient attached to the autograd graph.
-            return be.ones_like(wavelength) * self.absorp[0]
-        return self.absorp[0]
+            return be.ones_like(wavelength) * self._as_backend_array(self.absorp)[0]
+        return self._as_backend_array(self.absorp)[0]
 
     def to_dict(self):
         """Returns a dictionary representation of the material.

--- a/optiland/materials/material.py
+++ b/optiland/materials/material.py
@@ -97,6 +97,10 @@ class Material(MaterialFile):
         file, self.material_data = self._retrieve_file()
         super().__init__(file, propagation_model=propagation_model)
 
+    def _cache_state(self) -> tuple | None:
+        """Track the resolved file's optical state; labels do not affect n/k."""
+        return super()._cache_state()
+
     @classmethod
     def _load_dataframe(cls):
         """Load the catalog DataFrame (delegates to MaterialRegistry)."""

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -79,6 +79,33 @@ class MaterialFile(BaseMaterial):
         data = self._read_file()
         self._parse_file(data)
 
+    def _cache_state(self) -> tuple | None:
+        """Track the live optical arrays used by file and catalog materials."""
+        if not isinstance(self._n_formula, str):
+            return None
+        method_name = (
+            "_" + self._n_formula.replace(" ", "_")
+            if self._n_formula.startswith("formula ")
+            else "_tabulated_n"
+        )
+        formula = self.formula_map.get(self._n_formula)
+        if getattr(formula, "__func__", None) is not getattr(
+            MaterialFile, method_name, None
+        ):
+            return None  # A custom callable may depend on untracked mutable state.
+        return self._state_key(
+            (
+                self._n_formula,
+                self.coefficients,
+                self.thermdispcoef,
+                self._t0,
+                self._n_wavelength,
+                self._n,
+                self._k_wavelength,
+                self._k,
+            )
+        )
+
     def _calculate_n(self, wavelength, **kwargs):
         """Calculates the refractive index of the material at given wavelengths.
 
@@ -103,7 +130,7 @@ class MaterialFile(BaseMaterial):
         if (
             temperature is not None
             and self._t0 is not None
-            and be.any(be.array(self.thermdispcoef))
+            and be.any(self._as_backend_array(self.thermdispcoef))
         ):
             pressure = 1.0 if pressure is None else pressure
 
@@ -161,7 +188,7 @@ class MaterialFile(BaseMaterial):
         n_absolute_reference = base_relative_n * n_air_reference
 
         # Compute the change in the absolute index due to the temperature difference
-        c = self.thermdispcoef
+        c = self._as_backend_array(self.thermdispcoef)
         delta_t = temp_c - self._t0
 
         # This is the Schott formula for the change in absolute refractive index
@@ -245,7 +272,11 @@ class MaterialFile(BaseMaterial):
                 return be.zeros_like(wavelength)
             return 0.0
 
-        return be.interp(wavelength, self._k_wavelength, self._k)
+        return be.interp(
+            wavelength,
+            self._as_backend_array(self._k_wavelength),
+            self._as_backend_array(self._k),
+        )
 
     def _formula_1(self, w):
         """Calculate the refractive index using dispersion formula 1 from
@@ -258,7 +289,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = 1 + c[0]
             for k in range(1, len(c), 2):
@@ -278,7 +309,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = 1 + c[0]
             for k in range(1, len(c), 2):
@@ -298,7 +329,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = c[0]
             for k in range(1, len(c), 2):
@@ -318,7 +349,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = (
                 c[0]
@@ -342,7 +373,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = c[0]
             for k in range(1, len(c), 2):
@@ -362,7 +393,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = 1 + c[0]
             for k in range(1, len(c), 2):
@@ -382,7 +413,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         try:
             n = c[0] + c[1] / (w**2 - 0.028) + c[2] * (1 / (w**2 - 0.028)) ** 2
             for k in range(3, len(c)):
@@ -402,7 +433,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         if len(c) != 4:
             raise ValueError("Invalid coefficients for dispersion formula 8.")
 
@@ -420,7 +451,7 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: The refractive index(s) of the material.
 
         """
-        c = self.coefficients
+        c = self._as_backend_array(self.coefficients)
         if len(c) != 6:
             raise ValueError("Invalid coefficients for dispersion formula 9.")
 
@@ -437,7 +468,11 @@ class MaterialFile(BaseMaterial):
             float or be.ndarray: Interpolated refractive index(s).
         """
         try:
-            return be.interp(w, self._n_wavelength, self._n)
+            return be.interp(
+                w,
+                self._as_backend_array(self._n_wavelength),
+                self._as_backend_array(self._n),
+            )
         except ValueError as err:  # Typically if _n_wavelength or _n is None or empty
             raise ValueError(
                 "No tabular refractive index data found or data is invalid."

--- a/tests/test_abbe_parameter_state.py
+++ b/tests/test_abbe_parameter_state.py
@@ -1,0 +1,128 @@
+"""Abbe wrappers and derived coefficients must follow their live parameters."""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.materials import AbbeMaterial, AbbeMaterialE
+
+from .utils import assert_allclose
+
+
+def make_material(model, index=1.5, abbe=60.0):
+    if model == "e":
+        return AbbeMaterialE(index, abbe)
+    return AbbeMaterial(index, abbe, model=model)
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+def test_wrapper_and_model_share_parameter_storage(set_test_backend, model):
+    material = make_material(model)
+    assert material.index is material.model.index
+    assert material.abbe is material.model.abbe
+    material.index = be.asarray([1.6])
+    assert material.index is material.model.index
+    material.model.abbe = be.asarray([50.0])
+    assert material.abbe is material.model.abbe
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+@pytest.mark.parametrize("attribute,value", [("index", 1.7), ("abbe", 35.0)])
+@pytest.mark.parametrize("owner", ["wrapper", "model"])
+def test_in_place_parameter_changes_update_dispersion(
+    set_test_backend, model, attribute, value, owner
+):
+    material = make_material(model)
+    target = material if owner == "wrapper" else material.model
+    setattr(target, attribute, be.asarray([1.5 if attribute == "index" else 60.0]))
+    material.n(0.55)
+    getattr(target, attribute)[...] = value
+    expected = make_material(
+        model,
+        index=1.7 if attribute == "index" else 1.5,
+        abbe=35.0 if attribute == "abbe" else 60.0,
+    )
+    assert_allclose(material.n(0.55), expected.n(0.55))
+    restored = type(material).from_dict(material.to_dict())
+    assert_allclose(restored.n(0.55), material.n(0.55))
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+def test_direct_model_updates_derived_coefficients(set_test_backend, model):
+    prediction = make_material(model).model
+    prediction.index = be.asarray([1.5])
+    prediction.abbe = be.asarray([60.0])
+    prediction.predict_n(0.55)
+    prediction.abbe[...] = 35.0
+    expected = make_material(model, abbe=35.0).model.predict_n(0.55)
+    assert_allclose(prediction.predict_n(0.55), expected)
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_custom_model_tracks_additional_mutable_state(
+    set_test_backend, monkeypatch, model, property_name
+):
+    # Use numerical parameters so gradient bypass cannot hide unsafe cache reuse.
+    if be.get_backend() == "torch":
+        monkeypatch.setattr(be.grad_mode, "requires_grad", False)
+    material = make_material(model)
+    evaluate = getattr(material, property_name)
+    baseline = evaluate(0.55)
+
+    class OffsetModel(type(material.model)):
+        offset = 0.0
+
+        def predict_n(self, wavelength):
+            return super().predict_n(wavelength) + self.offset
+
+        def predict_k(self, wavelength):
+            return super().predict_k(wavelength) + self.offset
+
+    material.model = OffsetModel(1.5, 60.0)
+    for offset in (0.01, 0.02):
+        material.model.offset = offset
+        assert_allclose(evaluate(0.55), baseline + offset)
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+def test_repeated_parameter_backward_after_no_grad_query(set_test_backend, model):
+    if be.get_backend() != "torch":
+        pytest.skip("Torch gradients")
+    import torch
+
+    material = make_material(model)
+    parameter = torch.nn.Parameter(torch.tensor([1.5], dtype=torch.float64))
+    material.index = parameter
+    with torch.no_grad():
+        material.n(0.55)
+    for _ in range(2):
+        material.n(0.55).sum().backward()
+        step = 1e-5
+        upper = make_material(model, index=1.5 + step).n(0.55)
+        lower = make_material(model, index=1.5 - step).n(0.55)
+        assert_allclose(parameter.grad, (upper - lower) / (2 * step), rtol=1e-6)
+        parameter.grad = None
+
+
+@pytest.mark.parametrize("model", ["polynomial", "buchdahl", "e"])
+def test_abbe_parameters_follow_backend_and_precision(set_test_backend, model):
+    if "torch" not in be.list_available_backends():
+        pytest.skip("requires both backends")
+    import torch
+
+    material = make_material(model)
+    expected = be.to_numpy(material.n(0.55))
+    index = material.index
+    for backend, precision in (("numpy", "float32"), ("torch", "float64")):
+        be.set_backend(backend)
+        be.set_precision(precision)
+        if backend == "torch":
+            be.set_device("cpu")
+        result = material.n(0.55)
+        assert isinstance(result, torch.Tensor) == (backend == "torch")
+        assert_allclose(result, expected, rtol=1e-6)
+        assert material.index is index
+    be.set_backend("numpy")
+    be.set_precision("float64")

--- a/tests/test_material_cache_contracts.py
+++ b/tests/test_material_cache_contracts.py
@@ -1,0 +1,407 @@
+"""Material cache regressions across mutable data and execution contexts."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.materials import IdealMaterial, MaterialFile
+from optiland.materials.base import BaseMaterial
+
+from .utils import assert_allclose
+
+
+class SpectralMaterial(BaseMaterial):
+    """An immutable model with an independently known wavelength derivative."""
+
+    def _cache_state(self):
+        return ()
+
+    def _calculate_n(self, wavelength, **kwargs):
+        query = wavelength if hasattr(wavelength, "shape") else be.asarray(wavelength)
+        return 1.2 + 0.5 * query
+
+    def _calculate_k(self, wavelength, **kwargs):
+        query = wavelength if hasattr(wavelength, "shape") else be.asarray(wavelength)
+        return 0.01 * query
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_cache_preserves_query_shape(set_test_backend, property_name):
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    values = be.asarray([0.4, 0.5, 0.6, 0.7])
+    flat = evaluate(values)
+    matrix = evaluate(values.reshape(2, 2))
+    assert tuple(matrix.shape) == (2, 2)
+    assert_allclose(matrix.reshape(-1), flat)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_cache_preserves_query_dtype(set_test_backend, property_name):
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    if be.get_backend() == "torch":
+        import torch
+
+        wide = torch.tensor([0.5, 0.75], dtype=torch.float64)
+        narrow = wide.to(torch.float32)
+    else:
+        wide = np.array([0.5, 0.75], dtype=np.float64)
+        narrow = wide.astype(np.float32)
+    evaluate(wide)
+    assert evaluate(narrow).dtype == narrow.dtype
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_scalar_cache_follows_backend_precision(set_test_backend, property_name):
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    original_precision = be.get_precision()
+    try:
+        be.set_precision("float64")
+        wide = evaluate(0.5)
+        be.set_precision("float32")
+        narrow = evaluate(0.5)
+        assert wide.dtype != narrow.dtype
+        assert "32" in str(narrow.dtype)
+    finally:
+        be.set_precision(f"float{original_precision}")
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_scalar_cache_follows_backend(set_test_backend, property_name):
+    if "torch" not in be.list_available_backends():
+        pytest.skip("requires both backends")
+    import torch
+
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    be.set_backend("numpy")
+    assert not isinstance(evaluate(0.5), torch.Tensor)
+    be.set_backend("torch")
+    be.set_device("cpu")
+    assert isinstance(evaluate(0.5), torch.Tensor)
+    be.set_backend("numpy")
+    assert not isinstance(evaluate(0.5), torch.Tensor)
+
+
+@pytest.mark.parametrize("uniform", [True, False])
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_large_query_mutation(set_test_backend, uniform, property_name):
+    material = SpectralMaterial()
+    values = np.full(2048, 0.5) if uniform else np.linspace(0.4, 0.7, 2048)
+    query = be.asarray(values)
+    evaluate = getattr(material, property_name)
+    evaluate(query)
+    query[7] = 0.65
+    expected = 1.2 + 0.5 * query if property_name == "n" else 0.01 * query
+    assert_allclose(evaluate(query), expected)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_tensor_query_mutated_through_numpy_alias(set_test_backend, property_name):
+    if be.get_backend() != "torch":
+        pytest.skip("Torch/NumPy shared storage")
+    import torch
+
+    values = np.full(2048, 0.5)
+    query = torch.from_numpy(values)
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    evaluate(query)
+    values[7] = 0.65  # A foreign write does not increment tensor._version.
+    expected = 1.2 + 0.5 * query if property_name == "n" else 0.01 * query
+    assert_allclose(evaluate(query), expected)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_inference_tensor_mutation(set_test_backend, property_name):
+    if be.get_backend() != "torch":
+        pytest.skip("Torch inference tensors")
+    import torch
+
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    with torch.inference_mode():
+        query = torch.full((2048,), 0.5, dtype=torch.float64)
+        evaluate(query)
+        query[7] = 0.65
+        expected = 1.2 + 0.5 * query if property_name == "n" else 0.01 * query
+        assert_allclose(evaluate(query), expected)
+
+
+@pytest.mark.parametrize("property_name, derivative", [("n", 0.5), ("k", 0.01)])
+@pytest.mark.parametrize("size", [4, 2048])
+def test_cached_constant_then_trainable_query(
+    set_test_backend, property_name, derivative, size
+):
+    if be.get_backend() != "torch":
+        pytest.skip("Torch gradients")
+    import torch
+
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    query = torch.full((size,), 0.5, dtype=torch.float64)
+    evaluate(query)
+    query.requires_grad_()
+    for _ in range(2):
+        result = evaluate(query)
+        assert result.requires_grad
+        result.sum().backward()
+        assert_allclose(query.grad, np.full(size, derivative))
+        query.grad = None
+
+
+@pytest.mark.parametrize("property_name, attribute", [("n", "index"), ("k", "absorp")])
+def test_ideal_parameter_mutation(set_test_backend, property_name, attribute):
+    material = IdealMaterial(1.5, 0.01)
+    setattr(material, attribute, be.asarray([1.5 if property_name == "n" else 0.01]))
+    evaluate = getattr(material, property_name)
+    evaluate(0.5)
+    value = 1.7 if property_name == "n" else 0.02
+    getattr(material, attribute)[...] = value
+    assert_allclose(evaluate(0.5), value)
+
+
+@pytest.mark.parametrize("property_name, attribute", [("n", "index"), ("k", "absorp")])
+def test_cached_constant_then_trainable_parameter(
+    set_test_backend, property_name, attribute
+):
+    if be.get_backend() != "torch":
+        pytest.skip("Torch gradients")
+    import torch
+
+    material = IdealMaterial(1.5, 0.01)
+    parameter = torch.tensor([1.5], dtype=torch.float64)
+    setattr(material, attribute, parameter)
+    evaluate = getattr(material, property_name)
+    evaluate(0.5)
+    parameter.requires_grad_()
+    for _ in range(2):
+        evaluate(0.5).sum().backward()
+        assert_allclose(parameter.grad, [1.0])
+        parameter.grad = None
+
+
+def test_file_coefficient_mutation(set_test_backend, tmp_path):
+    path = tmp_path / "constant.yml"
+    path.write_text(
+        'DATA:\n- type: formula 5\n  wavelength_range: "0.4 0.7"\n'
+        '  coefficients: "1.5 0.1 2"\n',
+        encoding="utf-8",
+    )
+    material = MaterialFile(str(path))
+    material.coefficients = be.asarray([[1.5], [0.1], [2.0]])
+    material.n(0.5)
+    material.coefficients[0, 0] = 1.7
+    assert_allclose(material.n(0.5), 1.725)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_empty_sequence_queries_preserve_shape(set_test_backend, property_name):
+    evaluate = getattr(SpectralMaterial(), property_name)
+    for query, shape in (([], (0,)), ([[], []], (2, 0)), ([], (0,))):
+        for _ in range(2):
+            result = evaluate(query)
+            assert tuple(result.shape) == shape
+            assert be.to_numpy(result).size == 0
+    expected = 1.45 if property_name == "n" else 0.005
+    assert_allclose(evaluate(0.5), expected)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_cache_hook_can_delegate_to_uncached_default(set_test_backend, property_name):
+    class OptionalCacheMaterial(BaseMaterial):
+        cache_enabled = True
+        offset = 0.0
+
+        def _cache_state(self):
+            if self.cache_enabled:
+                return (self.offset,)
+            return super()._cache_state()
+
+        def _calculate_n(self, wavelength, **kwargs):
+            return 1.5 + self.offset
+
+        def _calculate_k(self, wavelength, **kwargs):
+            return 0.01 + self.offset
+
+    material = OptionalCacheMaterial()
+    evaluate = getattr(material, property_name)
+    baseline = 1.5 if property_name == "n" else 0.01
+    assert_allclose(evaluate(0.5), baseline)
+    material.cache_enabled = False
+    for offset in (0.1, 0.2):
+        material.offset = offset
+        assert_allclose(evaluate(0.5), baseline + offset)
+    material.cache_enabled = True
+    assert_allclose(evaluate(0.5), baseline + 0.2)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_mutable_mapping_environment_is_not_cached(set_test_backend, property_name):
+    class CalibratedMaterial(SpectralMaterial):
+        def _cache_state(self):
+            return ()
+
+        def _calculate_n(self, wavelength, **kwargs):
+            return super()._calculate_n(wavelength) + kwargs["calibration"]["offset"]
+
+        def _calculate_k(self, wavelength, **kwargs):
+            return super()._calculate_k(wavelength) + kwargs["calibration"]["offset"]
+
+    evaluate = getattr(CalibratedMaterial(), property_name)
+    calibration = {"offset": 0.0}
+    baseline = 1.45 if property_name == "n" else 0.005
+    assert_allclose(evaluate(0.5, calibration=calibration), baseline)
+    for offset in (0.1, 0.2):
+        calibration["offset"] = offset
+        assert_allclose(evaluate(0.5, calibration=calibration), baseline + offset)
+
+
+def test_extinction_only_file_tracks_live_table(set_test_backend, tmp_path):
+    path = tmp_path / "extinction.yml"
+    path.write_text(
+        "DATA:\n- type: tabulated k\n  data: |\n    0.4 0.01\n    0.6 0.03\n",
+        encoding="utf-8",
+    )
+    material = MaterialFile(str(path))
+    assert_allclose(material.k(0.5), 0.02)
+    material._k[...] = be.asarray([0.03, 0.05])
+    assert_allclose(material.k(0.5), 0.04)
+
+
+def test_custom_file_formula_tracks_closure_state(set_test_backend, tmp_path):
+    path = tmp_path / "constant.yml"
+    path.write_text(
+        'DATA:\n- type: formula 5\n  coefficients: "1.5"\n', encoding="utf-8"
+    )
+    material = MaterialFile(str(path))
+    material.coefficients = be.asarray([[1.5]])
+    original_formula = material.formula_map["formula 5"]
+    assert_allclose(material.n(0.5), 1.5)
+    calibration = {"offset": 0.1}
+
+    def calibrated_formula(wavelength):
+        return 1.5 + 0.1 * be.asarray(wavelength) + calibration["offset"]
+
+    material.formula_map["formula 5"] = calibrated_formula
+    assert_allclose(material.n(0.5), 1.65)
+    calibration["offset"] = 0.2
+    assert_allclose(material.n(0.5), 1.75)
+    material.formula_map["formula 5"] = original_formula
+    assert_allclose(material.n(0.5), 1.5)
+
+
+def test_untracked_custom_state_is_not_cached(set_test_backend):
+    class MutableMaterial(BaseMaterial):
+        index = 1.5
+
+        def _calculate_n(self, wavelength, **kwargs):
+            return self.index
+
+        def _calculate_k(self, wavelength, **kwargs):
+            return 0.0
+
+    material = MutableMaterial()
+    assert material.n(0.5) == 1.5
+    material.index = 1.7
+    assert material.n(0.5) == 1.7
+
+
+def test_builtin_subclass_must_track_its_additional_state(set_test_backend):
+    class OffsetMaterial(IdealMaterial):
+        offset = 0.0
+
+        def _calculate_n(self, wavelength, **kwargs):
+            return super()._calculate_n(wavelength, **kwargs) + self.offset
+
+    material = OffsetMaterial(1.5)
+    material.index = be.asarray([1.5])
+    material.absorp = be.asarray([0.0])
+    material.n(0.5)
+    material.offset = 0.2
+    assert_allclose(material.n(0.5), 1.7)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+def test_array_environment_and_gradients(set_test_backend, property_name):
+    class EnvironmentalMaterial(SpectralMaterial):
+        def _cache_state(self):
+            return ()
+
+        def _calculate_n(self, wavelength, **kwargs):
+            return super()._calculate_n(wavelength) + kwargs["temperature"] * 0.001
+
+        def _calculate_k(self, wavelength, **kwargs):
+            return super()._calculate_k(wavelength) + kwargs["temperature"] * 0.0001
+
+    material = EnvironmentalMaterial()
+    evaluate = getattr(material, property_name)
+    temperature = be.asarray([20.0, 25.0])
+    initial = evaluate(0.5, temperature=temperature)
+    temperature[0] = 30.0
+    updated = evaluate(0.5, temperature=temperature)
+    slope = 0.001 if property_name == "n" else 0.0001
+    assert_allclose(updated - initial, [10 * slope, 0.0])
+    waves = be.asarray(np.full(2048, 0.5))
+    temperatures = be.asarray(np.linspace(20.0, 30.0, 2048))
+    base = 1.45 if property_name == "n" else 0.005
+    assert_allclose(
+        evaluate(waves, temperature=temperatures), base + slope * temperatures
+    )
+    if be.get_backend() == "torch":
+        temperature.requires_grad_()
+        evaluate(0.5, temperature=temperature).sum().backward()
+        assert_allclose(temperature.grad, [slope, slope])
+
+
+@pytest.mark.parametrize("material_kind", ["ideal", "formula", "table"])
+def test_live_parameters_across_backend_changes(
+    set_test_backend, tmp_path, material_kind
+):
+    if "torch" not in be.list_available_backends():
+        pytest.skip("requires both backends")
+    import torch
+
+    initial_backend = be.get_backend()
+    if material_kind == "ideal":
+        material = IdealMaterial(1.5, 0.01)
+        parameter = material.index
+        expected = 1.5
+    else:
+        path = tmp_path / "sample.yml"
+        definition = (
+            'type: formula 5\n  coefficients: "1.5 0.1 2"\n'
+            if material_kind == "formula"
+            else "type: tabulated nk\n  data: |\n    0.4 1.5 0.01\n    0.6 1.6 0.02\n"
+        )
+        path.write_text("DATA:\n- " + definition, encoding="utf-8")
+        material = MaterialFile(str(path))
+        parameter = material.coefficients if material_kind == "formula" else material._n
+        expected = 1.525 if material_kind == "formula" else 1.55
+    assert_allclose(material.n(0.5), expected)
+    other_backend = "numpy" if initial_backend == "torch" else "torch"
+    for backend in (other_backend, initial_backend):
+        be.set_backend(backend)
+        if backend == "torch":
+            be.set_device("cpu")
+        be.set_precision("float64")
+        result = material.n(0.5)
+        assert isinstance(result, torch.Tensor) == (backend == "torch")
+        assert_allclose(result, expected)
+        current = (
+            material.index
+            if material_kind == "ideal"
+            else material.coefficients
+            if material_kind == "formula"
+            else material._n
+        )
+        assert current is parameter
+    # File tables use non-trainable asarray data; only existing trainable
+    # parameters promise an attached graph across a backend round trip.
+    if initial_backend == "torch" and parameter.requires_grad:
+        material.n(0.5).sum().backward()
+        assert parameter.grad is not None

--- a/tests/test_material_sequence_queries.py
+++ b/tests/test_material_sequence_queries.py
@@ -1,0 +1,44 @@
+"""Sequence queries keep the shape of the current call, including cache hits."""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.materials import IdealMaterial
+from tests.test_material_cache_contracts import SpectralMaterial
+from tests.utils import assert_allclose
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+@pytest.mark.parametrize("sequence", [list, tuple])
+def test_sequence_cache_distinguishes_flat_and_nested_queries(
+    set_test_backend, property_name, sequence
+):
+    material = SpectralMaterial()
+    evaluate = getattr(material, property_name)
+    flat = sequence([0.4, 0.5, 0.6, 0.7])
+    matrix = sequence([sequence([0.4, 0.5]), sequence([0.6, 0.7])])
+    expected = evaluate(be.asarray(matrix))
+    evaluate(flat)
+    for _ in range(2):
+        result = evaluate(matrix)
+        assert tuple(result.shape) == (2, 2)
+        assert_allclose(result, expected)
+
+
+@pytest.mark.parametrize("property_name", ["n", "k"])
+@pytest.mark.parametrize("sequence", [list, tuple])
+def test_uniform_sequence_query_is_broadcast_on_each_backend(
+    set_test_backend, property_name, sequence
+):
+    material = IdealMaterial(1.5, 0.01)
+    material.index = be.asarray([1.5])
+    material.absorp = be.asarray([0.01])
+    evaluate = getattr(material, property_name)
+    for shape in [sequence([0.55, 0.55]), sequence([sequence([0.55, 0.55])])]:
+        expected = evaluate(be.asarray(shape))
+        for _ in range(2):
+            result = evaluate(shape)
+            assert tuple(result.shape) == tuple(expected.shape)
+            assert_allclose(result, expected)

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -20,6 +20,9 @@ from .utils import assert_allclose
 class TestBaseMaterial:
     def test_caching(self, set_test_backend):
         class DummyMaterial(BaseMaterial):
+            def _cache_state(self):
+                return ()
+
             def _calculate_n(self, wavelength, **kwargs):
                 pass
 
@@ -67,11 +70,11 @@ class TestBaseMaterial:
         assert BaseMaterial._detach_if_tensor(1.5) == 1.5
         assert BaseMaterial._detach_if_tensor(None) is None
 
-    def test_large_array_cache_key_runtime_is_sublinear(self, set_test_backend):
-        """Regression guard for O(N) array cache-key construction.
+    def test_large_array_cache_key_avoids_python_scalar_overhead(self, set_test_backend):
+        """Bound Python overhead for large-array content checks.
 
-        Large wavelength arrays should use metadata-based keys rather than
-        materializing every array element into a Python tuple.
+        Mutable arrays require O(N) inspection on every lookup. A digest should
+        still cost much less than constructing a tuple of 200,000 Python scalars.
         """
 
         class DummyMaterial(BaseMaterial):
@@ -104,7 +107,7 @@ class TestBaseMaterial:
 
         ratio = large_avg_s / max(small_avg_s, 1e-9)
         assert ratio < 40.0, (
-            "Large-array cache-key generation appears to scale linearly with array size "
+            "Large-array content checks incur excessive per-element overhead "
             f"(ratio={ratio:.2f}, small_avg={small_avg_s:.3e}s, large_avg={large_avg_s:.3e}s)"
         )
 
@@ -167,14 +170,15 @@ class TestBaseMaterial:
 
         assert material._create_cache_key(a) != material._create_cache_key(b)
 
-    def test_large_array_digest_cache_evicts_dead_arrays(self, set_test_backend):
-        """#630: the per-array digest memo is weak -- entries are dropped when
-        the array is collected, so id() reuse cannot surface a stale digest and
-        the memo cannot grow without bound.
-        """
-        from optiland.materials.base import _ARRAY_DIGEST_CACHE
+    def test_large_array_cache_does_not_reuse_dead_array_content(self, set_test_backend):
+        """#630: recycled array addresses must never return an old optical value.
 
+        Content is re-inspected; no per-array identity memo is retained.
+        """
         class DummyMaterial(BaseMaterial):
+            def _cache_state(self):
+                return ()
+
             def _calculate_n(self, wavelength, **kwargs):
                 return float(np.asarray(wavelength)[1])
 
@@ -185,7 +189,6 @@ class TestBaseMaterial:
         n = 2_000
 
         gc.collect()
-        baseline = len(_ARRAY_DIGEST_CACHE)
         for i in range(50):
             arr = np.zeros(n, dtype=np.float64)
             # content (and so the expected n) differs each round; the +1 keeps
@@ -196,7 +199,7 @@ class TestBaseMaterial:
             gc.collect()  # free the buffer so the next array may reuse its address
 
         gc.collect()
-        assert len(_ARRAY_DIGEST_CACHE) <= baseline + 2
+        assert len(material._n_cache) == 50
 
     def test_large_array_key_handles_non_weakref_sequence(self, set_test_backend):
         """list/tuple wavelengths are content-addressed too, but cannot be
@@ -250,6 +253,9 @@ class TestUniformWavelengthFastPath:
     @staticmethod
     def _dispersive_dummy():
         class DummyMaterial(BaseMaterial):
+            def _cache_state(self):
+                return ()
+
             def _calculate_n(self, wavelength, **kwargs):
                 return 1.0 + 0.1 * wavelength**2
 
@@ -294,7 +300,7 @@ class TestUniformWavelengthFastPath:
 
     def test_inference_mode_does_not_crash(self, set_test_backend):
         """Torch inference tensors have no version counter; the cache-key
-        builder must treat them as immutable rather than raising."""
+        builder must inspect their content without raising."""
         if be.get_backend() != "torch":
             pytest.skip("torch-only regression")
         import torch


### PR DESCRIPTION
Material `n()`/`k()` cache hits can return results from an earlier parameter state, execution backend or wavelength shape. Warming an ideal material before installing a trainable parameter can return a detached constant. Abbe wrappers also own parameter arrays separately from their prediction models, so editing or saving a wrapper can describe different optics from its predictions.

Fixes #794.

The branch contains two focused commits: shared cache correctness, followed by Abbe parameter ownership. Both are based directly on upstream `master` at `b9127f76b7805c6bf572de7eca3d2b063eaa551a`.

### Changes

- Use one evaluation path for `n` and `k`, tracking the active backend, precision, device and supported material state before accepting a cached value.
- Preserve shape/dtype information for scalar, array and Python-sequence queries. Recheck caller-owned buffers so in-place edits and aliases cannot reuse stale fingerprints; preserve uniform-query broadcasting.
- Evaluate fresh graphs for trainable wavelength/material inputs, including transitions from previous numerical cache hits. Preserve the current trainable parameter storage and its gradient connection.
- Make the Abbe prediction model the single owner of index/Abbe arrays. Public wrapper attributes delegate to it, and derived coefficients follow current parameters on fresh predictions. Keep the existing polynomial/Buchdahl equations, d/e-line conventions and native JSON formats.
- Document cache responsibility, subclass opt-in and the wrapper/model ownership contract. Custom implementations without a complete state token continue evaluating without cached reuse.

Direct assignment and in-place edits remain supported for the existing public parameters; this change does not require an immutable-parameter migration.

### Validation and cost

The affected suite on this head passed **817 tests, with 14 skips**, covering material families, mutation/aliasing, sequence shapes, backend changes, fresh gradients, thermal/environment queries, propagation, file I/O and implicit differentiation. The focused cache/Abbe suite passed **127 tests, with 13 skips**. The new coverage cases run on both NumPy and Torch and check empty queries, explicit uncached hooks, mutable calibration arguments, extinction-only files, custom formula closures and custom Abbe model state. The Abbe extension tests use non-trainable parameters so gradient bypass cannot conceal stale cache reuse.

Local patch coverage under current Codecov exclusions is **147/147 changed executable lines (100%)**, covering all six lines previously flagged by Codecov. The coverage follow-up changes tests only; material equations, coverage settings and mathematical tolerances are unchanged. Ruff, formatting and `git diff --check` pass. The earlier material-package typing and focused API/ownership documentation checks also passed. Original correctness regressions were validated against failing implementations, fresh-material predictions, native reloads and finite-difference derivatives.

The coverage tests were validated in a separate commit, backed up, then folded into their cache and Abbe owner commits. The final two-commit tree exactly matches the validated tree.

Correctness adds state-inspection cost. The earlier CPU microbenchmark measured scalar cache hits increasing from about 2 microseconds to approximately 23 microseconds on NumPy and 36 microseconds on Torch. For 200,000-value uniform/nonuniform queries, the corrected path measured roughly 0.064/0.756 ms on NumPy and 0.220/0.950 ms on Torch. These are local measurements; checking mutable nonuniform buffers is O(N).
