### PR TITLE
Prepare System Viewer layouts outside the Qt event loop

### DIFF
--- a/optiland/visualization/system/surface.py
+++ b/optiland/visualization/system/surface.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 import vtk
+from vtk.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray
 
 import optiland.backend as be
 from optiland.physical_apertures import RadialAperture
@@ -222,13 +223,7 @@ class Surface3D(Surface2D):
         return actor
 
     def _get_asymmetric_surface(self):
-        """Generates an asymmetric surface using Delaunay triangulation and
-        returns a VTK actor for rendering.
-
-        This method computes the 3D sag values, creates a VTK poly data object
-        to store the points, applies Delaunay triangulation to generate a
-        surface mesh, maps the surface to a VTK actor, configures the actor's
-        material properties, and converts the actor to global coordinates.
+        """Build a clipped quad grid with bulk VTK point/connectivity arrays.
 
         Returns:
             vtk.vtkActor: A VTK actor representing the asymmetric surface.
@@ -246,34 +241,29 @@ class Surface3D(Surface2D):
             r = np.hypot(x, y)
             mask = r <= be.to_numpy(self.extent)
 
-        # Create VTK points.
+        # Preserve the original row-major vertex order and vtkPoints float32
+        # precision, but avoid one Python/VTK call per coordinate and quad.
         points = vtk.vtkPoints()
         num_rows, num_cols = x.shape
-
-        # Map grid indices to point IDs
-        point_ids = -np.ones((num_rows, num_cols), dtype=int)
-        for i in range(num_rows):
-            for j in range(num_cols):
-                point_ids[i, j] = points.InsertNextPoint(x[i, j], y[i, j], z[i, j])
-
-        # Create cells (quads) for the surface
-        # Only include a quad if all four of its vertices lie inside aperture
+        coordinates = np.column_stack((x.ravel(), y.ravel(), z.ravel()))
+        points.SetData(numpy_to_vtk(coordinates.astype(np.float32), deep=True))
+        point_ids = np.arange(num_rows * num_cols, dtype=np.int64).reshape(x.shape)
+        mask = np.asarray(be.to_numpy(mask), dtype=bool)
+        inside = mask[:-1, :-1] & mask[1:, :-1] & mask[1:, 1:] & mask[:-1, 1:]
+        quads = np.column_stack(
+            (
+                point_ids[:-1, :-1][inside],
+                point_ids[1:, :-1][inside],
+                point_ids[1:, 1:][inside],
+                point_ids[:-1, 1:][inside],
+            )
+        ).ravel()
+        offsets = np.arange(0, len(quads) + 1, 4, dtype=np.int64)
         cells = vtk.vtkCellArray()
-        for i in range(num_rows - 1):
-            for j in range(num_cols - 1):
-                # Check the four corners of the cell.
-                if (
-                    mask[i, j]
-                    and mask[i + 1, j]
-                    and mask[i + 1, j + 1]
-                    and mask[i, j + 1]
-                ):
-                    quad = vtk.vtkQuad()
-                    quad.GetPointIds().SetId(0, point_ids[i, j])
-                    quad.GetPointIds().SetId(1, point_ids[i + 1, j])
-                    quad.GetPointIds().SetId(2, point_ids[i + 1, j + 1])
-                    quad.GetPointIds().SetId(3, point_ids[i, j + 1])
-                    cells.InsertNextCell(quad)
+        cells.SetData(
+            numpy_to_vtkIdTypeArray(offsets, deep=True),
+            numpy_to_vtkIdTypeArray(quads, deep=True),
+        )
 
         polydata = vtk.vtkPolyData()
         polydata.SetPoints(points)

--- a/optiland_gui/layout_presenter.py
+++ b/optiland_gui/layout_presenter.py
@@ -1,0 +1,210 @@
+"""Install prepared numerical layout data exclusively on the GUI thread."""
+
+from __future__ import annotations
+
+import matplotlib
+from matplotlib.colors import to_rgb
+from matplotlib.patches import Polygon
+
+from optiland.visualization.themes import get_active_theme
+from optiland_gui import gui_plot_utils
+
+
+def present_2d(viewer, data, context, restyle=False):
+    """Reconstruct the 2D canvas and retain surface identities for highlighting."""
+    gui_plot_utils.apply_gui_matplotlib_styles(viewer.current_theme)
+    theme = get_active_theme().parameters
+    viewer._is_plotting = True
+    try:
+        same_document = (
+            getattr(viewer, "_scene_document_id", None) == context["document_id"]
+        )
+        preserve = same_document and (
+            restyle or viewer._preserve_next or viewer._user_initiated_view_change
+        )
+        xlim, ylim = viewer.ax.get_xlim(), viewer.ax.get_ylim()
+        if hasattr(viewer, "_finish_default_pan"):
+            viewer._finish_default_pan()
+        if hasattr(viewer, "clear_2d_highlights"):
+            viewer.clear_2d_highlights()
+        viewer.ax.clear()
+        background = matplotlib.rcParams["figure.facecolor"]
+        viewer.figure.set_facecolor(background)
+        viewer.ax.set_facecolor(background)
+        body_artists, surface_artists = {}, {}
+        identities = context["surface_identities"]
+        for item in data["primitives"]:
+            owned = tuple(identities[i] for i in item["surfaces"])
+            if item["kind"] == "polygon":
+                patch = Polygon(
+                    item["xy"],
+                    closed=True,
+                    facecolor=theme.get("lens.color", (0.8, 0.8, 0.8, 0.6)),
+                    edgecolor=theme.get("axes.edgecolor", "gray"),
+                    linewidth=item["linewidth"],
+                )
+                viewer.ax.add_patch(patch)
+                body_artists[patch] = owned
+            else:
+                role = item["role"]
+                if role == "ray":
+                    cycle = theme.get("ray_cycle", ["C0", "C1", "C2"])
+                    color = cycle[item["color_index"] % len(cycle)]
+                else:
+                    color = (
+                        "black"
+                        if role == "aperture"
+                        else theme.get("axes.edgecolor", "gray")
+                    )
+                (line,) = viewer.ax.plot(
+                    item["xy"][:, 0],
+                    item["xy"][:, 1],
+                    color=color,
+                    linewidth=item["linewidth"],
+                    linestyle=item["linestyle"],
+                    label=item["label"],
+                )
+                if role == "surface" and len(owned) == 1:
+                    surface_artists[line] = owned[0]
+        for annotation in data["annotations"]:
+            viewer.ax.annotate(
+                "",
+                xy=annotation["xy"],
+                xytext=annotation["xytext"],
+                arrowprops=annotation["arrowprops"],
+            )
+        viewer.ax.set_title(f"System: {data['name']} (2D)")
+        viewer.ax.set_xlabel("Z-axis (mm)")
+        viewer.ax.set_ylabel("Y-axis (mm)")
+        viewer.ax.grid(True, linestyle="--", alpha=0.7)
+        viewer.ax.autoscale_view()
+        if preserve:
+            viewer.ax.set_xlim(xlim)
+            viewer.ax.set_ylim(ylim)
+            viewer.ax.set_aspect("auto")
+        else:
+            viewer.ax.set_aspect("equal", adjustable="box")
+        # The interaction feature provides this seam; its absence requires no
+        # calculation fallback or dependence on the combined feature branch.
+        if hasattr(viewer, "install_2d_highlight_bindings"):
+            viewer.install_2d_highlight_bindings(
+                body_artists,
+                surface_artists,
+                {identities[i]: xy for i, xy in data["boundaries"].items()},
+                {identities[i]: xy for i, xy in data["references"].items()},
+            )
+        viewer.canvas.draw_idle()
+        viewer._scene_document_id = context["document_id"]
+    finally:
+        viewer._is_plotting = False
+
+
+def present_3d(viewer, data, context, restyle=False):
+    """Install bulk polydata and preserve the user's existing camera."""
+    import vtk
+    from vtk.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray
+
+    gui_plot_utils.apply_gui_matplotlib_styles(viewer.current_theme)
+    theme = get_active_theme().parameters
+    if not viewer._initialized:
+        viewer.iren.Initialize()
+        viewer._initialized = True
+    viewer.renderer.SetBackground(*to_rgb(theme.get("axes.facecolor", "#202020")))
+    if restyle and hasattr(viewer, "_scene_actor_specs"):
+        for actor, mesh in viewer._scene_actor_specs:
+            _style_3d_actor(actor, mesh, theme)
+        viewer.vtkWidget.GetRenderWindow().Render()
+        return
+    actors = []
+    for mesh in data["meshes"]:
+        points = vtk.vtkPoints()
+        points.SetData(numpy_to_vtk(mesh["points"], deep=True))
+        polydata = vtk.vtkPolyData()
+        polydata.SetPoints(points)
+        if mesh.get("normals") is not None:
+            polydata.GetPointData().SetNormals(numpy_to_vtk(mesh["normals"], deep=True))
+        for name, (offsets, connectivity) in mesh["cells"].items():
+            cells = vtk.vtkCellArray()
+            cells.SetData(
+                numpy_to_vtkIdTypeArray(offsets, deep=True),
+                numpy_to_vtkIdTypeArray(connectivity, deep=True),
+            )
+            {
+                "polys": polydata.SetPolys,
+                "lines": polydata.SetLines,
+                "verts": polydata.SetVerts,
+                "strips": polydata.SetStrips,
+            }[name](cells)
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputData(polydata)
+        actor = vtk.vtkActor()
+        actor.SetMapper(mapper)
+        matrix = vtk.vtkMatrix4x4()
+        matrix.DeepCopy(mesh["matrix"].ravel())
+        actor.SetUserMatrix(matrix)
+        _style_3d_actor(actor, mesh, theme)
+        actors.append(actor)
+    viewer._scene_actor_specs = list(zip(actors, data["meshes"], strict=True))
+    viewer.renderer.RemoveAllViewProps()
+    for actor in actors:
+        viewer.renderer.AddActor(actor)
+    if (
+        not viewer._has_scene
+        or getattr(viewer, "_scene_document_id", None) != context["document_id"]
+    ):
+        viewer.renderer.ResetCamera()
+    viewer._has_scene = True
+    viewer._scene_document_id = context["document_id"]
+    viewer.renderer.ResetCameraClippingRange()
+    viewer.vtkWidget.GetRenderWindow().Render()
+
+
+def _style_3d_actor(actor, mesh, theme):
+    prop = actor.GetProperty()
+    if mesh["role"] == "ray":
+        cycle = theme.get("ray_cycle")
+        color = (
+            to_rgb(cycle[mesh["color_index"] % len(cycle)]) if cycle else mesh["color"]
+        )
+    else:
+        color = to_rgb(theme.get("lens.color", "white"))
+    prop.SetColor(color)
+    prop.SetOpacity(mesh["opacity"])
+    prop.SetAmbient(mesh["ambient"])
+    prop.SetDiffuse(mesh["diffuse"])
+    prop.SetSpecular(mesh["specular"])
+    prop.SetSpecularPower(mesh["power"])
+    prop.SetLineWidth(mesh["linewidth"])
+
+
+def present_sag(viewer, data, context, restyle=False):
+    """Plot already computed sag values without calling surface geometry."""
+    import numpy as np
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+    gui_plot_utils.apply_gui_matplotlib_styles(viewer.current_theme)
+    viewer.figure.clear()
+    axes = viewer.figure.add_subplot(111)
+    divider = make_axes_locatable(axes)
+    bottom = divider.append_axes("bottom", size="25%", pad=0.25, sharex=axes)
+    right = divider.append_axes("right", size="25%", pad=0.25, sharey=axes)
+    color_axes = divider.append_axes("top", size="5%", pad=0.25)
+    x, y = np.meshgrid(data["coordinates"], data["coordinates"])
+    contours = axes.contourf(x, y, data["sag"], levels=50)
+    viewer.figure.colorbar(contours, cax=color_axes, orientation="horizontal")
+    parameters = data["parameters"]
+    axes.axhline(parameters["y_cross_section"], color="red", linestyle="--")
+    axes.axvline(parameters["x_cross_section"], color="blue", linestyle="--")
+    axes.set_aspect("equal")
+    axes.set_title(
+        f"Surface S{parameters['surface_index']} | "
+        f"View: ±{parameters['max_extent']:.2f} mm",
+        pad=65,
+    )
+    axes.set_ylabel("Y-coordinate (mm)")
+    bottom.plot(data["coordinates"], data["profile_x"], color="red")
+    right.plot(data["profile_y"], data["coordinates"], color="blue")
+    bottom.set_xlabel("X-coordinate (mm)")
+    bottom.set_ylabel("Sag (z)")
+    right.set_xlabel("Sag (z)")
+    viewer.canvas.draw_idle()

--- a/optiland_gui/main_window.py
+++ b/optiland_gui/main_window.py
@@ -23,6 +23,7 @@ from PySide6.QtCore import (
     QPropertyAnimation,
     QSettings,
     Qt,
+    QTimer,
     Slot,
 )
 from PySide6.QtGui import QAction, QIcon, QKeySequence, QResizeEvent, QShortcut
@@ -873,11 +874,24 @@ class MainWindow(FramelessWindow):
         self._load_layout_from_slot(2)
 
     def closeEvent(self, event: QEvent) -> None:
-        """Shut down the Jupyter kernel and accept the close event."""
+        """Revoke calculations and wait asynchronously before destroying Qt owners."""
+        if not getattr(self, "_calculation_shutdown_complete", False):
+            event.ignore()
+            if not getattr(self, "_calculation_shutdown_requested", False):
+                self._calculation_shutdown_requested = True
+                jobs = self.connector.calculation_jobs
+                jobs.stopped.connect(self._calculations_stopped)
+                jobs.shutdown()
+            return
         logger.debug("Closing application.")
         if hasattr(self, "panel_manager") and self.panel_manager.python_terminal:
             self.panel_manager.python_terminal.shutdown_kernel()
         event.accept()
+
+    @Slot()
+    def _calculations_stopped(self) -> None:
+        self._calculation_shutdown_complete = True
+        QTimer.singleShot(0, self.close)
 
     @Slot()
     def show_settings_wip(self):

--- a/optiland_gui/optiland_connector.py
+++ b/optiland_gui/optiland_connector.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import QObject, Signal
 
 from optiland.optic import Optic
 from optiland_gui.services.analysis_runner import AnalysisRunner
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
 from optiland_gui.services.file_service import (
     FileService,
     SpecialFloatEncoder,  # re-exported for backward compat
@@ -76,6 +77,12 @@ class OptilandConnector(QObject):
 
     def __init__(self) -> None:
         super().__init__()
+
+        # Invalidate before any panel handles the same synchronous notification.
+        self.document_state = DocumentState(self)
+        self.opticLoaded.connect(self.document_state.replace)
+        self.opticChanged.connect(self.document_state.change)
+        self.calculation_jobs = CalculationJobs(self.document_state, self)
 
         self._optic = Optic("Default System")
         self._undo_redo_manager = UndoRedoManager(self)

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -108,6 +108,7 @@ class CalculationJobs(QObject):
         parameters: dict,
         *,
         replace: bool = True,
+        cancel_on_document_change: bool = True,
         context: Any = None,
     ) -> JobRequest:
         """Queue detached inputs; replace previews while keeping explicit FIFO jobs."""
@@ -129,6 +130,7 @@ class CalculationJobs(QObject):
             handler,
             snapshot,
             pickle.loads(pickle.dumps(parameters, protocol=5)),
+            cancel_on_document_change,
             context,
         )
         self._pending.append(request)
