### PR TITLE
Correct Kohlrausch air refractivity and validate array queries

### DIFF
--- a/docs/api/api_environment.rst
+++ b/docs/api/api_environment.rst
@@ -25,6 +25,20 @@ module under ``environment.models`` and can also be called directly.
    )
    n = refractive_index_air(0.55, conditions, model="ciddor")
 
+The Kohlrausch model uses the OpticStudio dry-air convention. Its pressure input
+is in pascals; the evaluator converts it to atmospheres before applying the
+reference-temperature scaling. Humidity and CO2 do not enter this model.
+At 0.55 µm it reproduces 1.00027308 at 20 °C / 101325 Pa and 1.00052810 at
+30 °C / 202650 Pa, to the precision published in the
+`Ansys worked example <https://optics.ansys.com/hc/en-us/articles/42661799783443-How-OpticStudio-calculates-refractive-index-at-arbitrary-temperatures-and-pressures>`_.
+The evaluator accepts NumPy/Torch wavelength and temperature arrays and preserves
+their gradients; other environmental models retain their own input contracts.
+It rejects non-finite or non-positive wavelengths consistently for scalar and
+array inputs, and rejects a non-positive temperature scaling denominator.
+Changing this formula
+does not switch the dispatcher's default model or connect global environment
+settings to material evaluation automatically.
+
 .. autosummary::
    :toctree: environment/
    :caption: Environment Modules

--- a/optiland/environment/models/kohlrausch.py
+++ b/optiland/environment/models/kohlrausch.py
@@ -20,7 +20,9 @@ Kramer Harrison, 2025
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import optiland.backend as be
 
 if TYPE_CHECKING:
     from ..conditions import EnvironmentalConditions
@@ -29,12 +31,12 @@ if TYPE_CHECKING:
 
 # Constants for the reference dispersion formula (n_ref), from Zemax documentation.
 # This is a Sellmeier-2 formula written as:
-# (n_ref - 1) * 10^5 = A + B / (C - σ²) + D / (E - σ²)
+# (n_ref - 1) * 10^8 = A + B / (C - σ²) + D / (E - σ²)
 # where σ = 1/λ is the wavenumber in μm⁻¹.
-DISP_A = 64.328
-DISP_B = 29498.1
+DISP_A = 6432.8
+DISP_B = 2949810.0
 DISP_C = 146.0  # In μm⁻²
-DISP_D = 25.54
+DISP_D = 25540.0
 DISP_E = 41.0  # In μm⁻²
 
 # Reference and scaling constants for the pressure/temperature correction.
@@ -42,12 +44,12 @@ T_REF_C = 15.0  # Reference temperature in degrees Celsius.
 P_STD_PA = 101325.0  # Standard atmospheric pressure in Pascals (1 atm).
 
 # Linearized thermal coefficient for air, from Zemax documentation.
-ALPHA_T = 0.00348  # In °C⁻¹
+ALPHA_T = 0.0034785  # In °C⁻¹
 
 
 def kohlrausch_refractive_index(
-    wavelength_um: float, conditions: EnvironmentalConditions
-) -> float:
+    wavelength_um: Any, conditions: EnvironmentalConditions
+) -> Any:
     """Calculates air refractive index using the Kohlrausch (Zemax) formula.
 
     This model ignores the humidity and CO₂ concentration from the conditions
@@ -62,7 +64,7 @@ def kohlrausch_refractive_index(
         The refractive index of air (n).
 
     Raises:
-        ValueError: If the wavelength is zero or if the temperature results in
+        ValueError: If wavelengths are not finite and positive, or temperature gives
             a non-positive denominator in the scaling term.
 
     Example:
@@ -73,21 +75,20 @@ def kohlrausch_refractive_index(
         ... )
         >>> n = kohlrausch_refractive_index(0.55, conditions_std)
         >>> print(f"Refractive index at 0.55 µm is {n:.8f}")
-        Refractive index at 0.55 µm is 1.00271728
+        Refractive index at 0.55 µm is 1.00027783
     """
     # --- 1. Calculate the reference refractivity (n_ref - 1) ---
     # The formula uses λ directly, but we convert it to the standard Sellmeier
     # form which uses wavenumber σ = 1/λ for clarity and robustness.
-    try:
-        sigma_sq = (1.0 / wavelength_um) ** 2
-    except ZeroDivisionError as err:
-        raise ValueError("Wavelength must be non-zero.") from err
+    if not be.all(be.isfinite(wavelength_um)) or be.any(wavelength_um <= 0):
+        raise ValueError("Wavelength must be finite and positive (non-zero).")
+    sigma_sq = (1.0 / wavelength_um) ** 2
 
