### PR TITLE
fix(raytrace): preserve signed optical path for virtual propagation

### DIFF
--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -299,7 +299,9 @@ class Surface(ObserverMixin):
         """
         t = _aperture_aware_distance(self, rays)
         self.material_pre.propagation_model.propagate(rays, t)
-        rays.opd = rays.opd + be.abs(t * self.material_pre.n(rays.w))
+        # t is oriented along the ray: virtual propagation subtracts OPL.
+        # Real return paths after reflection still have t > 0 and add OPL.
+        rays.opd = rays.opd + t * self.material_pre.n(rays.w)
         if self.aperture:
             self.aperture.clip(rays)
         rays = self.interaction_model.interact_real_rays(rays)

--- a/tests/test_standard_surface.py
+++ b/tests/test_standard_surface.py
@@ -10,6 +10,7 @@ from optiland.interactions.refractive_reflective_model import RefractiveReflecti
 from optiland.materials import IdealMaterial
 from optiland.rays import ParaxialRays, RealRays
 from optiland.surfaces.standard_surface import Surface
+from tests.utils import assert_allclose
 
 
 class TestSurface:
@@ -53,6 +54,155 @@ class TestSurface:
         rays = RealRays(x, x, x, x, x, x, x, x)
         traced_rays = surface.trace(rays)
         assert isinstance(traced_rays, RealRays)
+
+    def test_trace_signed_propagation_opl(self, set_test_backend) -> None:
+        """OPL follows oriented travel, including real travel toward negative Z."""
+        surface = Surface(None, IdealMaterial(1.5), Plane(CoordinateSystem()))
+        rays = RealRays(
+            x=be.zeros(4),
+            y=be.zeros(4),
+            z=be.array([-5.0, 5.0, 5.0, -5.0]),
+            L=be.zeros(4),
+            M=be.zeros(4),
+            N=be.array([1.0, 1.0, -1.0, -1.0]),
+            intensity=be.ones(4),
+            wavelength=be.full(4, 0.55),
+        )
+        initial_opl = be.array([1.0, 2.0, 3.0, 4.0])
+        rays.opd = be.copy(initial_opl)
+
+        assert_allclose(
+            surface.geometry.distance(rays), [5.0, -5.0, 5.0, -5.0], rtol=0, atol=1e-12
+        )
+        surface.trace(rays)
+
+        for component in (rays.x, rays.y, rays.z):
+            assert_allclose(component, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.N, [1.0, 1.0, -1.0, -1.0], rtol=0, atol=1e-12)
+        assert_allclose(
+            rays.opd - initial_opl, [7.5, -7.5, 7.5, -7.5], rtol=0, atol=1e-12
+        )
+
+    def test_virtual_propagation_uses_incident_material(self, set_test_backend) -> None:
+        """Propagation uses the previous surface's medium before refraction."""
+        previous = Surface(None, IdealMaterial(1.5), Plane(CoordinateSystem(z=5.0)))
+        surface = Surface(previous, IdealMaterial(2.0), Plane(CoordinateSystem()))
+        rays = RealRays(
+            x=0.0,
+            y=0.0,
+            z=5.0,
+            L=0.0,
+            M=0.0,
+            N=1.0,
+            intensity=1.0,
+            wavelength=0.55,
+        )
+
+        surface.trace(rays)
+
+        for component in (rays.x, rays.y, rays.z, rays.L, rays.M):
+            assert_allclose(component, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.N, 1.0, rtol=0, atol=1e-12)
+        # Five virtual millimeters in n=1.5, not the transmitted n=2 medium.
+        assert_allclose(rays.opd, -7.5, rtol=0, atol=1e-12)
+
+    def test_virtual_inverse_excursion_cancels_opl(self, set_test_backend) -> None:
+        """A virtual inverse restores geometry and OPL for axial and oblique rays."""
+        medium = IdealMaterial(1.5)
+        virtual_plane = Surface(None, medium, Plane(CoordinateSystem(z=-5.0)))
+        return_plane = Surface(virtual_plane, medium, Plane(CoordinateSystem()))
+        rays = RealRays(
+            x=be.zeros(2),
+            y=be.zeros(2),
+            z=be.zeros(2),
+            L=be.zeros(2),
+            M=be.array([0.0, 0.6]),
+            N=be.array([1.0, 0.8]),
+            intensity=be.ones(2),
+            wavelength=be.full(2, 0.55),
+        )
+        initial_opl = be.array([1.0, 2.0])
+        rays.opd = be.copy(initial_opl)
+
+        virtual_plane.trace(rays)
+        assert_allclose(
+            rays.opd - initial_opl, [-7.5, -9.375], rtol=0, atol=1e-12
+        )
+        assert_allclose(rays.z, -5.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.y, [0.0, -3.75], rtol=0, atol=1e-12)
+        assert_allclose(rays.M, [0.0, 0.6], rtol=0, atol=1e-12)
+        assert_allclose(rays.N, [1.0, 0.8], rtol=0, atol=1e-12)
+        return_plane.trace(rays)
+
+        for component in (rays.x, rays.y, rays.z, rays.L):
+            assert_allclose(component, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.M, [0.0, 0.6], rtol=0, atol=1e-12)
+        assert_allclose(rays.N, [1.0, 0.8], rtol=0, atol=1e-12)
+        assert_allclose(rays.opd, initial_opl, rtol=0, atol=1e-12)
+
+    def test_mirror_round_trip_adds_propagation_opl(self, set_test_backend) -> None:
+        """Both physical legs add OPL even after reflection reverses direction."""
+        medium = IdealMaterial(1.5)
+        # An uncoated geometric mirror isolates propagation from interface phase.
+        mirror = Surface(
+            None,
+            medium,
+            Plane(CoordinateSystem(z=5.0)),
+            interaction_model=RefractiveReflectiveModel(None, is_reflective=True),
+        )
+        return_plane = Surface(mirror, medium, Plane(CoordinateSystem()))
+        rays = RealRays(
+            x=0.0,
+            y=0.0,
+            z=0.0,
+            L=0.0,
+            M=0.0,
+            N=1.0,
+            intensity=1.0,
+            wavelength=0.55,
+        )
+
+        mirror.trace(rays)
+        assert_allclose(rays.z, 5.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.N, -1.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.opd, 7.5, rtol=0, atol=1e-12)
+        return_plane.trace(rays)
+
+        for component in (rays.x, rays.y, rays.z, rays.L, rays.M):
+            assert_allclose(component, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.N, -1.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.opd, 15.0, rtol=0, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        "distance", [-5.0, 0.0, 5.0], ids=["virtual", "zero", "real"]
+    )
+    def test_virtual_propagation_opl_gradient(
+        self, distance: float, set_test_backend
+    ) -> None:
+        """The oriented OPL derivative is positive n, including at zero travel."""
+        if be.get_backend() != "torch":
+            pytest.skip("Autograd requires the torch backend")
+
+        travel = be.array([distance])
+        travel.requires_grad_(True)
+        rays = RealRays(
+            x=0.0,
+            y=0.0,
+            z=-travel,
+            L=0.0,
+            M=0.0,
+            N=1.0,
+            intensity=1.0,
+            wavelength=0.55,
+        )
+        surface = Surface(None, IdealMaterial(1.5), Plane(CoordinateSystem()))
+
+        surface.trace(rays)
+        rays.opd.sum().backward()
+
+        assert_allclose(rays.z, 0.0, rtol=0, atol=1e-12)
+        assert travel.grad is not None
+        assert_allclose(travel.grad, 1.5, rtol=0, atol=1e-12)
 
     def test_set_semi_aperture(self, set_test_backend):
         surface = self.create_surface()