@@ -137,6 +139,11 @@ class CalculationJobs(QObject):
         return request
 
     def is_current(self, request: JobRequest) -> bool:
+        """Recheck immediately before presentation/commit, even after a result signal.
+
+        Detached explicit jobs may finish against an older document; their data
+        can be offered for review but never automatically overwrite current edits.
+        """
         return (
             not self._closed
             and request.document == self.document.token
@@ -171,8 +178,13 @@ class CalculationJobs(QObject):
     def _document_changed(self, token: DocumentToken) -> None:
         pending, self._pending = self._pending, deque()
         for request in pending:
-            self._terminal(request, "cancelled")
-        if self._active is not None:
+            if self._closed or request.cancel_on_document_change:
+                self._terminal(request, "cancelled")
+            else:
+                self._pending.append(request)
+        if self._active is not None and (
+            self._closed or self._active.cancel_on_document_change
+        ):
             self._request_cancel()
 
     def _request_cancel(self) -> None:
@@ -187,7 +199,13 @@ class CalculationJobs(QObject):
     def _dispatch(self) -> None:
         if self._closed or self._active is not None or not self._pending:
             return
-        if not self.is_current(self._pending[0]):
+        request = self._pending[0]
+        eligible = (
+            request.generation == self._generations.get(request.target, 0)
+            and self._visible.get(request.target, True)
+            and (not request.cancel_on_document_change or self.is_current(request))
+        )
+        if not eligible:
             self._terminal(self._pending.popleft(), "cancelled")
             QTimer.singleShot(0, self._dispatch)
             return

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -268,9 +268,8 @@ class CalculationJobs(QObject):
                 # In-band protocol-5 decoding owns reconstructed array buffers.
                 # Decode directly from the receive storage instead of making a
                 # bytearray slice and a second full-size bytes copy on Qt.
-                with memoryview(self._buffer) as frame:
-                    with frame[4 : 4 + size] as payload:
-                        message = pickle.loads(payload)
+                with memoryview(self._buffer) as frame, frame[4 : 4 + size] as payload:
+                    message = pickle.loads(payload)
                 del self._buffer[: 4 + size]
                 self._message(message)
         except Exception as exc:

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -1,0 +1,365 @@
+"""GUI-owned, bounded calculation queue with asynchronous process teardown."""
+
+from __future__ import annotations
+
+import pickle
+import struct
+import sys
+import uuid
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QTimer, Signal, Slot
+
+from optiland_gui.services.calculation_worker import MAX_MESSAGE_BYTES, encode_message
+from optiland_gui.services.job_records import (
+    BackendConfig,
+    DocumentToken,
+    JobRequest,
+    JobResult,
+)
+
+if TYPE_CHECKING:
+    from optiland_gui.services.job_records import OpticSnapshot
+
+
+class DocumentState(QObject):
+    """Conservative revision boundary, connected before any panel subscriptions."""
+
+    changed = Signal(object)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self.token = DocumentToken(uuid.uuid4().hex, 0)
+
+    @Slot()
+    def change(self) -> None:
+        self.token = DocumentToken(self.token.document_id, self.token.revision + 1)
+        self.changed.emit(self.token)
+
+    @Slot()
+    def replace(self) -> None:
+        self.token = DocumentToken(uuid.uuid4().hex, 0)
+        self.changed.emit(self.token)
+
+
+class CalculationJobs(QObject):
+    """One persistent process and a finite queue of detached calculations.
+
+    Signals are emitted by this GUI-owned QObject. Receivers that access widgets
+    must be GUI-owned QObject slots. Every submitted job receives one terminal
+    result, including replaced pending work. Only ``result.current`` grants
+    permission to present or commit; consumers may keep obsolete data separately.
+    """
+
+    state_changed = Signal(object, str)
+    progress = Signal(object, dict)
+    finished = Signal(object)
+    stopped = Signal()
+
+    def __init__(
+        self,
+        document: DocumentState,
+        parent: QObject | None = None,
+        *,
+        max_pending: int = 16,
+        cancel_grace_ms: int = 1000,
+        worker_command: list[str] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.document = document
+        self.max_pending = max_pending
+        self._cancel_grace_ms = cancel_grace_ms
+        self._command = worker_command or [
+            sys.executable,
+            "-u",
+            "-m",
+            "optiland_gui.services.calculation_worker",
+        ]
+        self._pending: deque[JobRequest] = deque()
+        self._active: JobRequest | None = None
+        self._process: QProcess | None = None
+        self._ready = False
+        self._buffer = bytearray()
+        self._stderr = ""
+        self._generations: dict[str, int] = {}
+        self._visible: dict[str, bool] = {}
+        self._serial = 0
+        self._closed = False
+        self._cancelling = False
+        self._kill_timer = QTimer(self)
+        self._kill_timer.setSingleShot(True)
+        self._kill_timer.timeout.connect(self._kill_worker)
+        document.changed.connect(self._document_changed)
+
+    @property
+    def running(self) -> bool:
+        return self._active is not None or bool(self._pending)
+
+    @property
+    def active_request(self) -> JobRequest | None:
+        return self._active
+
+    def submit(
+        self,
+        target: str,
+        handler: str,
+        snapshot: OpticSnapshot | None,
+        parameters: dict,
+        *,
+        replace: bool = True,
+        context: Any = None,
+    ) -> JobRequest:
+        """Queue detached inputs; replace previews while keeping explicit FIFO jobs."""
+        if self._closed:
+            raise RuntimeError("Calculation service is closed.")
+        if replace:
+            self.cancel_target(target)
+        if len(self._pending) >= self.max_pending:
+            raise RuntimeError(
+                "Calculation queue is full; wait or cancel a pending job."
+            )
+        self._serial += 1
+        generation = self._generations.setdefault(target, 0)
+        request = JobRequest(
+            self._serial,
+            self.document.token,
+            target,
+            generation,
+            handler,
+            snapshot,
+            pickle.loads(pickle.dumps(parameters, protocol=5)),
+            context,
+        )
+        self._pending.append(request)
+        self.state_changed.emit(request, "queued")
+        QTimer.singleShot(0, self._dispatch)
+        return request
+
+    def is_current(self, request: JobRequest) -> bool:
+        return (
+            not self._closed
+            and request.document == self.document.token
+            and request.generation == self._generations.get(request.target, 0)
+            and self._visible.get(request.target, True)
+            and (
+                request.snapshot is None
+                or request.snapshot.backend == BackendConfig.capture()
+            )
+        )
+
+    def set_target_visible(self, target: str, visible: bool) -> None:
+        """Revoke a hidden target immediately; showing it allows fresh submissions."""
+        self._visible[target] = visible
+        if not visible:
+            self.cancel_target(target)
+
+    def cancel_target(self, target: str) -> None:
+        self._generations[target] = self._generations.get(target, 0) + 1
+        retained = deque()
+        cancelled = []
+        while self._pending:
+            request = self._pending.popleft()
+            (cancelled if request.target == target else retained).append(request)
+        self._pending = retained
+        for request in cancelled:
+            self._terminal(request, "cancelled")
+        if self._active is not None and self._active.target == target:
+            self._request_cancel()
+
+    @Slot(object)
+    def _document_changed(self, token: DocumentToken) -> None:
+        pending, self._pending = self._pending, deque()
+        for request in pending:
+            self._terminal(request, "cancelled")
+        if self._active is not None:
+            self._request_cancel()
+
+    def _request_cancel(self) -> None:
+        if self._active is None or self._cancelling:
+            return
+        self._cancelling = True
+        self.state_changed.emit(self._active, "cancelling")
+        self._send({"command": "cancel", "job_id": self._active.job_id})
+        self._kill_timer.start(self._cancel_grace_ms)
+
+    @Slot()
+    def _dispatch(self) -> None:
+        if self._closed or self._active is not None or not self._pending:
+            return
+        if not self.is_current(self._pending[0]):
+            self._terminal(self._pending.popleft(), "cancelled")
+            QTimer.singleShot(0, self._dispatch)
+            return
+        if self._process is None:
+            self._launch()
+            return
+        if not self._ready:
+            return
+        request = self._pending.popleft()
+        self._active = request
+        self._cancelling = False
+        try:
+            self._send(request.worker_message())
+        except Exception as exc:
+            self._active = None
+            self._terminal(request, "failed", error=str(exc))
+            QTimer.singleShot(0, self._dispatch)
+            return
+        self.state_changed.emit(request, "running")
+
+    def _launch(self) -> None:
+        process = self._process = QProcess(self)
+        process.setProgram(self._command[0])
+        process.setArguments(self._command[1:])
+        environment = QProcessEnvironment.systemEnvironment()
+        # Leave CPU capacity for Qt; each worker has independent backend state.
+        for name in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS"):
+            if not environment.contains(name):
+                environment.insert(name, "1")
+        environment.insert("MPLBACKEND", "Agg")
+        process.setProcessEnvironment(environment)
+        self._buffer.clear()
+        self._stderr = ""
+        self._ready = False
+        process.readyReadStandardOutput.connect(self._read_stdout)
+        process.readyReadStandardError.connect(self._read_stderr)
+        process.finished.connect(self._process_finished)
+        process.errorOccurred.connect(self._process_error)
+        process.start()
+        self._kill_timer.start(30000)
+
+    def _send(self, message: dict) -> None:
+        if self._process is not None:
+            self._process.write(encode_message(message))
+
+    @Slot()
+    def _read_stdout(self) -> None:
+        process = self.sender()
+        if process is not self._process:
+            return
+        self._buffer.extend(bytes(process.readAllStandardOutput()))
+        try:
+            while len(self._buffer) >= 4:
+                size = struct.unpack("!I", self._buffer[:4])[0]
+                if size > MAX_MESSAGE_BYTES:
+                    raise ValueError("Invalid calculation-worker message size.")
+                if len(self._buffer) < 4 + size:
+                    break
+                payload = bytes(self._buffer[4 : 4 + size])
+                del self._buffer[: 4 + size]
+                self._message(pickle.loads(payload))
+        except Exception as exc:
+            self._stderr = str(exc)
+            self._kill_worker()
+
+    def _message(self, message: dict) -> None:
+        if message["event"] == "ready":
+            self._kill_timer.stop()
+            self._ready = True
+            if self._closed:
+                self._send({"command": "shutdown"})
+                self._kill_timer.start(self._cancel_grace_ms)
+                return
+            self._dispatch()
+            return
+        request = self._active
+        if request is None or message.get("job_id") != request.job_id:
+            return
+        if message["event"] == "progress":
+            if not self._cancelling and self.is_current(request):
+                self.progress.emit(request, message)
+        elif message["event"] == "result":
+            self._kill_timer.stop()
+            status = "cancelled" if self._cancelling else message["status"]
+            self._active = None
+            self._cancelling = False
+            self._terminal(
+                request, status, message.get("data"), message.get("error", "")
+            )
+            if self._closed:
+                self._send({"command": "shutdown"})
+                self._kill_timer.start(self._cancel_grace_ms)
+            QTimer.singleShot(0, self._dispatch)
+
+    def _terminal(
+        self, request: JobRequest, status: str, data: Any = None, error: str = ""
+    ) -> None:
+        self.state_changed.emit(request, status)
+        self.finished.emit(
+            JobResult(
+                request,
+                status,
+                data,
+                error,
+                status != "cancelled" and self.is_current(request),
+            )
+        )
+
+    @Slot()
+    def _read_stderr(self) -> None:
+        process = self.sender()
+        if process is self._process:
+            self._stderr = (
+                self._stderr
+                + bytes(process.readAllStandardError()).decode(
+                    "utf-8", errors="replace"
+                )
+            )[-16000:]
+
+    @Slot()
+    def _kill_worker(self) -> None:
+        if self._process is not None:
+            self._process.kill()
+
+    @Slot(int, QProcess.ExitStatus)
+    def _process_finished(self, code: int, status: QProcess.ExitStatus) -> None:
+        self._release_process()
+
+    @Slot(QProcess.ProcessError)
+    def _process_error(self, error: QProcess.ProcessError) -> None:
+        if error == QProcess.ProcessError.FailedToStart:
+            self._release_process()
+
+    def _release_process(self) -> None:
+        process = self.sender()
+        if process is not self._process:
+            return
+        self._process = None
+        self._ready = False
+        self._kill_timer.stop()
+        process.deleteLater()
+        if self._active is not None:
+            request, self._active = self._active, None
+            self._terminal(
+                request,
+                "cancelled" if self._cancelling else "failed",
+                error=self._stderr or "Calculation worker exited unexpectedly.",
+            )
+        elif not self._closed and self._pending:
+            # A failed launch must not loop forever, or leave queued controls busy.
+            pending, self._pending = self._pending, deque()
+            for request in pending:
+                self._terminal(
+                    request,
+                    "failed",
+                    error=self._stderr or "Could not start the calculation worker.",
+                )
+        self._cancelling = False
+        if self._closed:
+            self.stopped.emit()
+        else:
+            QTimer.singleShot(0, self._dispatch)
+
+    @Slot()
+    def shutdown(self) -> None:
+        """Revoke results and reap asynchronously; callers never join on the GUI."""
+        if self._closed:
+            return
+        self._closed = True
+        self._document_changed(self.document.token)
+        if self._process is None:
+            self.stopped.emit()
+        elif self._active is None:
+            self._send({"command": "shutdown"})
+            self._kill_timer.start(self._cancel_grace_ms)

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -256,17 +256,23 @@ class CalculationJobs(QObject):
         process = self.sender()
         if process is not self._process:
             return
-        self._buffer.extend(bytes(process.readAllStandardOutput()))
+        chunk = process.readAllStandardOutput()
+        self._buffer.extend(memoryview(chunk))
         try:
             while len(self._buffer) >= 4:
-                size = struct.unpack("!I", self._buffer[:4])[0]
+                size = struct.unpack_from("!I", self._buffer)[0]
                 if size > MAX_MESSAGE_BYTES:
                     raise ValueError("Invalid calculation-worker message size.")
                 if len(self._buffer) < 4 + size:
                     break
-                payload = bytes(self._buffer[4 : 4 + size])
+                # In-band protocol-5 decoding owns reconstructed array buffers.
+                # Decode directly from the receive storage instead of making a
+                # bytearray slice and a second full-size bytes copy on Qt.
+                with memoryview(self._buffer) as frame:
+                    with frame[4 : 4 + size] as payload:
+                        message = pickle.loads(payload)
                 del self._buffer[: 4 + size]
-                self._message(pickle.loads(payload))
+                self._message(message)
         except Exception as exc:
             self._stderr = str(exc)
             self._kill_worker()

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -48,8 +48,9 @@ class CalculationJobs(QObject):
 
     Signals are emitted by this GUI-owned QObject. Receivers that access widgets
     must be GUI-owned QObject slots. Every submitted job receives one terminal
-    result, including replaced pending work. Only ``result.current`` grants
-    permission to present or commit; consumers may keep obsolete data separately.
+    result, including replaced pending work. Recheck ``is_current(request)``
+    immediately before presenting or committing; ``result.current`` is only the
+    signal-time hint. Consumers may keep obsolete data separately.
     """
 
     state_changed = Signal(object, str)

--- a/optiland_gui/services/calculation_worker.py
+++ b/optiland_gui/services/calculation_worker.py
@@ -24,6 +24,31 @@ def encode_message(message: dict) -> bytes:
     return struct.pack("!I", len(payload)) + payload
 
 
+def _progress_reporter(job_id, cancelled, send):
+    """Create a cancellation-aware reporter for counts and plain job metadata."""
+
+    def progress(
+        stage: str,
+        completed: int | None = None,
+        total: int | None = None,
+        *,
+        details: dict | None = None,
+    ) -> None:
+        check_cancelled(cancelled)
+        send(
+            {
+                "event": "progress",
+                "job_id": job_id,
+                "stage": stage,
+                "completed": completed,
+                "total": total,
+                "details": details,
+            }
+        )
+
+    return progress
+
+
 def main() -> None:
     """Keep cancellation readable while numerical work occupies the main thread."""
     incoming: queue.Queue = queue.Queue()
@@ -75,24 +100,7 @@ def main() -> None:
         with state_lock:
             cancelled = cancellations[job_id]
 
-        def progress(
-            stage: str,
-            completed: int | None = None,
-            total: int | None = None,
-            *,
-            _cancelled=cancelled,
-            _job_id=job_id,
-        ) -> None:
-            check_cancelled(_cancelled)
-            send(
-                {
-                    "event": "progress",
-                    "job_id": _job_id,
-                    "stage": stage,
-                    "completed": completed,
-                    "total": total,
-                }
-            )
+        progress = _progress_reporter(job_id, cancelled, send)
 
         try:
             check_cancelled(cancelled)

--- a/optiland_gui/services/calculation_worker.py
+++ b/optiland_gui/services/calculation_worker.py
@@ -1,0 +1,133 @@
+"""Private persistent worker; stdout contains only framed job messages."""
+
+from __future__ import annotations
+
+import importlib
+import pickle
+import queue
+import struct
+import sys
+import threading
+import traceback
+from contextlib import redirect_stdout
+
+from optiland_gui.services.job_records import CalculationCancelled, check_cancelled
+
+MAX_MESSAGE_BYTES = 256 * 1024 * 1024
+
+
+def encode_message(message: dict) -> bytes:
+    """Encode one internally generated message; never an external file format."""
+    payload = pickle.dumps(message, protocol=5)
+    if len(payload) > MAX_MESSAGE_BYTES:
+        raise ValueError("Calculation message exceeds the 256 MiB transfer limit.")
+    return struct.pack("!I", len(payload)) + payload
+
+
+def main() -> None:
+    """Keep cancellation readable while numerical work occupies the main thread."""
+    incoming: queue.Queue = queue.Queue()
+    cancellations: dict[int, threading.Event] = {}
+    state_lock = threading.Lock()
+    output = sys.stdout.buffer
+
+    def send(message: dict) -> None:
+        output.write(encode_message(message))
+        output.flush()
+
+    def read_exact(count: int) -> bytes:
+        parts = bytearray()
+        while len(parts) < count:
+            part = sys.stdin.buffer.read(count - len(parts))
+            if not part:
+                raise EOFError()
+            parts.extend(part)
+        return bytes(parts)
+
+    def read_commands() -> None:
+        try:
+            while True:
+                size = struct.unpack("!I", read_exact(4))[0]
+                if size > MAX_MESSAGE_BYTES:
+                    raise ValueError("Calculation request is too large.")
+                message = pickle.loads(read_exact(size))
+                if message["command"] == "cancel":
+                    with state_lock:
+                        event = cancellations.get(message["job_id"])
+                        if event is not None:
+                            event.set()
+                elif message["command"] == "run":
+                    with state_lock:
+                        cancellations[message["job_id"]] = threading.Event()
+                    incoming.put(message)
+                elif message["command"] == "shutdown":
+                    break
+        finally:
+            with state_lock:
+                for event in cancellations.values():
+                    event.set()
+            incoming.put(None)
+
+    threading.Thread(target=read_commands, daemon=True).start()
+    send({"event": "ready"})
+    while (message := incoming.get()) is not None:
+        job_id = message["job_id"]
+        with state_lock:
+            cancelled = cancellations[job_id]
+
+        def progress(
+            stage: str,
+            completed: int | None = None,
+            total: int | None = None,
+            *,
+            _cancelled=cancelled,
+            _job_id=job_id,
+        ) -> None:
+            check_cancelled(_cancelled)
+            send(
+                {
+                    "event": "progress",
+                    "job_id": _job_id,
+                    "stage": stage,
+                    "completed": completed,
+                    "total": total,
+                }
+            )
+
+        try:
+            check_cancelled(cancelled)
+            module_name, function_name = message["handler"].split(":", 1)
+            if not module_name.startswith("optiland_gui."):
+                raise ValueError("Calculation handlers must belong to optiland_gui.")
+            with redirect_stdout(sys.stderr):
+                handler = getattr(importlib.import_module(module_name), function_name)
+                result = handler(
+                    message["snapshot"], message["parameters"], progress, cancelled
+                )
+            check_cancelled(cancelled)
+            send(
+                {
+                    "event": "result",
+                    "job_id": job_id,
+                    "status": "succeeded",
+                    "data": result,
+                }
+            )
+        except CalculationCancelled:
+            send({"event": "result", "job_id": job_id, "status": "cancelled"})
+        except Exception:
+            send(
+                {
+                    "event": "result",
+                    "job_id": job_id,
+                    "status": "failed",
+                    "error": traceback.format_exc(),
+                }
+            )
+        finally:
+            with state_lock:
+                cancellations.pop(job_id, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 from dataclasses import dataclass, field
+from types import MethodType
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -76,12 +77,23 @@ class OpticSnapshot:
                 ("generate_rays",),
             ),
         ):
-            if component is not None and any(
-                name in vars(component) for name in methods
-            ):
-                raise ValueError(
-                    "This custom tracing model needs an owned snapshot adapter."
-                )
+            if component is None:
+                continue
+            for name in methods:
+                if name not in vars(component):
+                    continue
+                method = vars(component)[name]
+                # Restoring an instrumented method may bind the unchanged class
+                # implementation on the instance. Only that exact same-owner
+                # method is equivalent to what the serializer reconstructs.
+                if not (
+                    isinstance(method, MethodType)
+                    and method.__self__ is component
+                    and method.__func__ is getattr(type(component), name, None)
+                ):
+                    raise ValueError(
+                        "This custom tracing model needs an owned snapshot adapter."
+                    )
         component_types = _component_types(optic)
         return cls(
             pickle.dumps(optic.to_dict(), protocol=5),

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -1,0 +1,115 @@
+"""Owned calculation inputs and revision-tagged results (no Qt objects)."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from optiland.optic import Optic
+
+
+@dataclass(frozen=True)
+class DocumentToken:
+    """Identity and optical revision of a GUI-owned document."""
+
+    document_id: str
+    revision: int
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    """Backend configuration explicitly installed in the calculation process."""
+
+    name: str = "numpy"
+    device: str = "cpu"
+    precision: int = 64
+
+    @classmethod
+    def capture(cls) -> BackendConfig:
+        import optiland.backend as be
+
+        name = be.get_backend()
+        if name == "torch":
+            return cls(name, be.get_device(), be.get_precision())
+        return cls(name)
+
+    def apply(self) -> None:
+        import optiland.backend as be
+
+        be.set_backend(self.name)
+        if self.name == "torch":
+            be.set_device(self.device)
+            be.set_precision(f"float{self.precision}")
+
+
+@dataclass(frozen=True)
+class OpticSnapshot:
+    """Detached prescription bytes; capturing does not run the optic updater.
+
+    The internal pickle transports our own serializer output, including existing
+    polarization records and arrays. It is never loaded from an external file.
+    The public Optiland data format remains unchanged.
+    """
+
+    data: bytes
+    backend: BackendConfig
+
+    @classmethod
+    def capture(cls, optic: Optic) -> OpticSnapshot:
+        return cls(pickle.dumps(optic.to_dict(), protocol=5), BackendConfig.capture())
+
+    def restore(self) -> Optic:
+        from optiland.optic import Optic
+
+        self.backend.apply()
+        return Optic.from_dict(pickle.loads(self.data))
+
+
+@dataclass(frozen=True)
+class JobRequest:
+    """One calculation target generation and its detached inputs.
+
+    ``context`` belongs to the GUI only (for example captured surface identities).
+    The process transport deliberately excludes it.
+    """
+
+    job_id: int
+    document: DocumentToken
+    target: str
+    generation: int
+    handler: str
+    snapshot: OpticSnapshot | None
+    parameters: dict[str, Any]
+    context: Any = field(default=None, compare=False, repr=False)
+
+    def worker_message(self) -> dict:
+        return {
+            "command": "run",
+            "job_id": self.job_id,
+            "handler": self.handler,
+            "snapshot": self.snapshot,
+            "parameters": self.parameters,
+        }
+
+
+@dataclass(frozen=True)
+class JobResult:
+    """Terminal calculation outcome, with GUI-side freshness determined once."""
+
+    request: JobRequest
+    status: str
+    data: Any = None
+    error: str = ""
+    current: bool = False
+
+
+class CalculationCancelled(Exception):
+    """Raised at a safe numerical checkpoint after cancellation."""
+
+
+def check_cancelled(cancelled: Any) -> None:
+    """Stop numerical work at a safe boundary if cancellation was requested."""
+    if cancelled.is_set():
+        raise CalculationCancelled()

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -82,6 +82,7 @@ class JobRequest:
     handler: str
     snapshot: OpticSnapshot | None
     parameters: dict[str, Any]
+    cancel_on_document_change: bool = True
     context: Any = field(default=None, compare=False, repr=False)
 
     def worker_message(self) -> dict:

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -55,16 +55,65 @@ class OpticSnapshot:
 
     data: bytes
     backend: BackendConfig
+    component_types: tuple = ()
 
     @classmethod
     def capture(cls, optic: Optic) -> OpticSnapshot:
-        return cls(pickle.dumps(optic.to_dict(), protocol=5), BackendConfig.capture())
+        from optiland.optic import Optic
+
+        if type(optic).trace is not Optic.trace or "trace" in vars(optic):
+            raise ValueError(
+                "This custom tracing model needs an owned snapshot adapter."
+            )
+        component_types = _component_types(optic)
+        return cls(
+            pickle.dumps(optic.to_dict(), protocol=5),
+            BackendConfig.capture(),
+            component_types,
+        )
 
     def restore(self) -> Optic:
         from optiland.optic import Optic
 
         self.backend.apply()
-        return Optic.from_dict(pickle.loads(self.data))
+        optic = Optic.from_dict(pickle.loads(self.data))
+        if self.component_types and _component_types(optic) != self.component_types:
+            raise ValueError(
+                "Snapshot reconstruction changed an optical component type."
+            )
+        return optic
+
+
+def _component_types(optic: Optic) -> tuple:
+    """Reject unsupported runtime extensions rather than silently losing their type."""
+    components = [optic.aperture, optic.apodization, optic.fields.field_definition]
+    for surface in optic.surfaces:
+        components.extend(
+            (
+                surface,
+                surface.geometry,
+                surface.geometry.cs,
+                surface.material_post,
+                surface.aperture,
+                surface.interaction_model,
+                getattr(surface.interaction_model, "coating", None),
+                getattr(surface, "source", None),
+            )
+        )
+    components.extend(optic.pickups.pickups)
+    components.extend(optic.solves.solves)
+    records = []
+    for component in components:
+        if component is None:
+            records.append(None)
+            continue
+        cls = type(component)
+        if not cls.__module__.startswith("optiland."):
+            raise ValueError(
+                f"Custom component {cls.__qualname__} needs a snapshot adapter."
+            )
+        records.append((cls.__module__, cls.__qualname__))
+    return tuple(records)
 
 
 @dataclass(frozen=True)

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -61,10 +61,27 @@ class OpticSnapshot:
     def capture(cls, optic: Optic) -> OpticSnapshot:
         from optiland.optic import Optic
 
-        if type(optic).trace is not Optic.trace or "trace" in vars(optic):
+        if any(
+            getattr(type(optic), name) is not getattr(Optic, name)
+            for name in ("trace", "trace_generic")
+        ):
             raise ValueError(
                 "This custom tracing model needs an owned snapshot adapter."
             )
+        for component, methods in (
+            (optic, ("trace", "trace_generic")),
+            (optic.ray_tracer, ("trace", "trace_generic")),
+            (
+                getattr(optic.ray_tracer, "ray_generator", None),
+                ("generate_rays",),
+            ),
+        ):
+            if component is not None and any(
+                name in vars(component) for name in methods
+            ):
+                raise ValueError(
+                    "This custom tracing model needs an owned snapshot adapter."
+                )
         component_types = _component_types(optic)
         return cls(
             pickle.dumps(optic.to_dict(), protocol=5),
@@ -86,7 +103,13 @@ class OpticSnapshot:
 
 def _component_types(optic: Optic) -> tuple:
     """Reject unsupported runtime extensions rather than silently losing their type."""
-    components = [optic.aperture, optic.apodization, optic.fields.field_definition]
+    components = [
+        optic.aperture,
+        optic.apodization,
+        optic.fields.field_definition,
+        optic.ray_tracer,
+        getattr(optic.ray_tracer, "ray_generator", None),
+    ]
     for surface in optic.surfaces:
         components.extend(
             (

--- a/optiland_gui/services/layout_tasks.py
+++ b/optiland_gui/services/layout_tasks.py
@@ -1,0 +1,312 @@
+"""Prepare owned layout geometry in the calculation process.
+
+Existing plotters run against an isolated, noninteractive Matplotlib figure or
+render-free VTK collector. Only copied numerical arrays and plain metadata leave
+the process: no figure, artist, actor, render context, or Optic is transported.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import optiland.backend as be
+from optiland_gui.services.job_records import check_cancelled
+
+
+def _surface_indices(component, indices):
+    if hasattr(component, "surfaces"):
+        return tuple(indices[id(surface.surf)] for surface in component.surfaces)
+    surface = getattr(component, "surf", component)
+    index = indices.get(id(surface))
+    return () if index is None else (index,)
+
+
+def prepare_2d(snapshot, parameters, progress, cancelled):
+    """Return themed-independent 2D primitives and surface/body ownership."""
+    from matplotlib.figure import Figure
+    from matplotlib.text import Annotation
+
+    from optiland.visualization.system.lens import Lens2D
+    from optiland.visualization.system.ray_bundle import RayBundle
+    from optiland.visualization.system.rays import Rays2D
+    from optiland.visualization.system.surface import Surface2D
+    from optiland.visualization.system.system import OpticalSystem
+    from optiland.visualization.system.utils import transform
+
+    progress("Restoring optical snapshot")
+    optic = snapshot.restore()
+    indices = {id(surface): i for i, surface in enumerate(optic.surfaces)}
+    figure = Figure()
+    axes = figure.add_subplot()
+    rays = Rays2D(optic)
+    progress("Tracing layout rays")
+    ray_artists = rays.plot(
+        axes,
+        fields="all",
+        wavelengths="primary",
+        num_rays=parameters["num_rays"],
+        distribution=parameters["distribution"],
+    )
+    check_cancelled(cancelled)
+    progress("Preparing optical outlines")
+    system = OpticalSystem(optic, rays, projection="2d")
+    artists = {**ray_artists, **system.plot(axes)}
+    primitives = []
+    boundaries = {}
+    references = {}
+    surface_views = {}
+    for component in system.components:
+        if isinstance(component, Lens2D):
+            surface_views.update((id(item.surf), item) for item in component.surfaces)
+        elif isinstance(component, Surface2D):
+            surface_views[id(component.surf)] = component
+    for line in axes.lines:
+        component = artists.get(line)
+        role = "ray" if isinstance(component, RayBundle) else "surface"
+        if id(component) in indices:
+            role = "aperture"
+        primitives.append(
+            {
+                "kind": "line",
+                "xy": line.get_xydata().copy(),
+                "role": role,
+                "surfaces": _surface_indices(component, indices),
+                "color_index": int(component.bundle_id.rsplit("_", 1)[-1])
+                if role == "ray"
+                else 0,
+                "linewidth": line.get_linewidth(),
+                "linestyle": line.get_linestyle(),
+                "label": line.get_label(),
+            }
+        )
+    for patch in axes.patches:
+        component = artists.get(patch)
+        if not hasattr(patch, "get_xy"):
+            raise ValueError("This component needs a numerical 2D layout adapter.")
+        owned = _surface_indices(component, indices)
+        pairs = getattr(component, "artist_surfaces", {})
+        if patch in pairs:
+            owned = tuple(indices[id(surface)] for surface in pairs[patch])
+        primitives.append(
+            {
+                "kind": "polygon",
+                "xy": patch.get_xy().copy(),
+                "role": "lens",
+                "surfaces": owned,
+                "linewidth": patch.get_linewidth(),
+            }
+        )
+    for component in system.components:
+        if isinstance(component, Lens2D):
+            sags = component._compute_sag()
+            for surface, (_x, y, z) in zip(component.surfaces, sags, strict=True):
+                boundaries[indices[id(surface.surf)]] = (
+                    be.to_numpy(z).copy(),
+                    be.to_numpy(y).copy(),
+                )
+    # Reference markers are available only on demand for editor highlighting.
+    # They are never added to the ordinary physical layout or ray path.
+    for index, surface in enumerate(optic.surfaces):
+        if index in boundaries or getattr(surface, "is_infinite", False):
+            continue
+        item = surface_views.get(id(surface))
+        if item is None:
+            item = Surface2D(surface, rays.r_extent[index])
+        projection = "XY" if item._is_face_on("YZ") else "YZ"
+        x, y, z = item._compute_sag(projection)
+        _, y, z = transform(x, y, z, surface, is_global=False)
+        references[index] = (be.to_numpy(z).copy(), be.to_numpy(y).copy())
+    annotations = [
+        {
+            "xy": tuple(text.xy),
+            "xytext": tuple(text.get_position()),
+            "arrowprops": dict(text.arrowprops),
+        }
+        for text in axes.texts
+        if isinstance(text, Annotation) and text.arrowprops
+    ]
+    check_cancelled(cancelled)
+    return {
+        "name": optic.name,
+        "primitives": primitives,
+        "boundaries": boundaries,
+        "references": references,
+        "annotations": annotations,
+        "extent": be.to_numpy(rays.r_extent).copy(),
+        "extent_sources": {
+            indices[identity]: item.extent_source
+            for identity, item in surface_views.items()
+            if hasattr(item, "extent_source")
+        },
+    }
+
+
+class _ActorCollector:
+    """Collect CPU-side actors without constructing a renderer or render window."""
+
+    def __init__(self):
+        self.actors = []
+
+    def AddActor(self, actor):  # noqa: N802
+        self.actors.append(actor)
+
+
+def prepare_3d(snapshot, parameters, progress, cancelled):
+    """Return VTK polydata arrays without any native rendering context."""
+    from vtk.util.numpy_support import vtk_to_numpy
+
+    from optiland.visualization.system.rays import Rays3D
+    from optiland.visualization.system.system import OpticalSystem
+
+    progress("Restoring optical snapshot")
+    optic = snapshot.restore()
+    indices = {id(surface): i for i, surface in enumerate(optic.surfaces)}
+    rays = Rays3D(optic)
+    collector = _ActorCollector()
+    progress("Tracing 3D rays")
+    rays.plot(
+        collector, fields="all", wavelengths="primary", num_rays=24, distribution="ring"
+    )
+    groups = [(actor, "ray", ()) for actor in collector.actors]
+    system = OpticalSystem(optic, rays, projection="3d")
+    system._identify_components()
+    for index, component in enumerate(system.components):
+        progress("Preparing 3D components", index, len(system.components))
+        collector.actors = []
+        component.plot(collector)
+        groups.extend(
+            (actor, "lens", _surface_indices(component, indices))
+            for actor in collector.actors
+        )
+    meshes = []
+    for index, (actor, role, surfaces) in enumerate(groups):
+        progress("Preparing display arrays", index, len(groups))
+        mapper = actor.GetMapper()
+        mapper.Update()
+        data = mapper.GetInput()
+        if data is None or data.GetPoints() is None:
+            continue
+        cells = {}
+        for name, source in (
+            ("polys", data.GetPolys()),
+            ("lines", data.GetLines()),
+            ("verts", data.GetVerts()),
+            ("strips", data.GetStrips()),
+        ):
+            if source.GetNumberOfCells():
+                cells[name] = (
+                    vtk_to_numpy(source.GetOffsetsArray()).copy(),
+                    vtk_to_numpy(source.GetConnectivityArray()).copy(),
+                )
+        matrix = actor.GetMatrix()
+        prop = actor.GetProperty()
+        color = tuple(prop.GetColor())
+        color_index = min(
+            range(len(rays._rgb_colors)),
+            key=lambda i: np.linalg.norm(np.asarray(rays._rgb_colors[i]) - color),
+        )
+        meshes.append(
+            {
+                "points": vtk_to_numpy(data.GetPoints().GetData()).copy(),
+                "cells": cells,
+                "matrix": np.array(
+                    [[matrix.GetElement(i, j) for j in range(4)] for i in range(4)]
+                ),
+                "color": color,
+                "color_index": color_index,
+                "opacity": prop.GetOpacity(),
+                "ambient": prop.GetAmbient(),
+                "diffuse": prop.GetDiffuse(),
+                "specular": prop.GetSpecular(),
+                "power": prop.GetSpecularPower(),
+                "linewidth": prop.GetLineWidth(),
+                "role": role,
+                "surfaces": surfaces,
+                "normals": vtk_to_numpy(data.GetPointData().GetNormals()).copy()
+                if data.GetPointData().GetNormals() is not None
+                else None,
+            }
+        )
+    check_cancelled(cancelled)
+    return {"name": optic.name, "meshes": _batch_ray_meshes(meshes)}
+
+
+def _batch_ray_meshes(meshes):
+    """Pack equal-style ray segments without changing vertices or connectivity.
+
+    The public renderer can produce one actor per segment. Sending one polydata
+    per style avoids hundreds of GUI-side actor allocations and draw calls.
+    Optical body ownership and surface meshes remain separate.
+    """
+    groups = {}
+    result = []
+    for mesh in meshes:
+        if mesh["role"] != "ray" or set(mesh["cells"]) != {"lines"}:
+            result.append(mesh)
+            continue
+        key = tuple(
+            mesh[name]
+            for name in (
+                "color",
+                "color_index",
+                "opacity",
+                "ambient",
+                "diffuse",
+                "specular",
+                "power",
+                "linewidth",
+            )
+        ) + (mesh["matrix"].tobytes(),)
+        if key not in groups:
+            groups[key] = []
+            result.append(groups[key])
+        groups[key].append(mesh)
+    batched = []
+    for item in result:
+        if isinstance(item, dict):
+            batched.append(item)
+            continue
+        points, offsets, connectivity = [], [np.array([0], dtype=np.int64)], []
+        point_count = cell_size = 0
+        for mesh in item:
+            mesh_offsets, mesh_cells = mesh["cells"]["lines"]
+            points.append(mesh["points"])
+            offsets.append(mesh_offsets[1:] + cell_size)
+            connectivity.append(mesh_cells + point_count)
+            point_count += len(mesh["points"])
+            cell_size += len(mesh_cells)
+        batched.append(
+            {
+                **item[0],
+                "points": np.concatenate(points),
+                "cells": {
+                    "lines": (np.concatenate(offsets), np.concatenate(connectivity))
+                },
+            }
+        )
+    return batched
+
+
+def prepare_sag(snapshot, parameters, progress, cancelled):
+    """Compute sag grid/profile arrays while keeping the embedded figure GUI-owned."""
+    progress("Computing surface sag")
+    optic = snapshot.restore()
+    surface = optic.surfaces[parameters["surface_index"]]
+    extent = parameters["max_extent"]
+    coordinates = be.linspace(-extent, extent, 50)
+    x, y = be.meshgrid(coordinates, coordinates)
+    sag = surface.geometry.sag(x, y)
+    profile_x = surface.geometry.sag(
+        coordinates, be.full_like(coordinates, parameters["y_cross_section"])
+    )
+    profile_y = surface.geometry.sag(
+        be.full_like(coordinates, parameters["x_cross_section"]), coordinates
+    )
+    check_cancelled(cancelled)
+    return {
+        "coordinates": be.to_numpy(coordinates).copy(),
+        "sag": be.to_numpy(sag).copy(),
+        "profile_x": be.to_numpy(profile_x).copy(),
+        "profile_y": be.to_numpy(profile_y).copy(),
+        "parameters": parameters,
+    }

--- a/optiland_gui/system_properties_panel.py
+++ b/optiland_gui/system_properties_panel.py
@@ -632,10 +632,16 @@ class PolarizationEditor(PropertyEditorBase):
 
         self.btnApply = QPushButton("Apply Polarization")
         main_layout.addWidget(self.btnApply)
+        self.lblApplied = QLabel()
+        self.lblApplied.setWordWrap(True)
+        main_layout.addWidget(self.lblApplied)
         main_layout.addStretch()
 
         self.cmbMode.currentIndexChanged.connect(self._on_mode_changed)
         self.btnApply.clicked.connect(self.apply_polarization)
+        self.cmbMode.currentIndexChanged.connect(self.lblApplied.clear)
+        for control in (self.spnEx, self.spnEy, self.spnPhaseX, self.spnPhaseY):
+            control.valueChanged.connect(self.lblApplied.clear)
 
         self._set_inputs_enabled(False)
 
@@ -751,6 +757,9 @@ class PolarizationEditor(PropertyEditorBase):
             )
             # Reload to display the normalized values the core computed
             self.load_data()
+            self.lblApplied.setText(
+                "Polarization applied. View updates are shown in the System Viewer."
+            )
         except ValueError as exc:
             self.lblError.setText(str(exc))
             self.lblError.show()

--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -10,10 +10,9 @@ plots and `VTKViewer` for 3D rendering.
 
 from __future__ import annotations
 
-import matplotlib
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PySide6.QtCore import Qt, Slot
+from PySide6.QtCore import Qt, QTimer, Slot
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -41,14 +40,10 @@ except ImportError:
 
 from typing import TYPE_CHECKING
 
-from optiland.visualization.analysis.surface_sag import SurfaceSagViewer
-from optiland.visualization.system.rays import Rays2D, Rays3D
-from optiland.visualization.system.system import (
-    OpticalSystem as OptilandOpticalSystemPlotter,
-)
-
 from . import gui_plot_utils
 from .analysis_panel import CustomMatplotlibToolbar
+from .layout_presenter import present_2d, present_3d, present_sag
+from .widgets.layout_job_view import LayoutJobView
 
 if TYPE_CHECKING:
     from .optiland_connector import OptilandConnector
@@ -104,7 +99,7 @@ class SagViewer(QWidget):
         for action in self.toolbar.actions():
             if action.toolTip() == "Reset original view":
                 action.triggered.disconnect()
-                action.triggered.connect(self.plot_sag)
+                action.triggered.connect(self.reset_view)
                 break
 
         # --- Cursor Coordinate Label ---
@@ -161,10 +156,24 @@ class SagViewer(QWidget):
         main_layout.addWidget(self.settings_area)
 
         # Initial setup
+        self.layout_job = LayoutJobView(
+            self, "sag", plot_layout, self._layout_parameters, self._present_layout
+        )
         self.connector.opticChanged.connect(self.update_surface_range)
         self.update_surface_range()
-        self.plot_sag()
+        self.layout_job.redraw()
         self.update_theme()
+
+    def _layout_parameters(self):
+        return {
+            "surface_index": self.surface_selector.value(),
+            "x_cross_section": self.x_cross_section.value(),
+            "y_cross_section": self.y_cross_section.value(),
+            "max_extent": self.maxExtentSpinBox.value(),
+        }
+
+    def _present_layout(self, data, context, restyle=False):
+        present_sag(self, data, context, restyle)
 
     def _toggle_settings(self, checked):
         """Toggle the visibility of the settings panel."""
@@ -203,41 +212,19 @@ class SagViewer(QWidget):
     def update_theme(self, theme="dark"):
         self.current_theme = theme
         self.settings_toggle_btn.setIcon(QIcon(f":/icons/{theme}/settings.svg"))
-        self.plot_sag()
+        self.layout_job.redraw()
 
     @Slot()
     def plot_sag(self):
-        gui_plot_utils.apply_gui_matplotlib_styles(theme=self.current_theme)
-        optic = self.connector.get_optic()
-        surface_index = self.surface_selector.value()
-        self.figure.clear()
+        """Request a visible sag update without evaluating geometry on Qt."""
+        self.layout_job.request()
 
-        if not optic or not (0 <= surface_index < optic.surface_group.num_surfaces):
-            ax = self.figure.add_subplot(111)
-            ax.text(
-                0.5,
-                0.5,
-                f"Invalid Surface Index: {surface_index}",
-                ha="center",
-                va="center",
-            )
-            self.canvas.draw()
-            return
-
-        # Use the existing backend SurfaceSagViewer class
-        viewer = SurfaceSagViewer(optic)
-
-        # Call its view method, passing our figure to be plotted on
-        viewer.view(
-            surface_index=surface_index,
-            y_cross_section=self.y_cross_section.value(),
-            x_cross_section=self.x_cross_section.value(),
-            max_extent=self.maxExtentSpinBox.value(),
-            fig_to_plot_on=self.figure,
-        )
-
-        # Redraw our canvas
-        self.canvas.draw()
+    def reset_view(self):
+        """Fit the retained sag data without rerunning surface calculations."""
+        if self.layout_job.data is not None:
+            self.layout_job.redraw()
+        else:
+            self.layout_job.request()
 
 
 class ViewerPanel(QWidget):
@@ -454,6 +441,10 @@ class MatplotlibViewer(QWidget):
         self._pan_start_y = None
         self._is_panning = False
 
+        self._preserve_next = False
+        self.layout_job = LayoutJobView(
+            self, "2d", self.layout, self._layout_parameters, self._present_layout
+        )
         self.plot_optic()
         self.update_theme()
 
@@ -463,9 +454,13 @@ class MatplotlibViewer(QWidget):
             self._user_initiated_view_change = True
 
     def reset_view(self):
-        """Resets the view to the default 1:1 aspect ratio and zoom."""
+        """Fit retained geometry without launching another optical calculation."""
         self._user_initiated_view_change = False
-        self.plot_optic(preserve_zoom=False)
+        self._preserve_next = False
+        if self.layout_job.data is not None:
+            self._present_layout(self.layout_job.data, self.layout_job.context)
+        else:
+            self.layout_job.request()
 
     def on_mouse_button_press(self, event):
         """
@@ -572,110 +567,22 @@ class MatplotlibViewer(QWidget):
         if self.current_theme != theme:
             self.current_theme = theme
             gui_plot_utils.apply_gui_matplotlib_styles(theme=self.current_theme)
-            self.plot_optic()
+            self.layout_job.redraw()
         self.settings_toggle_btn.setIcon(QIcon(f":/icons/{theme}/settings.svg"))
 
+    def _layout_parameters(self):
+        return {
+            "num_rays": self.num_rays_spinbox.value(),
+            "distribution": self.dist_combo.currentText(),
+        }
+
+    def _present_layout(self, data, context, restyle=False):
+        present_2d(self, data, context, restyle)
+
     def plot_optic(self, preserve_zoom=False):
-        """
-        Clears the current plot and redraws the optical system.
-
-        This method retrieves the current optical system from the connector and
-        uses Optiland's plotting utilities to generate a 2D layout.
-
-        Args:
-            preserve_zoom (bool): If True, maintains the current view
-            limits after redrawing.
-        """
-        self._is_plotting = True
-        try:
-            gui_plot_utils.apply_gui_matplotlib_styles(theme=self.current_theme)
-
-            should_preserve_limits = preserve_zoom or self._user_initiated_view_change
-            xlim = self.ax.get_xlim() if should_preserve_limits else None
-            ylim = self.ax.get_ylim() if should_preserve_limits else None
-
-            self.ax.clear()
-            face_color = matplotlib.rcParams["figure.facecolor"]
-            self.figure.set_facecolor(face_color)
-            self.ax.set_facecolor(face_color)
-
-            optic = self.connector.get_optic()
-            num_rays = self.num_rays_spinbox.value()
-            distribution = self.dist_combo.currentText()
-            if optic and optic.surface_group.num_surfaces > 0:
-                try:
-                    rays2d_plotter = Rays2D(optic)
-                    system_plotter = OptilandOpticalSystemPlotter(
-                        optic, rays2d_plotter, projection="2d"
-                    )
-                    from optiland.visualization.themes import get_active_theme
-
-                    theme = get_active_theme()
-                    rays2d_plotter.plot(
-                        self.ax,
-                        fields="all",
-                        wavelengths="primary",
-                        num_rays=num_rays,
-                        distribution=distribution,
-                        theme=theme,
-                    )
-                    system_plotter.plot(self.ax, theme=theme)
-                    self.ax.set_title(
-                        f"System: {optic.name} (2D)",
-                        color=matplotlib.rcParams["text.color"],
-                    )
-                    self.ax.set_xlabel("Z-axis (mm)")
-                    self.ax.set_ylabel("Y-axis (mm)")
-                    self.ax.grid(True, linestyle="--", alpha=0.7)
-
-                    if should_preserve_limits and xlim is not None and ylim is not None:
-                        self.ax.set_xlim(xlim)
-                        self.ax.set_ylim(ylim)
-                        self.ax.set_aspect("auto")
-                    else:
-                        fig_width, fig_height = self.figure.get_size_inches()
-                        widget_aspect = fig_height / fig_width
-
-                        xlim_data = self.ax.get_xlim()
-                        ylim_data = self.ax.get_ylim()
-                        x_range = xlim_data[1] - xlim_data[0]
-                        y_range = ylim_data[1] - ylim_data[0]
-
-                        if x_range == 0:
-                            x_range = 1e-6
-                        if y_range == 0:
-                            y_range = 1e-6
-
-                        data_aspect = y_range / x_range
-
-                        # determine which axis to expand to achieve equal aspect ratio
-                        if data_aspect < widget_aspect:
-                            # expand Y
-                            y_center = (ylim_data[0] + ylim_data[1]) / 2
-                            new_y_range = x_range * widget_aspect
-                            self.ax.set_ylim(
-                                y_center - new_y_range / 2, y_center + new_y_range / 2
-                            )
-                        else:
-                            # expand X
-                            x_center = (xlim_data[0] + xlim_data[1]) / 2
-                            new_x_range = y_range / widget_aspect
-                            self.ax.set_xlim(
-                                x_center - new_x_range / 2, x_center + new_x_range / 2
-                            )
-
-                        self.ax.set_aspect("equal")
-
-                except Exception:
-                    self.ax.text(
-                        0.5, 0.5, "Error plotting system", ha="center", va="center"
-                    )
-            else:
-                self.ax.text(0.5, 0.5, "No system loaded", ha="center", va="center")
-
-            self.canvas.draw()
-        finally:
-            self._is_plotting = False
+        """Request the latest visible layout; calculation belongs to its worker."""
+        self._preserve_next = bool(preserve_zoom)
+        self.layout_job.request()
 
 
 class VTKViewer(QWidget):
@@ -702,6 +609,8 @@ class VTKViewer(QWidget):
         super().__init__(parent)
 
         self.connector = connector
+        self.current_theme = "dark"
+        self._has_scene = False
         if not VTK_AVAILABLE:
             self.layout = QVBoxLayout(self)
             self.layout.addWidget(QLabel("VTK is not available."))
@@ -716,7 +625,29 @@ class VTKViewer(QWidget):
         self.iren = self.vtkWidget.GetRenderWindow().GetInteractor()
         self.iren.SetInteractorStyle(vtk.vtkInteractorStyleTrackballCamera())
         self.setup_default_camera()
-        self.iren.Initialize()
+        self._initialized = False
+        self.layout_job = LayoutJobView(
+            self, "3d", self.layout, self._layout_parameters, self._present_layout
+        )
+
+    def _layout_parameters(self):
+        return {}
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        # Context initialization can incur a native driver startup cost. Keep it
+        # separate from result installation and never initialize a hidden tab.
+        if VTK_AVAILABLE and not self._initialized:
+            QTimer.singleShot(0, self._initialize_interactor)
+
+    @Slot()
+    def _initialize_interactor(self):
+        if self.isVisible() and not self._initialized:
+            self.iren.Initialize()
+            self._initialized = True
+
+    def _present_layout(self, data, context, restyle=False):
+        present_3d(self, data, context, restyle)
 
     def setup_default_camera(self):
         """Sets up the default camera position and orientation for the 3D view."""
@@ -731,98 +662,12 @@ class VTKViewer(QWidget):
             camera.Azimuth(150)
 
     def update_theme(self, theme="dark"):
-        """
-        Updates the background color of the VTK renderer based on the theme.
-
-        Args:
-            theme (str, optional): The theme name ('dark' or 'light').
-                                   Defaults to "dark".
-        """
-        from matplotlib.colors import to_rgb
-
-        from optiland.visualization.themes import get_active_theme, set_theme
-
-        set_theme(theme)
-        theme = get_active_theme()
-        background = to_rgb(theme.parameters["axes.facecolor"])
-        self.renderer.SetBackground(*background)
-        self.vtkWidget.GetRenderWindow().Render()
+        """Restyle retained scene data and defer native rendering for hidden tabs."""
+        self.current_theme = theme
+        if VTK_AVAILABLE:
+            self.layout_job.redraw()
 
     def render_optic(self):
-        """
-        Clears the current scene and re-renders the optical system in 3D.
-
-        This method retrieves the current optical system and uses Optiland's
-        VTK plotting utilities to generate the 3D visualization.
-        """
-        if not VTK_AVAILABLE:
-            return
-
-        self.renderer.RemoveAllViewProps()
-        optic = self.connector.get_optic()
-
-        # Check if optic has surfaces and a valid aperture
-        if (
-            optic
-            and optic.surface_group.num_surfaces > 0
-            and hasattr(optic, "aperture")
-            and optic.aperture is not None
-        ):
-            try:
-                rays3d_plotter = Rays3D(optic)
-                system_plotter = OptilandOpticalSystemPlotter(
-                    optic, rays3d_plotter, projection="3d"
-                )
-
-                from optiland.visualization.themes import get_active_theme
-
-                theme = get_active_theme()
-                rays3d_plotter.plot(
-                    self.renderer,
-                    fields="all",
-                    wavelengths="primary",
-                    num_rays=24,
-                    distribution="ring",
-                    theme=theme,
-                )
-
-                system_plotter.plot(self.renderer, theme=theme)
-
-                if not self.renderer.GetActiveCamera():
-                    self.setup_default_camera()
-                else:
-                    self.renderer.ResetCameraClippingRange()
-                    self.renderer.ResetCamera()
-
-            except Exception as e:
-                print(f"VTKViewer Error: {e}")
-                textActor = vtk.vtkTextActor()
-                textActor.SetInput(f"Error rendering 3D view:\n{e}")
-                textActor.GetTextProperty().SetColor(1, 0, 0)
-                self.renderer.AddActor2D(textActor)
-        else:
-            # Display a message if the optic doesn't have a valid aperture
-            if (
-                optic
-                and optic.surface_group.num_surfaces > 0
-                and (not hasattr(optic, "aperture") or optic.aperture is None)
-            ):
-                textActor = vtk.vtkTextActor()
-                textActor.SetInput("Please set an aperture in System Properties.")
-                textActor.GetTextProperty().SetColor(1, 0, 0)
-                self.renderer.AddActor2D(textActor)
-
-            # Add a default sphere for empty systems
-            sphereSource = vtk.vtkSphereSource()
-            sphereSource.SetRadius(0.1)
-            mapper = vtk.vtkPolyDataMapper()
-            mapper.SetInputConnection(sphereSource.GetOutputPort())
-            actor = vtk.vtkActor()
-            actor.SetMapper(mapper)
-            self.renderer.AddActor(actor)
-            if not self.renderer.GetActiveCamera():
-                self.setup_default_camera()
-            else:
-                self.renderer.ResetCamera()
-
-        self.vtkWidget.GetRenderWindow().Render()
+        """Request 3D geometry only when this viewer is visible."""
+        if VTK_AVAILABLE:
+            self.layout_job.request()

--- a/optiland_gui/widgets/layout_job_view.py
+++ b/optiland_gui/widgets/layout_job_view.py
@@ -109,7 +109,6 @@ class LayoutJobView(QObject):
                 "parameters": parameters,
                 "key": key,
             }
-            self._requested_key = key
             request = self.jobs.submit(
                 self.target,
                 f"optiland_gui.services.layout_tasks:prepare_{self.kind}",
@@ -118,6 +117,9 @@ class LayoutJobView(QObject):
                 context=context,
             )
             self._job_id = request.job_id
+            # Cancelling a previous queued preview emits its terminal result
+            # synchronously inside submit. Install the new key afterwards.
+            self._requested_key = key
         except Exception as exc:
             self._requested_key = None
             self._set_busy(False)
@@ -139,7 +141,9 @@ class LayoutJobView(QObject):
 
     @Slot(object, str)
     def _state_changed(self, request, state):
-        if request.target != self.target:
+        if request.target != self.target or (
+            self._job_id is not None and request.job_id < self._job_id
+        ):
             return
         if state in ("queued", "running", "cancelling"):
             self._set_busy(True)

--- a/optiland_gui/widgets/layout_job_view.py
+++ b/optiland_gui/widgets/layout_job_view.py
@@ -1,0 +1,206 @@
+"""Visible-view scheduling and contextual progress for numeric layout jobs."""
+
+from __future__ import annotations
+
+import pickle
+import uuid
+
+from PySide6.QtCore import QEvent, QObject, QTimer, Slot
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QProgressBar, QPushButton, QWidget
+
+from optiland_gui.services.job_records import BackendConfig, OpticSnapshot
+
+
+class LayoutJobView(QObject):
+    """Keep one view's last result while its detached replacement is calculated."""
+
+    def __init__(self, viewer, kind, layout, parameters, present):
+        super().__init__(viewer)
+        self.viewer = viewer
+        self.connector = viewer.connector
+        self.jobs = self.connector.calculation_jobs
+        self.kind = kind
+        self.target = f"layout-{kind}-{uuid.uuid4().hex}"
+        self.parameters = parameters
+        self.present = present
+        self.data = None
+        self.context = None
+        self._requested_key = None
+        self._completed_key = None
+        self._job_id = None
+        self._active = False
+        self._restyle_pending = False
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setSingleShot(True)
+        self._refresh_timer.timeout.connect(self.request)
+        self.status_widget = QWidget(viewer)
+        row = QHBoxLayout(self.status_widget)
+        row.setContentsMargins(5, 0, 5, 0)
+        self.label = QLabel("Layout will update when shown.")
+        self.label.setWordWrap(True)
+        row.addWidget(self.label, 1)
+        self.activity = QProgressBar()
+        self.activity.setRange(0, 0)
+        self.activity.setFixedSize(65, 12)
+        self.activity.setAccessibleName("Layout calculation in progress")
+        self.activity.hide()
+        row.addWidget(self.activity)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.cancel)
+        self.cancel_button.hide()
+        row.addWidget(self.cancel_button)
+        layout.addWidget(self.status_widget)
+        self._busy_timer = QTimer(self)
+        self._busy_timer.setSingleShot(True)
+        self._busy_timer.timeout.connect(self._show_activity)
+        self.jobs.state_changed.connect(self._state_changed)
+        self.jobs.progress.connect(self._progress)
+        self.jobs.finished.connect(self._finished)
+        self.connector.document_state.changed.connect(self.invalidate)
+        viewer.installEventFilter(self)
+
+    def eventFilter(self, watched, event):
+        if watched is self.viewer:
+            if event.type() == QEvent.Type.Show:
+                self.jobs.set_target_visible(self.target, True)
+                self._refresh_timer.start(0)
+            elif event.type() == QEvent.Type.Hide:
+                self._refresh_timer.stop()
+                self.jobs.set_target_visible(self.target, False)
+                if self._active:
+                    self._requested_key = None
+        return super().eventFilter(watched, event)
+
+    @Slot(object)
+    def invalidate(self, token=None):
+        self._requested_key = None
+        self._completed_key = None
+        self.label.setText("Previous layout is stale; update pending.")
+        if self.viewer.isVisible():
+            self._refresh_timer.start(0)
+
+    @Slot()
+    def request(self):
+        if not self.viewer.isVisible():
+            return
+        parameters = self.parameters()
+        key = (
+            self.connector.document_state.token,
+            BackendConfig.capture(),
+            pickle.dumps(parameters, protocol=5),
+        )
+        if key in (self._requested_key, self._completed_key):
+            if key == self._completed_key and self._restyle_pending:
+                self.redraw()
+            return
+        try:
+            optic = self.connector.get_optic()
+            self.label.setText("Preparing layout update…")
+            snapshot = OpticSnapshot.capture(optic)
+            context = {
+                "surface_identities": tuple(optic.surfaces),
+                "document_id": self.connector.document_state.token.document_id,
+                "parameters": parameters,
+                "key": key,
+            }
+            self._requested_key = key
+            request = self.jobs.submit(
+                self.target,
+                f"optiland_gui.services.layout_tasks:prepare_{self.kind}",
+                snapshot,
+                parameters,
+                context=context,
+            )
+            self._job_id = request.job_id
+        except Exception as exc:
+            self._requested_key = None
+            self._set_busy(False)
+            self.label.setText(f"Unable to update layout: {exc}")
+
+    @Slot()
+    def cancel(self):
+        self._refresh_timer.stop()
+        self.jobs.cancel_target(self.target)
+        self._requested_key = None
+
+    def redraw(self):
+        """Restyle retained data; no optical snapshot or calculation is requested."""
+        if self.data is not None and self.viewer.isVisible():
+            self.present(self.data, self.context, True)
+            self._restyle_pending = False
+        else:
+            self._restyle_pending = True
+
+    @Slot(object, str)
+    def _state_changed(self, request, state):
+        if request.target != self.target:
+            return
+        if state in ("queued", "running", "cancelling"):
+            self._set_busy(True)
+            text = {
+                "queued": "Update queued",
+                "running": "Updating layout",
+                "cancelling": "Cancelling layout update",
+            }[state]
+            self.label.setText(
+                f"{text}… Previous result is stale." if self.data else f"{text}…"
+            )
+        else:
+            self._set_busy(False)
+
+    def _set_busy(self, busy):
+        self._active = busy
+        self.cancel_button.setVisible(busy)
+        if busy:
+            if not self._busy_timer.isActive() and not self.activity.isVisible():
+                self._busy_timer.start(500)
+        else:
+            self._busy_timer.stop()
+            self.activity.hide()
+
+    @Slot()
+    def _show_activity(self):
+        if self._active:
+            self.activity.show()
+
+    @Slot(object, dict)
+    def _progress(self, request, message):
+        if request.target != self.target or not self.jobs.is_current(request):
+            return
+        text = message["stage"]
+        if message.get("completed") is not None and message.get("total") is not None:
+            text += f" ({message['completed']} of {message['total']})"
+        self.label.setText(f"{text}…")
+
+    @Slot(object)
+    def _finished(self, result):
+        request = result.request
+        if request.target != self.target or request.job_id != self._job_id:
+            return
+        self._set_busy(False)
+        self._requested_key = None
+        if result.status == "cancelled":
+            self.label.setText("Update cancelled; previous layout is stale.")
+        elif result.status == "failed":
+            if "Polarization must be set" in result.error:
+                self.label.setText(
+                    "Set incident polarization in System Properties > Polarization, "
+                    "then click Apply Polarization."
+                )
+            else:
+                self.label.setText(
+                    "Error updating layout. Apply or reopen the view to retry."
+                )
+            self.label.setToolTip(result.error)
+        elif result.current and self.jobs.is_current(request):
+            try:
+                self.present(result.data, request.context, False)
+            except Exception as exc:
+                self.label.setText(f"Error presenting layout: {exc}")
+                return
+            self.data = result.data
+            self.context = request.context
+            self._completed_key = request.context["key"]
+            self._restyle_pending = False
+            self.label.setToolTip("")
+            self.label.setText("Layout is up to date.")

--- a/optiland_gui/widgets/layout_job_view.py
+++ b/optiland_gui/widgets/layout_job_view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 import uuid
+from dataclasses import replace
 
 from PySide6.QtCore import QEvent, QObject, QTimer, Slot
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QProgressBar, QPushButton, QWidget
@@ -209,3 +210,15 @@ class LayoutJobView(QObject):
             self._restyle_pending = False
             self.label.setToolTip("")
             self.label.setText("Layout is up to date.")
+        else:
+            self.label.setText("Previous layout is stale; apply to update.")
+            backend_changed = (
+                request.snapshot is not None
+                and request.snapshot.backend != BackendConfig.capture()
+            )
+            # Recheck document, target generation, visibility and shutdown while
+            # excluding only the obsolete backend. Cancellation must stay revoked.
+            if backend_changed and self.jobs.is_current(
+                replace(request, snapshot=None)
+            ):
+                self.invalidate()

--- a/optiland_gui/widgets/layout_job_view.py
+++ b/optiland_gui/widgets/layout_job_view.py
@@ -60,7 +60,12 @@ class LayoutJobView(QObject):
         viewer.installEventFilter(self)
 
     def eventFilter(self, watched, event):
-        if watched is self.viewer:
+        # Qt may deliver final native events while Python is breaking the
+        # parent/child reference cycle during widget destruction.
+        viewer = getattr(self, "viewer", None)
+        if viewer is None:
+            return False
+        if watched is viewer:
             if event.type() == QEvent.Type.Show:
                 self.jobs.set_target_visible(self.target, True)
                 self._refresh_timer.start(0)

--- a/tests/gui/calculation_worker_fixture.py
+++ b/tests/gui/calculation_worker_fixture.py
@@ -1,0 +1,34 @@
+"""Subprocess fixture for queue, crash and noninterruptible cancellation tests."""
+
+from __future__ import annotations
+
+import os
+import pickle
+import struct
+import sys
+import time
+
+from optiland_gui.services.calculation_worker import encode_message
+
+
+def send(message):
+    sys.stdout.buffer.write(encode_message(message))
+    sys.stdout.buffer.flush()
+
+
+send({"event": "ready"})
+while header := sys.stdin.buffer.read(4):
+    size = struct.unpack("!I", header)[0]
+    message = pickle.loads(sys.stdin.buffer.read(size))
+    if message["command"] == "shutdown":
+        break
+    if message["command"] != "run":
+        continue
+    job_id = message["job_id"]
+    parameters = message["parameters"]
+    send({"event": "progress", "job_id": job_id, "stage": "fixture"})
+    if parameters.get("crash"):
+        os._exit(7)
+    time.sleep(parameters.get("delay", 0.01))
+    send({"event": "result", "job_id": job_id, "status": "succeeded",
+          "data": parameters.get("value", 42)})

--- a/tests/gui/calculation_worker_fixture.py
+++ b/tests/gui/calculation_worker_fixture.py
@@ -30,5 +30,11 @@ while header := sys.stdin.buffer.read(4):
     if parameters.get("crash"):
         os._exit(7)
     time.sleep(parameters.get("delay", 0.01))
-    send({"event": "result", "job_id": job_id, "status": "succeeded",
-          "data": parameters.get("value", 42)})
+    send(
+        {
+            "event": "result",
+            "job_id": job_id,
+            "status": "succeeded",
+            "data": parameters.get("value", 42),
+        }
+    )

--- a/tests/gui/test_calculation_frames.py
+++ b/tests/gui/test_calculation_frames.py
@@ -1,0 +1,77 @@
+"""Framed worker decoding preserves ownership without redundant payload copies."""
+
+from __future__ import annotations
+
+import struct
+from types import SimpleNamespace
+
+import numpy as np
+from PySide6.QtCore import QByteArray
+
+from optiland_gui.services.calculation_jobs import CalculationJobs
+from optiland_gui.services.calculation_worker import MAX_MESSAGE_BYTES, encode_message
+
+
+def receiver():
+    process = SimpleNamespace(chunk=b"")
+    process.readAllStandardOutput = lambda: QByteArray(process.chunk)
+    messages, failures = [], []
+    service = SimpleNamespace(
+        sender=lambda: process,
+        _process=process,
+        _buffer=bytearray(),
+        _message=messages.append,
+        _kill_worker=lambda: failures.append(True),
+        _stderr="",
+    )
+    return service, process, messages, failures
+
+
+def feed(service, process, chunk):
+    process.chunk = chunk
+    CalculationJobs._read_stdout(service)
+
+
+def test_fragmented_header_payload_and_multiple_frames():
+    service, process, messages, failures = receiver()
+    first = {"event": "ready"}
+    second = {"event": "result", "data": np.arange(10000, dtype=np.float32)}
+    third = {"event": "progress", "stage": "next"}
+    wire = encode_message(first) + encode_message(second) + encode_message(third)
+    for start, stop in ((0, 2), (2, 19), (19, 700), (700, len(wire) - 1)):
+        feed(service, process, wire[start:stop])
+    assert messages[0] == first
+    np.testing.assert_array_equal(messages[1]["data"], second["data"])
+    assert len(messages) == 2
+    feed(service, process, wire[-1:])
+    assert messages[2] == third
+    assert not failures and not service._buffer
+
+
+def test_decoded_arrays_own_data_after_receive_storage_reuse():
+    service, process, messages, failures = receiver()
+    expected = np.arange(99999, dtype=np.float32).reshape(-1, 3)
+    shared = {"points": expected, "also_points": expected}
+    feed(service, process, encode_message({"data": shared}))
+    actual = messages[0]["data"]
+    assert actual["points"] is actual["also_points"]
+    service._buffer.extend(b"overwrite reused receive storage" * 50000)
+    service._buffer[:] = b"\x00" * len(service._buffer)
+    np.testing.assert_array_equal(actual["points"], expected)
+    actual["points"][0, 0] = -12
+    assert expected[0, 0] == 0
+    assert not failures
+
+
+def test_oversized_or_invalid_frames_keep_protocol_failure_behavior():
+    for wire in (
+        struct.pack("!I", MAX_MESSAGE_BYTES + 1),
+        struct.pack("!I", 3) + b"bad",
+    ):
+        service, process, messages, failures = receiver()
+        feed(service, process, wire)
+        assert failures == [True]
+        assert service._stderr
+        assert not messages
+        # Any decode memoryviews are released even on an exception.
+        service._buffer.clear()

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -120,6 +120,46 @@ def test_polarized_snapshot_preserves_aperture_and_incident_state(minimal_optic)
     )
 
 
+@pytest.mark.parametrize("component_name", ["ray_tracer", "ray_generator"])
+@pytest.mark.parametrize("override_kind", ["subclass", "instance_method"])
+def test_snapshot_rejects_unserializable_tracing_extensions(
+    minimal_optic, component_name, override_kind
+):
+    component = minimal_optic.ray_tracer
+    method_name = "trace"
+    if component_name == "ray_generator":
+        component = component.ray_generator
+        method_name = "generate_rays"
+    if override_kind == "subclass":
+
+        class CustomTracingComponent(type(component)):
+            pass
+
+        component.__class__ = CustomTracingComponent
+    else:
+        setattr(component, method_name, lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="snapshot adapter"):
+        OpticSnapshot.capture(minimal_optic)
+
+
+@pytest.mark.parametrize("method_name", ["trace", "trace_generic"])
+@pytest.mark.parametrize("override_kind", ["subclass", "instance_method"])
+def test_snapshot_rejects_custom_optic_trace_methods(
+    minimal_optic, method_name, override_kind
+):
+    if override_kind == "subclass":
+        minimal_optic.__class__ = type(
+            "CustomOptic",
+            (type(minimal_optic),),
+            {method_name: lambda *args, **kwargs: None},
+        )
+    else:
+        setattr(minimal_optic, method_name, lambda *args, **kwargs: None)
+    with pytest.raises(ValueError, match="snapshot adapter"):
+        OpticSnapshot.capture(minimal_optic)
+
+
 def test_worker_keeps_heartbeat_and_delivers_slots_on_gui(qapp, jobs):
     state, service, receiver = jobs
     ticks = []

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -200,3 +200,26 @@ def test_actual_worker_reports_handler_failure_and_closes(qapp):
     finally:
         service.shutdown()
         wait_for(qapp, lambda: service._process is None)
+
+
+def test_detached_explicit_job_survives_document_edit_as_stale(qapp, jobs):
+    state, service, receiver = jobs
+    request = service.submit("save", "unused", None, {"delay": 0.2},
+                             replace=False, cancel_on_document_change=False)
+    # Still pending: a save/analysis batch may start after edits to its document.
+    state.change()
+    wait_for(qapp, lambda: request.job_id in receiver.progress or receiver.results)
+    state.replace()
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].status == "succeeded"
+    assert receiver.results[0].data == 42
+    assert not receiver.results[0].current
+
+
+def test_current_must_be_rechecked_at_commit(qapp, jobs):
+    state, service, receiver = jobs
+    request = service.submit("analysis", "unused", None, {})
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].current
+    state.change()
+    assert not service.is_current(request)

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -6,7 +6,9 @@ import pickle
 import sys
 import threading
 import time
