### PR TITLE
Fix Windows notification clicks reaching the underlying console

### DIFF
--- a/docs/developers_guide/gui.rst
+++ b/docs/developers_guide/gui.rst
@@ -114,6 +114,18 @@ Key Widgets
     *   Similar to the command palette found in VS Code, it provides a centralized interface for discovering and running various tools, analyses, and layout operations.
     *   Triggered from the `MainWindow` via the `Ctrl+K` shortcut.
 
+*   **Toast Notifications (``widgets/toast.py``)**:
+
+    *   ``MainWindow`` owns a ``ToastManager``, also exposed as
+        ``connector.toast_manager``. Call ``notify(message, severity)`` for
+        information, success, warning, or error feedback.
+    *   Cards can be dismissed by clicking them or their accessible close button.
+        Non-error cards expire after seven seconds; errors persist until dismissed
+        or evicted from the three-card stack.
+    *   Keep these child widgets free of ``WA_TranslucentBackground``. Alongside
+        native console/VTK widgets on Windows, this flag creates a layered native
+        child window whose mouse hit testing can select the underlying console.
+
 Styling and Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -135,6 +147,20 @@ This command is a convenient shortcut to the main GUI script. Alternatively, you
 .. code-block:: bash
 
    python -m optiland_gui.run_gui
+
+Testing Notification Dismissal
+------------------------------
+
+Run ``python -m pytest tests/gui/test_toast.py`` for card and close-button clicks,
+keyboard activation, timeouts, and stack cleanup. On Windows, run with the native
+Qt platform (leave ``QT_QPA_PLATFORM`` unset) to include the native hit-testing
+regressions. These cases are skipped on other platforms and with ``offscreen``.
+
+The Windows regressions use ``WindowFromPoint`` to select the actual native
+mouse recipient over a notification above a native text editor, then send input
+to that window. Sending a test click directly to a label, or selecting it with
+``QApplication.widgetAt``, bypasses layered-window hit testing and does not
+reproduce clicks passing through to the console.
 
 Contributing to the GUI
 -----------------------

--- a/docs/gui_quickstart.rst
+++ b/docs/gui_quickstart.rst
@@ -102,6 +102,17 @@ Optiland features a VS Code-style **Command Palette** that provides quick access
 
    All windows are dockable and can be rearranged to suit your workflow. You can also save your layout for future sessions. These can be loaded by pressing "1" or "2" in the top toolbar, corresponding to the slot used for saving your layout.
 
+Notifications
+-------------
+
+Notifications appear at the bottom-right of the main window. Click the
+notification card or its close button to dismiss it. You can also use ``Tab``
+to focus the close button, labeled "Dismiss notification", and press ``Space``.
+
+Error notifications stay visible until dismissed or replaced by newer
+notifications when the three-card stack is full. Information, success, and
+warning notifications disappear automatically after seven seconds.
+
 Light theme and Dark theme
 --------------------------
 

--- a/optiland_gui/widgets/toast.py
+++ b/optiland_gui/widgets/toast.py
@@ -4,7 +4,7 @@ Provides :class:`ToastWidget` (a single notification card) and
 :class:`ToastManager` (the singleton stack manager owned by ``MainWindow``).
 
 Design notes (from SPEC §1):
-- All toasts are passive (information only, no action buttons).
+- All toasts are informational, with a close button and click-to-dismiss.
 - Auto-dismiss after 7 s except Error-level toasts (persist until clicked).
 - Max 3 toasts visible; oldest is evicted immediately when a 4th arrives.
 - Position: bottom-right of the main window with 16 px margin.
@@ -30,6 +30,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QSizePolicy,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -80,7 +81,9 @@ class ToastWidget(QWidget):
         self._dismissed = False
 
         self.setFixedWidth(_TOAST_WIDTH)
-        self.setAttribute(Qt.WA_TranslucentBackground)
+        # This child can become native alongside the docked console/VTK widgets.
+        # WA_TranslucentBackground makes it a layered window on Windows, where
+        # mouse hit testing can pass through to the console underneath.
         self.setWindowFlags(Qt.SubWindow)
 
         self._build_ui(message, severity, sub_message)
@@ -142,6 +145,22 @@ class ToastWidget(QWidget):
 
         outer_layout.addLayout(text_layout, 1)
 
