### PR TITLE
Reject ideal-material absorption loss in Zemax and CODE V exports

### DIFF
--- a/docs/api/api_fileio.rst
+++ b/docs/api/api_fileio.rst
@@ -7,6 +7,12 @@ The ``optiland.fileio`` package handles saving and loading of optical systems.
 It supports the native Optiland JSON format, as well as Zemax (.zmx), CODE V (.seq), 
 and OSLO (.len) files.
 
+Zemax and CODE V export reject an ``IdealMaterial`` with nonzero extinction
+before opening the destination file, because their current glass encodings do
+not preserve that absorption. Save the native JSON format to retain it.
+The shared writer air classifier requires exactly unit index and zero extinction;
+a small refractive-index difference is still an optical property.
+
 .. autosummary::
    :toctree: generated
    :nosignatures:

--- a/optiland/fileio/codev/writer/formatter.py
+++ b/optiland/fileio/codev/writer/formatter.py
@@ -15,7 +15,12 @@ from typing import TYPE_CHECKING, Any
 import optiland.backend as be
 from optiland.fileio.codev.model import CodeVDataModel
 from optiland.fileio.codev.surfaces import get_handler_for_optiland_type
-from optiland.fileio.common import compute_abbe_number, field_type_string, is_air
+from optiland.fileio.common import (
+    compute_abbe_number,
+    field_type_string,
+    is_air,
+    reject_unsupported_ideal_absorption,
+)
 from optiland.materials.material import Material
 
 if TYPE_CHECKING:
@@ -267,6 +272,7 @@ class OpticToCodeVConverter:
         if is_reflective:
             return {"name": "REFL"}
 
+        reject_unsupported_ideal_absorption(mat)
         if is_air(mat):
             return None
 

--- a/optiland/fileio/common.py
+++ b/optiland/fileio/common.py
@@ -34,15 +34,24 @@ FIELD_CLASS_TO_TYPE: dict[str, str] = {
 
 
 def is_air(material: Any) -> bool:
-    """Return True if *material* represents air (n ~= 1.0, non-absorbing)."""
+    """Return True for exact unit index without extinction."""
     if material is None:
         return True
     if isinstance(material, str) and material.lower() in ("air", ""):
         return True
     if isinstance(material, IdealMaterial):
         n_val = float(be.atleast_1d(material.index)[0])
-        return abs(n_val - 1.0) < 1e-6
+        k_val = float(be.atleast_1d(material.absorp)[0])
+        return n_val == 1.0 and k_val == 0.0
     return False
+
+
+def reject_unsupported_ideal_absorption(material: Any) -> None:
+    """Fail before encoding an ideal material into a format that would lose k."""
+    if isinstance(material, IdealMaterial) and be.any(material.absorp != 0):
+        raise NotImplementedError(
+            "This writer cannot preserve ideal-material absorption; use native JSON"
+        )
 
 
 def field_type_string(optic: Optic) -> str:

--- a/optiland/fileio/zemax/writer/formatter.py
+++ b/optiland/fileio/zemax/writer/formatter.py
@@ -13,7 +13,13 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
-from optiland.fileio.common import WL_D, compute_abbe_number, field_type_string, is_air
+from optiland.fileio.common import (
+    WL_D,
+    compute_abbe_number,
+    field_type_string,
+    is_air,
+    reject_unsupported_ideal_absorption,
+)
 from optiland.fileio.zemax.model import ZemaxDataModel
 from optiland.fileio.zemax.surfaces import (
     CoordinateBreakSurfaceHandler,
@@ -323,6 +329,7 @@ class OpticToZemaxConverter:
         if is_reflective:
             return {"name": "MIRROR"}
 
+        reject_unsupported_ideal_absorption(mat)
         if is_air(mat):
             return None
 

--- a/tests/test_fileio/test_material_export_classification.py
+++ b/tests/test_fileio/test_material_export_classification.py
@@ -1,0 +1,37 @@
+"""Export must preserve index differences and fail before discarding absorption."""
+
+from __future__ import annotations
+
+import pytest
+
+from optiland.fileio import save_codev_file, save_zemax_file
+from optiland.fileio.common import is_air
+from optiland.materials import IdealMaterial
+from optiland.optic import Optic
+
+
+@pytest.mark.parametrize('index,extinction,expected', [
+    (1., 0., True), (1., .01, False), (1.5, .01, False),
+    (1.0000001, 0., False), (.9999999, 0., False),
+])
+def test_air_classification_keeps_index_and_extinction(index, extinction, expected, set_test_backend):
+    assert is_air(IdealMaterial(index, extinction)) is expected
+
+
+@pytest.mark.parametrize('writer', [save_zemax_file, save_codev_file])
+@pytest.mark.parametrize('index', [1., 1.5])
+def test_absorbing_ideal_export_preserves_existing_file(writer, index, tmp_path, set_test_backend):
+    optic = Optic()
+    optic.add_surface(index=0, radius=float('inf'), thickness=float('inf'))
+    optic.add_surface(index=1, radius=50, thickness=5, material=IdealMaterial(index, .01), is_stop=True)
+    optic.add_surface(index=2, radius=-50, thickness=50)
+    optic.add_surface(index=3, radius=float('inf'), thickness=0)
+    optic.set_aperture('EPD', 5)
+    optic.set_field_type('angle')
+    optic.add_field(y=0)
+    optic.add_wavelength(.55, is_primary=True)
+    path = tmp_path / 'existing.txt'
+    path.write_bytes(b'previous optical design')
+    with pytest.raises(NotImplementedError, match='absorption'):
+        writer(optic, path)
+    assert path.read_bytes() == b'previous optical design'


### PR DESCRIPTION
Zemax and CODE V export can silently remove absorption from an `IdealMaterial`. The shared air classifier ignores extinction and also rounds small nonzero differences from unit index away. An absorbing medium can therefore be exported as air or as glass without its extinction, while an existing destination is replaced.

Fixes #802.

Require exactly unit index and zero extinction for ideal air classification. Both writer converters now call a shared absorption check before glass encoding and before opening the destination. Unsupported ideal absorption raises `NotImplementedError` with a native-JSON alternative. Existing reflective-surface precedence and supported lossless exports are preserved. The file-I/O API documents the limitation.

### Validation

Fourteen regression cases failed before correction, covering NumPy/Torch, near-unit indices, absorbing ideal media at `n=1` and `n=1.5`, both writer formats and preservation of an existing destination. The final standalone writer/classification selection passed **129 tests**. Local patch coverage is **35/35 changed executable lines (100%)**, using unchanged Codecov policy. Ruff, formatting and whitespace checks pass.

This is one commit based directly on upstream `master` at `7df37590c2d561d95403dc264e27b8b9a77ee879`. It changes the current encoders' validation; it does not claim that the external formats can never represent absorption.