+from operator import attrgetter
 from pathlib import Path
+from types import MethodType
 
 import numpy as np
 import pytest
@@ -158,6 +160,49 @@ def test_snapshot_rejects_custom_optic_trace_methods(
         setattr(minimal_optic, method_name, lambda *args, **kwargs: None)
     with pytest.raises(ValueError, match="snapshot adapter"):
         OpticSnapshot.capture(minimal_optic)
+
+
+@pytest.mark.parametrize(
+    ("component_path", "method_name"),
+    [
+        ("", "trace"),
+        ("", "trace_generic"),
+        ("ray_tracer", "trace"),
+        ("ray_tracer", "trace_generic"),
+        ("ray_tracer.ray_generator", "generate_rays"),
+    ],
+)
+@pytest.mark.parametrize("binding", ["same_owner", "foreign_owner", "wrapper"])
+def test_snapshot_accepts_only_behaviorally_identical_rebound_trace_methods(
+    minimal_optic, component_path, method_name, binding
+):
+    def component(optic):
+        return attrgetter(component_path)(optic) if component_path else optic
+
+    owner = component(minimal_optic)
+    method = getattr(owner, method_name)
+    if binding == "foreign_owner":
+        other = OpticSnapshot.capture(minimal_optic).restore()
+        method = getattr(component(other), method_name)
+    elif binding == "wrapper":
+        original = method
+
+        def wrapper(self, *args, **kwargs):
+            return original(*args, **kwargs)
+
+        method = MethodType(wrapper, owner)
+    setattr(owner, method_name, method)
+
+    if binding != "same_owner":
+        with pytest.raises(ValueError, match="snapshot adapter"):
+            OpticSnapshot.capture(minimal_optic)
+        return
+
+    restored = OpticSnapshot.capture(minimal_optic).restore()
+    assert method_name not in vars(component(restored))
+    minimal_optic.trace(0, 0, 0.55, 5, "line_y")
+    restored.trace(0, 0, 0.55, 5, "line_y")
+    np.testing.assert_allclose(restored.surfaces.y, minimal_optic.surfaces.y)
 
 
 def test_worker_keeps_heartbeat_and_delivers_slots_on_gui(qapp, jobs):

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pickle
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -22,6 +23,30 @@ def wait_for(qapp, predicate, timeout=15):
         if time.monotonic() > deadline:
             raise AssertionError("Calculation condition timed out")
         time.sleep(0.002)
+
+
+def test_progress_preserves_bounded_plain_details_and_cancellation():
+    from optiland_gui.services.calculation_worker import (
+        _progress_reporter,
+        encode_message,
+    )
+    from optiland_gui.services.job_records import CalculationCancelled
+
+    encoded = []
+    cancelled = threading.Event()
+    report = _progress_reporter(
+        7, cancelled, lambda message: encoded.append(encode_message(message))
+    )
+    details = {"merit": 0.123, "evaluations": 12, "variables": [1.5, 2.5]}
+    report("Optimizing", details=details)
+    message = pickle.loads(encoded[0][4:])
+    assert message["job_id"] == 7
+    assert message["details"] == details
+    assert message["completed"] is None and message["total"] is None
+    cancelled.set()
+    with pytest.raises(CalculationCancelled):
+        report("Optimizing", details=details)
+    assert len(encoded) == 1
 
 
 class Receiver(QObject):
@@ -45,9 +70,15 @@ class Receiver(QObject):
 @pytest.fixture
 def jobs(qapp):
     state = DocumentState()
-    service = CalculationJobs(state, cancel_grace_ms=40,
-                              worker_command=[sys.executable, "-u", str(
-                                  Path(__file__).with_name("calculation_worker_fixture.py"))])
+    service = CalculationJobs(
+        state,
+        cancel_grace_ms=40,
+        worker_command=[
+            sys.executable,
+            "-u",
+            str(Path(__file__).with_name("calculation_worker_fixture.py")),
+        ],
+    )
     receiver = Receiver()
     service.finished.connect(receiver.result)
     service.progress.connect(receiver.update)
@@ -58,7 +89,9 @@ def jobs(qapp):
 
 def test_snapshot_is_owned_pure_and_numerically_equivalent(minimal_optic, monkeypatch):
     before = pickle.dumps(minimal_optic.to_dict(), protocol=5)
-    monkeypatch.setattr(minimal_optic.updater, "update", lambda: pytest.fail("capture ran solves"))
+    monkeypatch.setattr(
+        minimal_optic.updater, "update", lambda: pytest.fail("capture ran solves")
+    )
     snapshot = OpticSnapshot.capture(minimal_optic)
     assert pickle.dumps(minimal_optic.to_dict(), protocol=5) == before
     copy = snapshot.restore()
@@ -77,10 +110,14 @@ def test_polarized_snapshot_preserves_aperture_and_incident_state(minimal_optic)
 
     minimal_optic.polarization = PolarizationState(is_polarized=False)
     minimal_optic.surfaces[1].aperture = RectangularAperture(
-        x_min=-4.0, x_max=4.0, y_min=-3.0, y_max=3.0)
+        x_min=-4.0, x_max=4.0, y_min=-3.0, y_max=3.0
+    )
     copy = OpticSnapshot.capture(minimal_optic).restore()
     assert not copy.polarization.is_polarized