+        close_button = QToolButton(outer)
+        close_button.setObjectName("ToastCloseButton")
+        close_button.setText("\u00d7")
+        close_button.setToolTip("Dismiss notification")
+        close_button.setAccessibleName("Dismiss notification")
+        close_button.setCursor(Qt.PointingHandCursor)
+        close_button.setFocusPolicy(Qt.StrongFocus)
+        close_button.setFixedSize(24, 24)
+        close_button.setStyleSheet(
+            "QToolButton { color: #E0E0E0; background: transparent;"
+            " border: none; border-radius: 4px; padding: 0; font-size: 18px; }"
+            "QToolButton:hover, QToolButton:focus { background: #505050; }"
+        )
+        close_button.clicked.connect(self._dismiss)
+        outer_layout.addWidget(close_button, 0, Qt.AlignTop)
+
         # Root layout
         root_layout = QVBoxLayout(self)
         root_layout.setContentsMargins(0, 0, 0, 0)
@@ -162,11 +181,14 @@ class ToastWidget(QWidget):
 
     def mousePressEvent(self, event) -> None:  # noqa: ANN001
         """Dismiss the toast when the user clicks anywhere on it."""
+        self._dismiss()
+        event.accept()
+
+    def _dismiss(self) -> None:
         if self.parent() and hasattr(self.parent(), "_toast_manager"):
             self.parent()._toast_manager._dismiss(self)
         else:
             self.hide()
-        super().mousePressEvent(event)
 
 
 class ToastManager:

--- a/tests/gui/test_toast.py
+++ b/tests/gui/test_toast.py
@@ -1,0 +1,137 @@
+"""Interaction regressions for notifications over native console widgets."""
+
+from __future__ import annotations
+
+import pytest
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QLabel, QMainWindow, QTextEdit, QToolButton, QWidget
+from shiboken6 import isValid
+
+from optiland_gui.widgets import toast as toast_module
+
+
+@pytest.fixture
+def toast_manager(qapp):
+    window = QMainWindow()
+    window.setGeometry(50, 50, 900, 700)
+    console = QTextEdit()
+    # VTK creates native widgets in the real GUI, including sibling docks.
+    console.setAttribute(Qt.WA_NativeWindow)
+    window.setCentralWidget(console)
+    window.show()
+    manager = toast_module.ToastManager(window)
+    yield manager
+    window.close()
+    window.deleteLater()
+    qapp.sendPostedEvents(None, QEvent.DeferredDelete)
+
+
+def show_error(manager):
+    manager.notify(
+        "An error occurred during OPD:\nPolarization must be set when surfaces "
+        "have polarization-dependent coatings.",
+        "error",
+        sub_message="Select polarization and retry.",
+    )
+    toast = manager._stack[-1]
+    QTest.qWait(toast_module._ENTER_DURATION + 100)
+    return toast
+
+
+def click_target(toast, target):
+    if target == "close":
+        return toast.findChild(QToolButton, "ToastCloseButton")
+    if target == "background":
+        return toast.findChild(QWidget, "ToastOuter")
+    return toast.findChildren(QLabel)[{"icon": 0, "message": 1, "detail": 2}[target]]
+
+
+@pytest.mark.parametrize("target", ["icon", "message", "detail", "background", "close"])
+def test_click_dismisses_notification(toast_manager, target):
+    toast = show_error(toast_manager)
+    widget = click_target(toast, target)
+    QTest.mouseClick(widget, Qt.LeftButton)
+    QTest.qWait(toast_module._EXIT_DURATION + 100)
+    assert toast_manager._stack == []
+    assert not isValid(toast)
+
+
+def test_close_button_keyboard_activation(toast_manager):
+    toast = show_error(toast_manager)
+    button = click_target(toast, "close")
+    assert button.accessibleName() == "Dismiss notification"
+    button.setFocus()
+    QTest.keyClick(button, Qt.Key_Space)
+    QTest.qWait(toast_module._EXIT_DURATION + 100)
+    assert toast_manager._stack == []
+    assert not isValid(toast)
+
+
+@pytest.mark.parametrize("severity", ["info", "success", "warning", "error"])
+def test_timeout_preserves_errors_only(toast_manager, monkeypatch, severity):
+    monkeypatch.setattr(toast_module, "_AUTO_DISMISS_MS", 300)
+    toast_manager.notify("Notification", severity)
+    toast = toast_manager._stack[-1]
+    QTest.qWait(300 + toast_module._EXIT_DURATION + 150)
+    if severity == "error":
+        assert toast_manager._stack == [toast]
+        assert toast.isVisible()
+    else:
+        assert toast_manager._stack == []
+        assert not isValid(toast)
+
+
+def test_dismissal_restacks_remaining_notifications(toast_manager):
+    first = show_error(toast_manager)
+    second = show_error(toast_manager)
+    QTest.mouseClick(click_target(second, "close"), Qt.LeftButton)
+    # Repeated input while exiting must not start a second dismissal.
+    QTest.mouseClick(click_target(second, "close"), Qt.LeftButton)
+    QTest.qWait(toast_module._EXIT_DURATION + toast_module._SHIFT_DURATION + 100)
+    assert toast_manager._stack == [first]
+    assert first.pos() == toast_manager._target_pos(0, first)
+    assert not isValid(second)
+
+
+@pytest.mark.parametrize("target", ["icon", "message", "close"])
+def test_windows_hit_testing_keeps_clicks_out_of_console(toast_manager, target, qapp):
+    if qapp.platformName() != "windows":
+        pytest.skip("Requires native Windows hit testing (not the offscreen plugin)")
+
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    user32.ClientToScreen.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.POINT)]
+    user32.ClientToScreen.restype = wintypes.BOOL
+    user32.WindowFromPoint.argtypes = [wintypes.POINT]
+    user32.WindowFromPoint.restype = wintypes.HWND
+
+    window = toast_manager._parent
+    window.raise_()
+    window.activateWindow()
+    assert QTest.qWaitForWindowActive(window)
+    toast = show_error(toast_manager)
+    widget = click_target(toast, target)
+    global_point = widget.mapToGlobal(widget.rect().center())
+    local_point = window.mapFromGlobal(global_point)
+    ratio = window.devicePixelRatioF()
+    native_point = wintypes.POINT(
+        round(local_point.x() * ratio), round(local_point.y() * ratio)
+    )
+    assert user32.ClientToScreen(window.winId(), ctypes.byref(native_point))
+    recipient = QWidget.find(user32.WindowFromPoint(native_point))
+
+    # Sending directly to a QLabel (or using QApplication.widgetAt) bypasses
+    # Windows' layered-window hit testing and misses the original regression.
+    assert recipient is not None
+    assert recipient is toast or toast.isAncestorOf(recipient)
+    QTest.mouseClick(
+        recipient.windowHandle(),
+        Qt.LeftButton,
+        pos=recipient.mapFromGlobal(global_point),
+    )
+    QTest.qWait(toast_module._EXIT_DURATION + 100)
+    assert toast_manager._stack == []
+    assert not isValid(toast)