--- a/tests/test_thin_lens_interaction_model.py
+++ b/tests/test_thin_lens_interaction_model.py
@@ -230,6 +230,78 @@ class TestThinLensInteractionModel:
         )
         assert_allclose(rays.opd, rays.opd[0], atol=1e-10)
 
+    @pytest.mark.parametrize("start_z", [0.0, 5.0], ids=["at_lens", "virtual"])
+    def test_surface_phase_with_virtual_propagation(
+        self, start_z: float, set_test_backend
+    ) -> None:
+        """Lens phase equalizes focal OPL even after virtual incident travel."""
+        air = IdealMaterial(1.0)
+        lens = Surface(
+            None,
+            air,
+            Plane(CoordinateSystem()),
+            interaction_model=ThinLensInteractionModel(None, 20.0, False),
+        )
+        focus = Surface(lens, air, Plane(CoordinateSystem(z=20.0)))
+        rays = RealRays(
+            x=be.zeros(2),
+            y=be.array([0.0, 3.0]),
+            z=be.full(2, start_z),
+            L=be.zeros(2),
+            M=be.zeros(2),
+            N=be.ones(2),
+            intensity=be.ones(2),
+            wavelength=be.full(2, 0.55),
+        )
+
+        lens.trace(rays)
+        assert_allclose(rays.z, 0.0, rtol=0, atol=1e-12)
+        focus.trace(rays)
+
+        assert_allclose(rays.x, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.y, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.z, 20.0, rtol=0, atol=1e-12)
+        # The lens compensates the longer off-axis path to the same focus.
+        assert_allclose(rays.opd, rays.opd[0], rtol=0, atol=1e-12)
+        # The axial ray has zero lens phase and travels 20 - start_z in air.
+        assert_allclose(rays.opd, 20.0 - start_z, rtol=0, atol=1e-12)
+
+    @pytest.mark.parametrize("focal_length", [-40.0, 40.0], ids=["virtual", "real"])
+    def test_equal_opl_at_virtual_and_real_focus(
+        self, focal_length: float, set_test_backend
+    ) -> None:
+        """Lens phase equalizes pupil-dependent travel to either kind of focus."""
+        air = IdealMaterial(1.0)
+        lens = Surface(
+            None,
+            air,
+            Plane(CoordinateSystem()),
+            interaction_model=ThinLensInteractionModel(None, focal_length, False),
+        )
+        focus = Surface(lens, air, Plane(CoordinateSystem(z=focal_length)))
+        rays = RealRays(
+            x=be.zeros(3),
+            y=be.array([0.0, 3.0, 7.0]),
+            z=be.full(3, -5.0),
+            L=be.zeros(3),
+            M=be.zeros(3),
+            N=be.ones(3),
+            intensity=be.ones(3),
+            wavelength=be.full(3, 0.55),
+        )
+
+        lens.trace(rays)
+        focus.trace(rays)
+
+        assert_allclose(rays.x, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.y, 0.0, rtol=0, atol=1e-12)
+        assert_allclose(rays.z, focal_length, rtol=0, atol=1e-12)
+        # Equal phase at the ideal focus includes the signed off-axis paths.
+        assert_allclose(rays.opd, rays.opd[0], rtol=0, atol=1e-12)
+        # The axial ray has zero lens phase: 5 mm incident plus oriented f.
+        # For these ~40 mm float64 paths, 1e-12 mm allows only roundoff.
+        assert_allclose(rays.opd, 5.0 + focal_length, rtol=0, atol=1e-12)
+
     def test_flip(self, surface):
         f_initial = be.copy(surface.interaction_model.f)
         surface.interaction_model.flip()