-    assert copy.surfaces[1].aperture.to_dict() == minimal_optic.surfaces[1].aperture.to_dict()
+    assert (
+        copy.surfaces[1].aperture.to_dict()
+        == minimal_optic.surfaces[1].aperture.to_dict()
+    )
 
 
 def test_worker_keeps_heartbeat_and_delivers_slots_on_gui(qapp, jobs):
@@ -124,10 +161,13 @@ def test_document_replacement_rejects_old_completion(qapp, jobs):
 
 def test_pending_replacement_has_exactly_one_terminal_each(qapp, jobs):
     state, service, receiver = jobs
-    requests = [service.submit("2d", "unused", None, {"value": value})
-                for value in range(5)]
+    requests = [
+        service.submit("2d", "unused", None, {"value": value}) for value in range(5)
+    ]
     wait_for(qapp, lambda: len(receiver.results) == 5)
-    assert sorted(r.request.job_id for r in receiver.results) == [r.job_id for r in requests]
+    assert sorted(r.request.job_id for r in receiver.results) == [
+        r.job_id for r in requests
+    ]
     assert sum(r.status == "succeeded" for r in receiver.results) == 1
     assert receiver.results[-1].data == 4
 
@@ -204,11 +244,17 @@ def test_actual_worker_reports_handler_failure_and_closes(qapp):
 
 def test_detached_explicit_job_survives_document_edit_as_stale(qapp, jobs):
     state, service, receiver = jobs