--- a/tests/gui/test_toast.py
+++ b/tests/gui/test_toast.py
@@ -109,10 +109,14 @@ def test_windows_hit_testing_keeps_clicks_out_of_console(toast_manager, target, 
     user32.WindowFromPoint.restype = wintypes.HWND
 
     window = toast_manager._parent
+    # WindowFromPoint uses desktop stacking, so keep this short-lived test
+    # window above unrelated applications while sampling the native target.
+    window.setWindowFlag(Qt.WindowStaysOnTopHint)
+    window.show()
+    toast = show_error(toast_manager)
     window.raise_()
     window.activateWindow()
     assert QTest.qWaitForWindowActive(window)
-    toast = show_error(toast_manager)
     widget = click_target(toast, target)
     global_point = widget.mapToGlobal(widget.rect().center())
     local_point = window.mapFromGlobal(global_point)


### PR DESCRIPTION
Fixes #808.

On Windows, clicking an error notification over the docked Python console can send the click to the console and leave the notification visible. Remove `WA_TranslucentBackground` from the notification child widget so native Windows hit testing selects the card. Add an accessible close button and consume card clicks after dismissal. Error persistence, seven-second non-error timeouts, and slide/fade animations are preserved.

The branch starts directly from current upstream `master` (`3dd53cbe`) and contains only the notification fix, related tests, and GUI quickstart/developer documentation.

Validation:

- GUI suite: **59 passed, 3 skipped** with Qt's offscreen platform; the three skips require native Windows hit testing.
- Native Windows regression: **3 passed** on this branch, covering icon, message, and close-button clicks. The test uses Windows `WindowFromPoint` before delivering input, so it catches click-through behavior that direct Qt label clicks miss. The icon/message regressions fail against the original upstream implementation.
- The full GUI check over the docked Jupyter console passes, and the reporter confirmed the fix resolves the issue.
- Card/detail/background clicks, keyboard close, timeouts, repeated dismissal, and stack cleanup are covered.
- Ruff lint/formatting and `git diff --check` pass; both edited reStructuredText documents parse without warnings.

Tested on Windows with Python 3.14.6 and PySide6/Qt 6.11.2. Native Windows tests are skipped on other platforms and with the offscreen Qt plugin.