--- a/tests/test_wavefront.py
+++ b/tests/test_wavefront.py
@@ -11,6 +11,7 @@ from mpl_toolkits.mplot3d import Axes3D
 
 import optiland.backend as be
 from optiland import distribution
+from optiland.materials import IdealMaterial
 from optiland.optic import Optic
 from optiland.samples.eyepieces import EyepieceErfle
 from optiland.samples.objectives import CookeTriplet, DoubleGauss
@@ -142,6 +143,66 @@ class TestOPD:
         opd = OPD(optic, (0, 1), 0.55)
         rms = opd.rms()
         assert_allclose(rms, 0.9709788038168692)
+
+    def test_virtual_dummy_planes_preserve_wavefront(self, set_test_backend) -> None:
+        """Index-matched virtual detours preserve the finite-object wavefront."""
+        optics = []
+        wavefronts = []
+        # Stop-relative paths: 0 -> 20 versus 0 -> 10 -> 5 -> 20 mm.
+        for thicknesses in ([100.0, 20.0], [100.0, 10.0, -5.0, 15.0]):
+            optic = Optic()
+            medium = IdealMaterial(1.5)
+            for index, thickness in enumerate(thicknesses):
+                optic.surfaces.add(
+                    index=index,
+                    thickness=thickness,
+                    material=medium,
+                    is_stop=index == 1,
+                )
+            optic.surfaces.add(index=len(thicknesses), material=medium)
+            optic.set_aperture("EPD", 4.0)
+            optic.fields.set_type("object_height")
+            optic.fields.add(y=0.0)
+            optic.wavelengths.add(0.55, is_primary=True)
+
+            analysis = OPD(
+                optic,
+                (0.0, 0.0),
+                0.55,
+                num_rays=6,
+                strategy="chief_ray",
+                afocal=True,
+                remove_tilt=False,
+            )
+            data = analysis.get_data((0.0, 0.0), 0.55)
+            assert be.size(data.opd) > 1
+            assert be.all(data.intensity > 0)
+            assert be.all(be.isfinite(data.opd))
+            # Angular diversity makes the virtual-path error pupil-dependent.
+            final_ns = optic.surfaces.N[-1]
+            assert be.max(final_ns) - be.min(final_ns) > 1e-6
+            optics.append(optic)
+            wavefronts.append(data)
+
+        direct, detour = optics
+        for component in ("x", "y", "z", "L", "M", "N"):
+            assert_allclose(
+                getattr(direct.surfaces, component)[-1],
+                getattr(detour.surfaces, component)[-1],
+                rtol=0,
+                atol=1e-12,
+            )
+        for component in ("pupil_x", "pupil_y"):
+            assert_allclose(
+                getattr(wavefronts[0], component),
+                getattr(wavefronts[1], component),
+                rtol=0,
+                atol=1e-12,
+            )
+        # Subtracting ~180 mm paths in float64 then dividing by 0.00055 mm
+        # amplifies roundoff to ~1e-10 waves; 1e-9 allows a few dozen ulps.
+        # The direct finite-object wavefront need not itself be flat.
+        assert_allclose(wavefronts[0].opd, wavefronts[1].opd, rtol=0, atol=1e-9)
 
 
 class TestZernikeOPD:


### PR DESCRIPTION
## Summary

- Preserve the signed homogeneous propagation contribution, `t * material_pre.n(w)`, in `Surface._trace_real`.
- Document that virtual propagation subtracts optical path, while physical reflected return legs have positive travel along the current direction and add optical path.
- Add NumPy/Torch regressions for all four travel/direction sign combinations, incident-medium selection, inverse cancellation, actual mirror reflection, gradients through zero travel, additive surface phase, real/virtual thin-lens focus, and wavefront invariance under an index-matched virtual detour.

Closes #812.

## Correctness

The intersection parameter is oriented along the current normalized ray. Taking its absolute optical path changes a virtual segment from `n*t` to `-n*t` and reverses its local gradient. A real return path after reflection still has `t > 0`, even when global Z decreases.

The finite-object wavefront regression checks pointwise OPD equality and preserved final geometry after inserting index-matched dummy planes. It also requires angular diversity so the original error cannot disappear as common piston. The virtual-focus regression couples pupil-dependent negative travel to the actual thin-lens phase contribution.

This homogeneous correction is independent of the launch-phase work in #810/#811 and the propagation API design for GRIN in #337.

## Validation

Local validation on pinned upstream base `b9127f76b7805c6bf572de7eca3d2b063eaa551a`, using Python 3.14.2 on Windows, NumPy 2.5.3 and Torch 2.13.0+cpu in float64:

| Run | Result |
| --- | --- |
| All eight new regression methods against pristine original production | 14 failed, 7 passed, 3 skipped |
| Same methods against the fix | 21 passed, 3 skipped |
| Surrounding test modules and all of `tests/regression/` | 460 passed, 4 skipped |

The targeted runs checked that production imports originated from the selected pristine/fixed checkout. All Torch parameterizations executed; the three targeted skips are NumPy autograd cases. All eight golden snapshot cases passed.

Additional in-memory fault-injection checks verified that the regressions reject transmitted-index accumulation, a collimated wavefront fixture, incorrect negative-Z-direction sign handling, and omitted intermediate OPL accumulation.

Checks passed:

- `ruff check optiland/`
- `ruff format --check optiland/surfaces/standard_surface.py`
- `git diff --check`

<details>
<summary>Surrounding test command</summary>

```bash
.venv/Scripts/python.exe -m pytest -q --tb=short \
  tests/test_standard_surface.py \
  tests/test_object_surface.py \
  tests/test_image_surface.py \
  tests/test_surface_group.py \
  tests/test_surface_factory.py \
  tests/test_rays.py \
  tests/propagation/test_homogeneous.py \
  tests/test_wavefront.py \
  tests/test_wavefront_strategy.py \
  tests/test_thin_lens_interaction_model.py \
  tests/test_phase_interaction_model.py \
  tests/sequences/test_surface_view.py \
  tests/sequences/test_sequenced_optic.py \
  tests/sequences/test_sequenced_surface_group.py \
  tests/regression/
```

</details>