-    request = service.submit("save", "unused", None, {"delay": 0.2},
-                             replace=False, cancel_on_document_change=False)
+    request = service.submit(
+        "save",
+        "unused",
+        None,
+        {"delay": 0.2},
+        replace=False,
+        cancel_on_document_change=False,
+    )
     # Still pending: a save/analysis batch may start after edits to its document.
     state.change()
-    wait_for(qapp, lambda: request.job_id in receiver.progress or receiver.results)
+    wait_for(qapp, lambda: service.active_request is request)
     state.replace()
     wait_for(qapp, lambda: receiver.results)
     assert receiver.results[0].status == "succeeded"

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -1,0 +1,202 @@
+"""Behavioral coverage of owned snapshots, Qt delivery and process lifecycle."""
+
+from __future__ import annotations
+
+import pickle
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PySide6.QtCore import QObject, QThread, QTimer, Slot
+
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+from optiland_gui.services.job_records import OpticSnapshot
+
+
+def wait_for(qapp, predicate, timeout=15):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        qapp.processEvents()
+        if time.monotonic() > deadline:
+            raise AssertionError("Calculation condition timed out")
+        time.sleep(0.002)
+
+
+class Receiver(QObject):
+    def __init__(self):
+        super().__init__()
+        self.results = []
+        self.threads = []
+        self.progress = []
+
+    @Slot(object)
+    def result(self, result):
+        self.threads.append(QThread.currentThread())
+        self.results.append(result)
+
+    @Slot(object, dict)
+    def update(self, request, message):
+        self.threads.append(QThread.currentThread())
+        self.progress.append(request.job_id)
+
+
+@pytest.fixture
+def jobs(qapp):
+    state = DocumentState()
+    service = CalculationJobs(state, cancel_grace_ms=40,
+                              worker_command=[sys.executable, "-u", str(
+                                  Path(__file__).with_name("calculation_worker_fixture.py"))])
+    receiver = Receiver()
+    service.finished.connect(receiver.result)
+    service.progress.connect(receiver.update)
+    yield state, service, receiver
+    service.shutdown()
+    wait_for(qapp, lambda: service._process is None)
+
+
+def test_snapshot_is_owned_pure_and_numerically_equivalent(minimal_optic, monkeypatch):
+    before = pickle.dumps(minimal_optic.to_dict(), protocol=5)
+    monkeypatch.setattr(minimal_optic.updater, "update", lambda: pytest.fail("capture ran solves"))
+    snapshot = OpticSnapshot.capture(minimal_optic)
+    assert pickle.dumps(minimal_optic.to_dict(), protocol=5) == before
+    copy = snapshot.restore()
+    assert copy is not minimal_optic
+    assert copy.surfaces[1] is not minimal_optic.surfaces[1]
+    minimal_optic.trace(0, 0, 0.55, 5, "line_y")
+    copy.trace(0, 0, 0.55, 5, "line_y")
+    np.testing.assert_allclose(copy.surfaces.y, minimal_optic.surfaces.y)
+    copy.surfaces[1].comment = "Worker changed"
+    assert minimal_optic.surfaces[1].comment != "Worker changed"
+
+
+def test_polarized_snapshot_preserves_aperture_and_incident_state(minimal_optic):
+    from optiland.physical_apertures import RectangularAperture
+    from optiland.rays import PolarizationState
+
+    minimal_optic.polarization = PolarizationState(is_polarized=False)
+    minimal_optic.surfaces[1].aperture = RectangularAperture(
+        x_min=-4.0, x_max=4.0, y_min=-3.0, y_max=3.0)
+    copy = OpticSnapshot.capture(minimal_optic).restore()
+    assert not copy.polarization.is_polarized
+    assert copy.surfaces[1].aperture.to_dict() == minimal_optic.surfaces[1].aperture.to_dict()
+
+
+def test_worker_keeps_heartbeat_and_delivers_slots_on_gui(qapp, jobs):
+    state, service, receiver = jobs
+    ticks = []
+    timer = QTimer()
+    timer.setInterval(10)
+    timer.timeout.connect(lambda: ticks.append(time.monotonic()))
+    timer.start()
+    request = service.submit("2d", "unused", None, {"delay": 0.3})
+    wait_for(qapp, lambda: len(receiver.results) == 1)
+    timer.stop()
+    assert len(ticks) >= 10
+    assert receiver.results[0].request == request
+    assert receiver.results[0].current
+    assert receiver.results[0].data == 42
+    assert all(thread == qapp.thread() for thread in receiver.threads)
+
+
+def test_replacement_kills_stubborn_active_and_runs_latest(qapp, jobs):
+    state, service, receiver = jobs
+    first = service.submit("2d", "unused", None, {"delay": 10})
+    wait_for(qapp, lambda: first.job_id in receiver.progress)
+    second = service.submit("2d", "unused", None, {"value": "latest"})
+    wait_for(qapp, lambda: len(receiver.results) == 2)
+    assert [r.status for r in receiver.results] == ["cancelled", "succeeded"]
+    assert receiver.results[1].request == second
+    assert receiver.results[1].data == "latest"
+    assert not receiver.results[0].current
+
+
+def test_document_replacement_rejects_old_completion(qapp, jobs):
+    state, service, receiver = jobs
+    first = service.submit("2d", "unused", None, {"delay": 0.15})
+    wait_for(qapp, lambda: first.job_id in receiver.progress)
+    state.replace()
+    wait_for(qapp, lambda: len(receiver.results) == 1)
+    assert not receiver.results[0].current
+    assert receiver.results[0].status == "cancelled"
+
+
+def test_pending_replacement_has_exactly_one_terminal_each(qapp, jobs):
+    state, service, receiver = jobs
+    requests = [service.submit("2d", "unused", None, {"value": value})
+                for value in range(5)]
+    wait_for(qapp, lambda: len(receiver.results) == 5)
+    assert sorted(r.request.job_id for r in receiver.results) == [r.job_id for r in requests]
+    assert sum(r.status == "succeeded" for r in receiver.results) == 1
+    assert receiver.results[-1].data == 4
+
+
+def test_hidden_target_never_dispatches(qapp, jobs):
+    state, service, receiver = jobs
+    service.set_target_visible("3d", False)
+    service.submit("3d", "unused", None, {})
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].status == "cancelled"
+    assert not receiver.progress
+
+
+def test_crash_has_terminal_error_and_service_recovers(qapp, jobs):
+    state, service, receiver = jobs
+    service.submit("2d", "unused", None, {"crash": True})
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].status == "failed"
+    service.submit("2d", "unused", None, {})
+    wait_for(qapp, lambda: len(receiver.results) == 2)
+    assert receiver.results[1].status == "succeeded"
+
+
+def test_shutdown_revokes_and_reaps_without_blocking(qapp, jobs):
+    state, service, receiver = jobs
+    request = service.submit("2d", "unused", None, {"delay": 10})
+    wait_for(qapp, lambda: request.job_id in receiver.progress)
+    start = time.monotonic()
+    service.shutdown()
+    assert time.monotonic() - start < 0.1
+    wait_for(qapp, lambda: service._process is None)
+    assert len(receiver.results) == 1
+    assert not receiver.results[0].current
+    with pytest.raises(RuntimeError, match="closed"):
+        service.submit("2d", "unused", None, {})
+
+
+def test_failed_start_finishes_queued_request(qapp):
+    service = CalculationJobs(DocumentState(), worker_command=["nonexistent-worker"])
+    receiver = Receiver()
+    service.finished.connect(receiver.result)
+    service.submit("2d", "unused", None, {})
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].status == "failed"
+    assert not service.running
+    service.shutdown()
+
+
+def test_explicit_jobs_keep_fifo_and_enforce_queue_bound(qapp, jobs):
+    state, service, receiver = jobs
+    service.max_pending = 2
+    service.submit("analysis-a", "unused", None, {"value": "a"}, replace=False)
+    service.submit("analysis-b", "unused", None, {"value": "b"}, replace=False)
+    with pytest.raises(RuntimeError, match="queue is full"):
+        service.submit("analysis-c", "unused", None, {}, replace=False)
+    wait_for(qapp, lambda: len(receiver.results) == 2)
+    assert [r.data for r in receiver.results] == ["a", "b"]
+
+
+def test_actual_worker_reports_handler_failure_and_closes(qapp):
+    state = DocumentState()
+    service = CalculationJobs(state)
+    receiver = Receiver()
+    service.finished.connect(receiver.result)
+    service.submit("bad", "optiland_gui.services.job_records:does_not_exist", None, {})
+    try:
+        wait_for(qapp, lambda: receiver.results)
+        assert receiver.results[0].status == "failed"
+        assert "does_not_exist" in receiver.results[0].error
+    finally:
+        service.shutdown()
+        wait_for(qapp, lambda: service._process is None)