-    # Calculate (n_ref - 1) * 10^5
-    n_ref_minus_1_e5 = (
+    # Calculate (n_ref - 1) * 10^8
+    n_ref_minus_1_e8 = (
         DISP_A + DISP_B / (DISP_C - sigma_sq) + DISP_D / (DISP_E - sigma_sq)
     )
-    n_ref_minus_1 = n_ref_minus_1_e5 * 1.0e-5
+    n_ref_minus_1 = n_ref_minus_1_e8 * 1.0e-8
 
     # --- 2. Apply temperature and pressure scaling ---
     t_c = conditions.temperature
@@ -98,7 +99,7 @@ def kohlrausch_refractive_index(
 
     # Denominator of the scaling term.
     temp_scaling_denom = 1.0 + (t_c - T_REF_C) * ALPHA_T
-    if temp_scaling_denom <= 0:
+    if be.any(temp_scaling_denom <= 0):
         raise ValueError(
             f"Invalid temperature {t_c}°C results in non-positive denominator."
         )

--- a/tests/environment/test_air_index.py
+++ b/tests/environment/test_air_index.py
@@ -128,9 +128,9 @@ def test_wavelength_validation_passed_to_models(typical_conditions, set_test_bac
         else:
             raise
 
-    # Kohlrausch is known to check for non-zero wavelength.
+    # Kohlrausch rejects non-finite and non-positive wavelengths.
     try:
-        with pytest.raises(ValueError, match="Wavelength must be non-zero"):
+        with pytest.raises(ValueError, match="Wavelength must be finite and positive"):
             refractive_index_air(0.0, typical_conditions, model="kohlrausch")
     except ModuleNotFoundError as e:
         if "numpy" in str(e) or "optiland.backend" in str(e):

--- a/tests/environment/test_kohlrausch.py
+++ b/tests/environment/test_kohlrausch.py
@@ -25,7 +25,7 @@ class TestKohlrauschRefractiveIndex:
     # Reference value for Kohlrausch from Zemax OpticStudio documentation.
     # For 0.55 um, 15C, 101325 Pa, calculated from the authoritative formula.
     REF_WAVELENGTH_UM = 0.55
-    REF_N_KOHLRAUSCH = 1.00271728
+    REF_N_KOHLRAUSCH = 1.00027782604165
 
     def setup_method(self):
         """Set up standard conditions for tests."""
@@ -115,15 +115,13 @@ class TestKohlrauschRefractiveIndex:
 
     def test_kohlrausch_refractive_index_invalid_wavelength_zero(self):
         """Test Kohlrausch model with zero wavelength."""
-        with pytest.raises(ValueError, match="Wavelength must be non-zero."):
+        with pytest.raises(ValueError, match="Wavelength must be finite and positive"):
             kohlrausch_refractive_index(0.0, self.std_conditions)
 
     def test_kohlrausch_refractive_index_invalid_wavelength_negative(self):
-        """Test model with negative wavelength (computes, but physically invalid)."""
-        # The model computes with negative wavelength, but the result is not
-        # physically meaningful. This test ensures it doesn't crash.
-        n_neg_wavelength = kohlrausch_refractive_index(-0.5, self.std_conditions)
-        assert isinstance(n_neg_wavelength, float)
+        """Reject a physically invalid wavelength instead of returning an index."""
+        with pytest.raises(ValueError, match="Wavelength must be finite and positive"):
+            kohlrausch_refractive_index(-0.5, self.std_conditions)
 
     def test_kohlrausch_refractive_index_invalid_conditions_type(self):
         """Test Kohlrausch model with incorrect conditions type."""

--- a/tests/environment/test_kohlrausch_array_validation.py
+++ b/tests/environment/test_kohlrausch_array_validation.py
@@ -1,0 +1,17 @@
+"""Invalid wavelengths must not produce plausible air indices in vector queries."""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.environment import EnvironmentalConditions
+from optiland.environment.models.kohlrausch import kohlrausch_refractive_index
+
+
+@pytest.mark.parametrize("invalid", [0.0, -0.55, float("nan"), float("inf")])
+@pytest.mark.parametrize("vector", [False, True])
+def test_reject_invalid_wavelengths_consistently(invalid, vector, set_test_backend):
+    wavelength = be.asarray([0.55, invalid]) if vector else invalid
+    with pytest.raises(ValueError, match="Wavelength"):
+        kohlrausch_refractive_index(wavelength, EnvironmentalConditions())

--- a/tests/environment/test_kohlrausch_reference.py
+++ b/tests/environment/test_kohlrausch_reference.py
@@ -1,0 +1,43 @@
+"""Independent published air indices, physical scaling and backend queries."""
+
+from __future__ import annotations
+
+import pytest
+
+import optiland.backend as be
+from optiland.environment import EnvironmentalConditions
+from optiland.environment.models.kohlrausch import kohlrausch_refractive_index
+from tests.utils import assert_allclose
+
+
+@pytest.mark.parametrize('temperature,pressure,expected', [
+    (20., 101325., 1.00027308), (30., 202650., 1.00052810),
+])
+def test_ansys_published_air_index_example(temperature, pressure, expected):
+    # Ansys: How OpticStudio calculates refractive index at arbitrary
+    # temperatures and pressures, example at 0.55 µm. Published to 8 decimals.
+    actual = kohlrausch_refractive_index(.55, EnvironmentalConditions(temperature=temperature, pressure=pressure))
+    assert actual == pytest.approx(expected, abs=5e-9, rel=0)
+
+
+def test_independent_catalog_formula_at_multiple_wavelengths(set_test_backend):
+    waves = be.asarray([.4, .55, .8, 1.5])
+    conditions = EnvironmentalConditions(temperature=20., pressure=101325.)
+    expected = 1 + 1e-8*(6432.8 + 2949810/(146-waves**-2) + 25540/(41-waves**-2))/(1+5*.0034785)
+    assert_allclose(kohlrausch_refractive_index(waves, conditions), expected, rtol=1e-13)
+
+
+def test_temperature_vectors_and_gradients_for_material_callers(set_test_backend):
+    temperatures = be.asarray([10., 20., 30.])
+    conditions = EnvironmentalConditions(temperature=temperatures, pressure=101325.)
+    values = kohlrausch_refractive_index(.55, conditions)
+    expected = 1 + .0002778260416499504 / (1 + (temperatures-15)*.0034785)
+    assert_allclose(values, expected, rtol=1e-13)
+    if be.get_backend() == 'torch':
+        import torch
+        for _ in range(2):
+            temperature = torch.tensor([20.], dtype=torch.float64, requires_grad=True)
+            conditions = EnvironmentalConditions(temperature=temperature, pressure=101325.)
+            kohlrausch_refractive_index(.55, conditions).sum().backward()
+            derivative = -.0002778260416499504*.0034785/(1+5*.0034785)**2
+            assert temperature.grad.item() == pytest.approx(derivative, rel=1e-12)


### PR DESCRIPTION
The environmental Kohlrausch model gives approximately `1.002670808` at 0.55 micrometers, 20 degrees Celsius and one atmosphere; the documented OpticStudio formula gives `1.00027308`. Mixed coefficient scales and a rounded temperature coefficient cause the discrepancy, while the existing example and numerical test repeat the incorrect result.

Fixes #803.

### Changes

- Restore the documented `10^-8` convention with coefficients `6432.8`, `2949810` and `25540`, and the Celsius scaling coefficient `0.0034785`.
- Preserve `EnvironmentalConditions` pressure in pascals and explicitly convert to relative pressure.
- Use backend reductions for wavelength and temperature validation, supporting array queries and retaining valid Torch gradients.
- Reject zero, negative and non-finite wavelengths before reciprocal arithmetic, consistently for scalars and arrays. Zero array elements previously escaped the scalar-zero exception path.
- Update the example, error contract and independent numerical tests. The dispatcher default and the model's existing dry-air scope are unchanged.

The [Ansys formula and worked example](https://optics.ansys.com/hc/en-us/articles/42661799783443-How-OpticStudio-calculates-refractive-index-at-arbitrary-temperatures-and-pressures) independently specify `1.00027308` at 20 degrees Celsius/1 atmosphere and `1.00052810` at 30 degrees Celsius/2 atmospheres, both at 0.55 micrometers.

### Validation

Reference/dispersion and vector-temperature regressions failed before their corrections. Fourteen additional scalar/vector invalid-wavelength cases reproduced inconsistent validation. The standalone branch passes **all 129 environment tests**, including the published indices, pressure/vacuum behavior, scalar/array queries and fresh wavelength/temperature gradients on NumPy/Torch CPU. Reference comparisons use the published precision; no tolerance was widened.

Local patch coverage is **57/57 changed executable lines (100%)** under unchanged Codecov policy. Ruff, formatting and whitespace checks pass. This is one commit based directly on upstream `master` at `7df37590c2d561d95403dc264e27b8b9a77ee879`.