--- a/tests/gui/test_layout_backend_lifecycle.py
+++ b/tests/gui/test_layout_backend_lifecycle.py
@@ -1,0 +1,111 @@
+"""Actual-worker regression for backend changes during a visible layout job."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from PySide6.QtCore import QCoreApplication, QEvent
+from PySide6.QtWidgets import QVBoxLayout, QWidget
+
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+from optiland_gui.services.job_records import BackendConfig
+from optiland_gui.widgets.layout_job_view import LayoutJobView
+from tests.gui.test_calculation_jobs import wait_for
+
+
+@pytest.fixture
+def layout_job(qapp, minimal_optic, monkeypatch):
+    pytest.importorskip("torch")
+    current_backend = [BackendConfig()]
+    monkeypatch.setattr(
+        BackendConfig, "capture", classmethod(lambda cls: current_backend[0])
+    )
+    state = DocumentState()
+    jobs = CalculationJobs(state)
+    viewer = QWidget()
+    viewer.connector = SimpleNamespace(
+        document_state=state,
+        calculation_jobs=jobs,
+        get_optic=lambda: minimal_optic,
+    )
+    parameters = {"num_rays": 3, "distribution": "line_y"}
+    installed = []
+    helper = LayoutJobView(
+        viewer,
+        "2d",
+        QVBoxLayout(viewer),
+        lambda: dict(parameters),
+        lambda data, context, restyle: installed.append((data, context, restyle)),
+    )
+    yield viewer, helper, jobs, parameters, current_backend, installed
+    viewer.hide()
+    jobs.shutdown()
+    wait_for(qapp, lambda: jobs._process is None)
+    viewer.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+
+def test_backend_changed_completion_keeps_last_display_and_replaces_once(
+    qapp, layout_job
+):
+    viewer, helper, jobs, parameters, backend, installed = layout_job
+    viewer.show()
+    wait_for(qapp, lambda: helper.data is not None, timeout=30)
+    previous = helper.data
+    serial = jobs._serial
+    parameters["num_rays"] = 7
+    helper.request()
+    obsolete_id = helper._job_id
+    stale_completion = []
+
+    def switch_backend(request, message):
+        if request.job_id == obsolete_id:
+            backend[0] = BackendConfig("torch")
+
+    def completed(result):
+        if result.request.job_id == obsolete_id:
+            stale_completion.append(
+                (
+                    result,
+                    helper.data,
+                    helper.label.text(),
+                    helper._refresh_timer.isActive(),
+                )
+            )
+
+    jobs.progress.connect(switch_backend)
+    jobs.finished.connect(completed)
+    wait_for(qapp, lambda: len(installed) == 2 and not jobs.running, timeout=30)
+    result, retained, status, refresh_pending = stale_completion[0]
+    assert result.status == "succeeded" and not result.current
+    assert retained is previous
+    assert all(data is not result.data for data, _, _ in installed)
+    assert "stale" in status.lower() and refresh_pending
+    assert jobs._serial == serial + 2
+    assert installed[-1][1]["key"][1] == BackendConfig("torch")
+    assert helper.label.text() == "Layout is up to date."
+    assert not helper._refresh_timer.isActive()
+    assert not helper._active
+
+
+def test_backend_change_does_not_automatically_retry_a_calculation_error(
+    qapp, layout_job
+):
+    viewer, helper, jobs, parameters, backend, installed = layout_job
+    parameters["distribution"] = "invalid-layout-distribution"
+    results = []
+    jobs.finished.connect(results.append)
+    jobs.progress.connect(
+        lambda request, message: backend.__setitem__(0, BackendConfig("torch"))
+    )
+    viewer.show()
+    wait_for(qapp, lambda: bool(results), timeout=30)
+    qapp.processEvents()
+    assert results[0].status == "failed"
+    assert not installed
+    assert jobs._serial == 1
+    assert not jobs.running
+    assert not helper._refresh_timer.isActive()
+    assert not helper._active
+    assert "retry" in helper.label.text().lower()

--- a/tests/gui/test_layout_job_requests.py
+++ b/tests/gui/test_layout_job_requests.py
@@ -1,0 +1,90 @@
+"""Preview coalescing must preserve the newest request and its busy state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PySide6.QtCore import QCoreApplication, QEvent
+from PySide6.QtWidgets import QVBoxLayout, QWidget
+
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+from optiland_gui.widgets.layout_job_view import LayoutJobView
+from tests.gui.test_calculation_jobs import wait_for
+
+
+@pytest.fixture
+def preview(qapp, minimal_optic):
+    state = DocumentState()
+    jobs = CalculationJobs(
+        state,
+        cancel_grace_ms=40,
+        worker_command=[
+            sys.executable,
+            "-u",
+            str(Path(__file__).with_name("calculation_worker_fixture.py")),
+        ],
+    )
+    viewer = QWidget()
+    viewer.connector = SimpleNamespace(
+        document_state=state,
+        calculation_jobs=jobs,
+        get_optic=lambda: minimal_optic,
+    )
+    parameters = {"num_rays": 3, "distribution": "line_y", "delay": 0.15}
+    helper = LayoutJobView(
+        viewer,
+        "2d",
+        QVBoxLayout(viewer),
+        lambda: dict(parameters),
+        lambda *_: None,
+    )
+    viewer.show()
+    yield helper, jobs, parameters
+    viewer.hide()
+    jobs.shutdown()
+    wait_for(qapp, lambda: jobs._process is None)
+    viewer.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+
+def test_repeated_apply_reuses_the_latest_pending_preview(preview):
+    helper, jobs, parameters = preview
+    # All clicks arrive before the worker dispatch timer. Replacing a queued
+    # preview emits its cancellation synchronously inside the second submit.
+    helper.request()
+    parameters["num_rays"] = 5
+    helper.request()
+    newest_id = helper._job_id
+    helper.request()
+    assert helper._job_id == newest_id
+    assert jobs._serial == 2
+    assert len(jobs._pending) == 1
+    assert helper._active
+
+
+def test_cancelled_older_preview_does_not_clear_latest_busy_state(qapp, preview):
+    helper, jobs, parameters = preview
+    progress = []
+    jobs.progress.connect(lambda request, _message: progress.append(request.job_id))
+    helper.request()
+    previous_id = helper._job_id
+    wait_for(qapp, lambda: previous_id in progress)
+    parameters["num_rays"] = 5
+    helper.request()
+    latest_id = helper._job_id
+    observations = []
+
+    def finished(result):
+        if result.request.job_id == previous_id:
+            observations.append((helper._active, helper.cancel_button.isVisible()))
+
+    jobs.finished.connect(finished)
+    wait_for(qapp, lambda: bool(observations))
+    assert observations == [(True, True)]
+    assert helper._job_id == latest_id
+    wait_for(qapp, lambda: not jobs.running)
+    assert not helper._active
+    assert helper.label.text() == "Layout is up to date."

--- a/tests/gui/test_layout_jobs.py
+++ b/tests/gui/test_layout_jobs.py
@@ -1,0 +1,300 @@
+"""Numerical preparation, rendering boundary and visible-view scheduling tests."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland_gui.services.job_records import BackendConfig, OpticSnapshot
+from optiland_gui.services.layout_tasks import prepare_2d, prepare_3d, prepare_sag
+from tests.gui.test_calculation_jobs import wait_for
+
+
+def progress(*args):
+    pass
+
+
+def assert_plain_data(data):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            assert isinstance(key, str | int)
+            assert_plain_data(value)
+    elif isinstance(data, tuple | list):
+        for value in data:
+            assert_plain_data(value)
+    else:
+        assert isinstance(data, str | int | float | np.ndarray | type(None))
+
+
+def test_2d_payload_matches_core_plot_and_keeps_ownership(minimal_optic):
+    from matplotlib.figure import Figure
+
+    from optiland.visualization.system.rays import Rays2D
+    from optiland.visualization.system.system import OpticalSystem
+
+    snapshot = OpticSnapshot.capture(minimal_optic)
+    data = prepare_2d(
+        snapshot, {"num_rays": 5, "distribution": "line_y"}, progress, threading.Event()
+    )
+    assert_plain_data(data)
+    optic = snapshot.restore()
+    axes = Figure().add_subplot()
+    rays = Rays2D(optic)
+    rays.plot(axes, num_rays=5)
+    OpticalSystem(optic, rays).plot(axes)
+    lines = [p for p in data["primitives"] if p["kind"] == "line"]
+    polygons = [p for p in data["primitives"] if p["kind"] == "polygon"]
+    assert len(lines) == len(axes.lines)
+    assert len(polygons) == len(axes.patches)
+    for expected, actual in zip(axes.lines, lines, strict=True):
+        np.testing.assert_allclose(actual["xy"], expected.get_xydata())
+    for expected, actual in zip(axes.patches, polygons, strict=True):
+        np.testing.assert_allclose(actual["xy"], expected.get_xy())
+        assert actual["surfaces"] == (1, 2)
+    assert set(data["boundaries"]) == {1, 2}
+
+
+@pytest.mark.parametrize("backend", ["numpy", "torch"])
+def test_prepared_sag_and_mesh_have_owned_backend_independent_arrays(
+    minimal_optic, backend
+):
+    from optiland.physical_apertures import RectangularAperture
+
+    if backend == "torch":
+        pytest.importorskip("torch")
+    minimal_optic.surfaces[1].aperture = RectangularAperture(-4, 4, -3, 3)
+    snapshot = replace(
+        OpticSnapshot.capture(minimal_optic), backend=BackendConfig(backend)
+    )
+    try:
+        mesh = prepare_3d(snapshot, {}, progress, threading.Event())
+        sag = prepare_sag(
+            snapshot,
+            {
+                "surface_index": 1,
+                "max_extent": 5,
+                "x_cross_section": 0.2,
+                "y_cross_section": 0.3,
+            },
+            progress,
+            threading.Event(),
+        )
+        assert_plain_data(mesh)
+        assert_plain_data(sag)
+        assert len(mesh["meshes"]) > 0
+        assert sag["sag"].shape == (50, 50)
+        optic = snapshot.restore()
+        x, y = be.meshgrid(be.array(sag["coordinates"]), be.array(sag["coordinates"]))
+        np.testing.assert_allclose(
+            sag["sag"], be.to_numpy(optic.surfaces[1].geometry.sag(x, y))
+        )
+    finally:
+        be.set_backend("numpy")
+
+
+def test_snapshot_preserves_coating_pickup_solve_and_transform(minimal_optic):
+    from optiland.coatings import PolarizerCoating
+    from optiland.rays import PolarizationState
+    from optiland.solves import MarginalRayHeightThicknessSolve
+
+    minimal_optic.polarization = PolarizationState(
+        is_polarized=True, Ex=1, Ey=1, phase_x=0.2, phase_y=0.3
+    )
+    surface = minimal_optic.surfaces[1]
+    surface.interaction_model.coating = PolarizerCoating()
+    surface.geometry.cs.rx = 0.1
+    surface.geometry.cs.y = 0.2
+    minimal_optic.pickups.add(1, "conic", 2, scale=1, offset=0.2)
+    minimal_optic.solves.solves.append(
+        MarginalRayHeightThicknessSolve(minimal_optic, 2, 0)
+    )
+    restored = OpticSnapshot.capture(minimal_optic).restore()
+    assert restored.pickups.to_dict() == minimal_optic.pickups.to_dict()
+    assert restored.solves.to_dict() == minimal_optic.solves.to_dict()
+    assert restored.pickups.pickups[0].optic is restored
+    assert restored.solves.solves[0].optic is restored
+    assert (
+        restored.surfaces[1].interaction_model.coating.to_dict()
+        == surface.interaction_model.coating.to_dict()
+    )
+    np.testing.assert_allclose(
+        restored.surfaces[1].geometry.cs.rx, surface.geometry.cs.rx
+    )
+    np.testing.assert_allclose(
+        restored.surfaces[1].geometry.cs.y, surface.geometry.cs.y
+    )
+    np.testing.assert_allclose(restored.polarization.Ex, minimal_optic.polarization.Ex)
+    np.testing.assert_allclose(
+        restored.polarization.phase_y, minimal_optic.polarization.phase_y
+    )
+
+
+def test_ray_actor_batching_preserves_every_original_polyline(
+    minimal_optic, monkeypatch
+):
+    import optiland_gui.services.layout_tasks as module
+
+    batch = module._batch_ray_meshes
+    unbatched = []
+
+    def capture(meshes):
+        unbatched.extend(meshes)
+        return batch(meshes)
+
+    monkeypatch.setattr(module, "_batch_ray_meshes", capture)
+    data = prepare_3d(
+        OpticSnapshot.capture(minimal_optic), {}, progress, threading.Event()
+    )
+    original = [mesh for mesh in unbatched if mesh["role"] == "ray"]
+    prepared = [mesh for mesh in data["meshes"] if mesh["role"] == "ray"]
+    assert len(prepared) == 1 < len(original)
+
+    def paths(meshes):
+        for mesh in meshes:
+            offsets, cells = mesh["cells"]["lines"]
+            for start, end in zip(offsets[:-1], offsets[1:], strict=True):
+                yield mesh["points"][cells[start:end]]
+
+    for before, after in zip(paths(original), paths(prepared), strict=True):
+        np.testing.assert_array_equal(before, after)
+
+
+def test_runtime_custom_geometry_is_rejected_before_data_loss(minimal_optic):
+    base = type(minimal_optic.surfaces[1].geometry)
+
+    class ScriptedGeometry(base):
+        pass
+
+    minimal_optic.surfaces[1].geometry.__class__ = ScriptedGeometry
+    with pytest.raises(ValueError, match="snapshot adapter"):
+        OpticSnapshot.capture(minimal_optic)
+
+
+@pytest.mark.parametrize("aperture_kind", ["rectangle", "ellipse", "none"])
+def test_bulk_surface_mesh_preserves_vertices_and_clipped_quad_topology(
+    minimal_optic, aperture_kind
+):
+    from vtk.util.numpy_support import vtk_to_numpy
+
+    from optiland.physical_apertures import EllipticalAperture, RectangularAperture
+    from optiland.visualization.system.surface import Surface3D
+
+    surface = minimal_optic.surfaces[1]
+    if aperture_kind == "rectangle":
+        surface.aperture = RectangularAperture(-4, 3, -2, 5)
+    elif aperture_kind == "ellipse":
+        surface.aperture = EllipticalAperture(4, 3)
+    view = Surface3D(surface, 4)
+    x, y, z = (be.to_numpy(a) for a in view._compute_sag_3d())
+    actor = view._get_asymmetric_surface()
+    data = actor.GetMapper().GetInput()
+    np.testing.assert_array_equal(
+        vtk_to_numpy(data.GetPoints().GetData()),
+        np.column_stack((x.ravel(), y.ravel(), z.ravel())).astype(np.float32),
+    )
+    mask = surface.aperture.contains(x, y) if surface.aperture else np.hypot(x, y) <= 4
+    # Independent small per-cell construction mirrors VTK quad semantics and
+    # catches transposed rows, winding changes, or accidental edge inclusion.
+    nrows, ncols = x.shape
+    expected = []
+    for i in range(nrows - 1):
+        for j in range(ncols - 1):
+            corners = [(i, j), (i + 1, j), (i + 1, j + 1), (i, j + 1)]
+            if all(mask[row, col] for row, col in corners):
+                expected.extend(row * ncols + col for row, col in corners)
+    cells = data.GetPolys()
+    np.testing.assert_array_equal(vtk_to_numpy(cells.GetConnectivityArray()), expected)
+    np.testing.assert_array_equal(
+        vtk_to_numpy(cells.GetOffsetsArray()), np.arange(0, len(expected) + 1, 4)
+    )
+
+
+def test_only_visible_layout_submits_and_theme_reuses_data(
+    qapp, minimal_optic, monkeypatch
+):
+    import optiland_gui.viewer_panel as module
+    from optiland_gui.optiland_connector import OptilandConnector
+
+    # No native OpenGL context is needed to verify 2D/Sag visibility scheduling.
+    monkeypatch.setattr(module, "VTK_AVAILABLE", False)
+    connector = OptilandConnector()
+    connector._optic = minimal_optic
+    connector.opticLoaded.emit()
+    panel = module.ViewerPanel(connector)
+    assert not connector.calculation_jobs.running
+    panel.resize(700, 600)
+    panel.show()
+    try:
+        wait_for(qapp, lambda: panel.viewer2D.layout_job.data is not None, timeout=30)
+        assert panel.sagViewer.layout_job.data is None
+        serial = connector.calculation_jobs._serial
+        panel.update_theme("light")
+        qapp.processEvents()
+        assert connector.calculation_jobs._serial == serial
+        panel.tabWidget.setCurrentWidget(panel.sagViewer)
+        wait_for(qapp, lambda: panel.sagViewer.layout_job.data is not None, timeout=30)
+        serial = connector.calculation_jobs._serial
+        panel.update_theme("dark")
+        assert panel.viewer2D.layout_job._restyle_pending
+        panel.tabWidget.setCurrentIndex(0)
+        qapp.processEvents()
+        assert connector.calculation_jobs._serial == serial
+        assert not panel.viewer2D.layout_job._restyle_pending
+        connector.opticChanged.emit()
+        wait_for(qapp, lambda: not connector.calculation_jobs.running, timeout=30)
+        assert panel.sagViewer.layout_job._completed_key is None
+    finally:
+        panel.hide()
+        connector.calculation_jobs.shutdown()
+        wait_for(qapp, lambda: connector.calculation_jobs._process is None)
+        panel.deleteLater()
+
+
+def test_window_close_keeps_qt_owners_until_worker_is_reaped(qapp):
+    import sys
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from PySide6.QtWidgets import QWidget
+
+    from optiland_gui.main_window import MainWindow
+    from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+
+    service = CalculationJobs(
+        DocumentState(),
+        cancel_grace_ms=40,
+        worker_command=[
+            sys.executable,
+            "-u",
+            str(Path(__file__).with_name("calculation_worker_fixture.py")),
+        ],
+    )
+    closed = []
+
+    class Window(QWidget):
+        closeEvent = MainWindow.closeEvent
+        _calculations_stopped = MainWindow._calculations_stopped
+
+    window = Window()
+    window.connector = SimpleNamespace(calculation_jobs=service)
+    window.panel_manager = SimpleNamespace(
+        python_terminal=SimpleNamespace(shutdown_kernel=lambda: closed.append(True))
+    )
+    window.show()
+    service.submit("layout", "unused", None, {"delay": 10})
+    wait_for(qapp, lambda: service.active_request is not None)
+    try:
+        assert not window.close()
+        assert window.isVisible()
+        assert not closed
+        wait_for(qapp, lambda: not window.isVisible())
+        assert service._process is None
+        assert closed == [True]
+    finally:
+        service.shutdown()
+        wait_for(qapp, lambda: service._process is None)
+        window.deleteLater()


### PR DESCRIPTION
Applying an optical setting could block the whole GUI while both visible and hidden layouts traced rays and prepared meshes. This change adds an owned, revision-aware calculation process and a bounded queue, then separates 2D/3D/sag preparation from Qt presentation. Visible views retain the last result with contextual progress and cancellation; hidden views prepare on demand. Stale results are rejected and shutdown waits asynchronously for the worker to exit.

Bulk VTK mesh installation and batching of equal-style ray segments reduce GUI-side presentation work while preserving the existing numerical vertices, clipping and topology. Snapshot checks prevent unsupported custom tracing implementations from being silently reconstructed as default models while accepting an unchanged standard method rebound to the same instance. Repeated pending Apply requests coalesce without losing the newest busy state.

Validation: 242 GUI/visualization regression tests passed with 3 existing native-only skips; the final focused suite passed 56 tests. Native synthetic 2D and 3D runs remained responsive during preparation, including dark/light rendering and orderly shutdown. Ruff/format checks passed. The only Codecov-scored core patch has 9/9 changed executable lines covered; existing GUI exclusions are unchanged. Native rendering still runs on Qt, so first presentation of very large scenes may need further optimization.

Closes #815
