### PR TITLE
Highlight editor-selected surfaces and lens bodies in the 2D layout

### DIFF
--- a/optiland/visualization/system/lens.py
+++ b/optiland/visualization/system/lens.py
@@ -45,6 +45,10 @@ class Lens2D:
 
     def __init__(self, surfaces: list[Any]) -> None:
         self.surfaces = surfaces
+        # Sidecar ownership metadata preserves the existing public
+        # artist-to-component plot return value.
+        self.artist_surfaces = {}
+        self.boundary_coordinates = {}
         self._check_surface_overlap()
 
     def _check_surface_overlap(self) -> None:
@@ -145,6 +149,8 @@ class Lens2D:
                 'XZ', or 'YZ'. Defaults to 'YZ'.
 
         """
+        self.artist_surfaces = {}
+        self.boundary_coordinates = {}
         if projection == "XY":
             # For XY projection, draw a circle representing the lens aperture
             max_extent = self._get_max_extent()
@@ -174,9 +180,17 @@ class Lens2D:
                 label="Lens",
             )
             ax.add_patch(circle)
+            self.artist_surfaces[circle] = tuple(s.surf for s in self.surfaces)
             return {circle: self}
         else:
             sags = self._compute_sag(projection=projection)
+            self.boundary_coordinates = {
+                surface.surf: (
+                    be.to_numpy(z),
+                    be.to_numpy(x if projection == "XZ" else y),
+                )
+                for surface, (x, y, z) in zip(self.surfaces, sags, strict=True)
+            }
             return self._plot_lenses(ax, sags, theme=theme, projection=projection)
 
     def _compute_sag(self, apply_transform=True, projection="YZ"):
@@ -342,6 +356,10 @@ class Lens2D:
                 artists_for_lens = [artists_for_lens]
             for artist in artists_for_lens:
                 artists[artist] = self
+                self.artist_surfaces[artist] = (
+                    self.surfaces[k].surf,
+                    self.surfaces[k + 1].surf,
+                )
         return artists
 
 

--- a/optiland_gui/layout_highlighting.py
+++ b/optiland_gui/layout_highlighting.py
@@ -1,0 +1,170 @@
+"""Presentation-only styling of retained 2D scene artists."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from matplotlib.lines import Line2D
+from matplotlib.patches import Patch
+from PySide6.QtCore import QObject, Slot
+from PySide6.QtGui import QColor
+
+import optiland.backend as be
+from optiland.visualization.system.surface import Surface2D
+from optiland.visualization.system.utils import transform
+
+
+@dataclass
+class ArtistBinding:
+    """One styled artist and the live surface identities it represents."""
+
+    artist: object
+    surfaces: tuple
+    body: bool
+    normal: dict
+    overlay: bool = False
+
+
+class LayoutHighlightController(QObject):
+    """Apply current state without retracing, recalculating sag or resetting axes."""
+
+    def __init__(self, axes, canvas, state, theme):
+        super().__init__(canvas)
+        self.axes, self.canvas, self.state = axes, canvas, state
+        self.theme = theme
+        self.document = None
+        self.bindings = []
+        state.changed.connect(self.apply)
+
+    def clear(self):
+        for binding in self.bindings:
+            if binding.overlay:
+                if binding.artist.axes is not None:
+                    binding.artist.remove()
+            else:
+                binding.artist.set(**binding.normal)
+        self.bindings = []
+        self.document = None
+
+    def install(self, artists, scene_optic, surface_identities=None):
+        """Bind a scene to live identities captured with its accepted request."""
+        identities = tuple(surface_identities or self.state.surfaces)
+        scene_surfaces = tuple(scene_optic.surfaces)
+        if len(identities) != len(scene_surfaces):
+            self.clear()
+            return
+        lookup = {
+            id(scene): live
+            for scene, live in zip(scene_surfaces, identities, strict=True)
+        }
+        represented = set()
+        boundaries = {}
+        bodies, surfaces = {}, {}
+        for artist, component in artists.items():
+            if isinstance(artist, Patch):
+                owned = getattr(component, "artist_surfaces", {}).get(artist, ())
+                live = tuple(
+                    lookup[id(surface)] for surface in owned if id(surface) in lookup
+                )
+                if live:
+                    bodies[artist] = live
+                    represented.update(id(surface) for surface in live)
+                for surface, coordinates in getattr(
+                    component, "boundary_coordinates", {}
+                ).items():
+                    if id(surface) in lookup:
+                        boundaries[lookup[id(surface)]] = coordinates
+            elif isinstance(artist, Line2D):
+                # Raw Surface values in the public map identify aperture
+                # indicator chords, not the actual surface curve. Keep those
+                # indicators at normal width; a selected face must be exact.
+                surface = getattr(component, "surf", None)
+                if id(surface) in lookup:
+                    live = lookup[id(surface)]
+                    surfaces[artist] = live
+                    represented.add(id(live))
+
+        # Reference planes omitted by the ordinary renderer receive a short,
+        # dashed schematic surface marker only while selected/hovered. Adding
+        # an artist (rather than plotting it) leaves data limits unchanged.
+        span = abs(self.axes.get_ylim()[1] - self.axes.get_ylim()[0])
+        radius = max(span * 0.025, 0.1)
+        references = {}
+        for scene, live in zip(scene_surfaces, identities, strict=True):
+            if id(live) in represented or getattr(scene, "is_infinite", False):
+                continue
+            marker_surface = Surface2D(scene, radius)
+            x, y, z = marker_surface._compute_sag("YZ")
+            x, y, z = transform(x, y, z, scene, is_global=False)
+            z, y = be.to_numpy(z), be.to_numpy(y)
+            if not (np.isfinite(z) & np.isfinite(y)).any():
+                continue
+            references[live] = (z, y)
+        self.install_bindings(bodies, surfaces, boundaries, references)
+
+    def install_bindings(
+        self, body_artists, surface_artists, boundary_coordinates, reference_coordinates
+    ):
+        """Bind already prepared geometry; arguments contain GUI-local identities.
+
+        Workers transport indices and numeric arrays only. After accepting a
+        result the GUI maps those indices through its captured surface tuple.
+        No reconstructed Optic, geometry computation or tracing is required here.
+        """
+        self.clear()
+        self.document = self.state.document
+        for artist, surfaces in body_artists.items():
+            self._add(artist, tuple(surfaces), body=True)
+        for artist, surface in surface_artists.items():
+            self._add(artist, (surface,), body=False)
+        for surface, coordinates in boundary_coordinates.items():
+            line = Line2D(*coordinates, visible=False, zorder=4)
+            self.axes.add_artist(line)
+            self._add(line, (surface,), body=False, overlay=True)
+        for surface, (z, y) in reference_coordinates.items():
+            line = Line2D(z, y, linestyle="--", visible=False, zorder=4)
+            if np.allclose([z[0], y[0]], [z[-1], y[-1]]):
+                line.set_marker("+")
+            self.axes.add_artist(line)
+            self._add(line, (surface,), body=False, overlay=True)
+        self.apply()
+
+    def _add(self, artist, surfaces, *, body, overlay=False):
+        normal = {"linewidth": artist.get_linewidth(), "visible": artist.get_visible()}
+        if body:
+            normal.update(
+                facecolor=artist.get_facecolor(), edgecolor=artist.get_edgecolor()
+            )
+        else:
+            normal["color"] = artist.get_color()
+        self.bindings.append(ArtistBinding(artist, surfaces, body, normal, overlay))
+
+    @Slot()
+    def apply(self):
+        # Match the desktop theme's selection accent (dark) / focused
+        # selection accent (light), rather than an unrelated native palette.
+        selected = QColor("#007ACC" if self.theme() == "dark" else "#6C757D")
+        hover = selected.lighter(140)
+        for binding in self.bindings:
+            kind = (
+                self.state.state_for(binding.surfaces)
+                if self.document is self.state.document
+                else "normal"
+            )
+            artist = binding.artist
+            if kind == "normal":
+                artist.set(**binding.normal)
+                continue
+            color = selected if kind == "selected" else hover
+            rgb = (color.redF(), color.greenF(), color.blueF())
+            if binding.body:
+                artist.set_facecolor((*rgb, 0.28 if kind == "selected" else 0.18))
+                artist.set_edgecolor(rgb)
+                artist.set_linewidth(1.5)
+            else:
+                artist.set_color(rgb)
+                artist.set_linewidth(2.4 if kind == "selected" else 2.1)
+            artist.set_visible(True)
+        if self.bindings:
+            self.canvas.draw_idle()

--- a/optiland_gui/lens_editor.py
+++ b/optiland_gui/lens_editor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QEvent, QSize, Qt, QTimer, Signal, Slot
+from PySide6.QtCore import QEvent, QItemSelectionModel, QSize, Qt, QTimer, Signal, Slot
 from PySide6.QtGui import QBrush, QColor, QIcon, QPainter, QPen
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -30,6 +30,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from .surface_interaction import EditorHoverTracker, SurfaceInteractionState
 
 if TYPE_CHECKING:
     from .optiland_connector import OptilandConnector
@@ -239,16 +241,20 @@ class _AccentFocusDelegate(QStyledItemDelegate):
 class LensEditor(QWidget):
     """A widget for editing the properties of an optical system's surfaces."""
 
-    def __init__(self, connector: OptilandConnector, parent=None):
+    def __init__(
+        self, connector: OptilandConnector, parent=None, *, interaction_state=None
+    ):
         super().__init__(parent)
         self.connector = connector
         self.setWindowTitle("Lens Editor")
         self.open_prop_source_row = -1
+        self.interaction_state = interaction_state or SurfaceInteractionState(self)
 
         self._init_ui()
         self.setup_table()
         self.load_data()
         self.connect_signals()
+        self.hover_tracker = EditorHoverTracker(self)
 
     def _init_ui(self):
         """Initializes the main UI components of the editor."""
@@ -286,6 +292,7 @@ class LensEditor(QWidget):
         self.tableWidget.itemChanged.connect(self.on_item_changed_handler)
         self.tableWidget.customContextMenuRequested.connect(self.show_context_menu)
         self.tableWidget.itemSelectionChanged.connect(self.update_headers_on_selection)
+        self.tableWidget.itemSelectionChanged.connect(self._update_surface_selection)
         self.connector.opticLoaded.connect(self.full_refresh_from_optic)
         self.connector.opticChanged.connect(self.full_refresh_from_optic)
         self.connector.optimizationVariablesChanged.connect(
@@ -350,6 +357,13 @@ class LensEditor(QWidget):
         if self.open_prop_source_row != -1 and ui_row > self.open_prop_source_row:
             return ui_row - 1
         return ui_row
+
+    def _update_surface_selection(self):
+        indices = (
+            self.map_ui_row_to_surface_index(index.row())
+            for index in self.tableWidget.selectionModel().selectedRows()
+        )
+        self.interaction_state.set_selected_indices(indices)
 
     def map_surface_index_to_ui_row(self, surface_index):
         if (
@@ -438,6 +452,7 @@ class LensEditor(QWidget):
 
     @Slot()
     def load_data(self):
+        self.interaction_state.sync_document(self.connector.get_optic())
         self.tableWidget.blockSignals(True)
         self.tableWidget.setRowCount(0)
         num_surfaces = self.connector.get_surface_count()
@@ -449,7 +464,17 @@ class LensEditor(QWidget):
         if self.open_prop_source_row != -1 and self.open_prop_source_row < num_surfaces:
             self._insert_properties_widget(self.open_prop_source_row)
 
+        for surface in self.interaction_state.selected_surfaces:
+            index = self.interaction_state.index_of(surface)
+            ui_row = self.map_surface_index_to_ui_row(index)
+            model_index = self.tableWidget.model().index(ui_row, 0)
+            self.tableWidget.selectionModel().select(
+                model_index, QItemSelectionModel.Select | QItemSelectionModel.Rows
+            )
+
         self.tableWidget.blockSignals(False)
+        if hasattr(self, "hover_tracker"):
+            self.hover_tracker.refresh()
 
     def _insert_properties_widget(self, source_row):
         prop_row_index = source_row + 1

--- a/optiland_gui/panel_manager.py
+++ b/optiland_gui/panel_manager.py
@@ -68,6 +68,7 @@ class PanelManager:
         self.surface_interaction = SurfaceInteractionState(self.main_window)
         self.surface_interaction.sync_document(self.connector.get_optic())
         self.viewer_panel = ViewerPanel(self.connector)
+        self.viewer_panel.viewer2D.set_interaction_state(self.surface_interaction)
         self.viewer_dock = self._create_dock(
             self.viewer_panel, "ViewerDock", "System Viewer"
         )

--- a/optiland_gui/panel_manager.py
+++ b/optiland_gui/panel_manager.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import QDockWidget, QMainWindow, QWidget
 from .analysis_panel import AnalysisPanel
 from .lens_editor import LensEditor
 from .optimization_panel import OptimizationPanel
+from .surface_interaction import SurfaceInteractionState
 from .system_properties_panel import SystemPropertiesPanel
 from .viewer_panel import ViewerPanel
 from .widgets.custom_dock_widget import CustomDockWidget
@@ -64,12 +65,16 @@ class PanelManager:
         self.sidebar.setTitleBarWidget(QWidget())
 
         # Main panels
+        self.surface_interaction = SurfaceInteractionState(self.main_window)
+        self.surface_interaction.sync_document(self.connector.get_optic())
         self.viewer_panel = ViewerPanel(self.connector)
         self.viewer_dock = self._create_dock(
             self.viewer_panel, "ViewerDock", "System Viewer"
         )
 
-        self.lens_editor = LensEditor(self.connector)
+        self.lens_editor = LensEditor(
+            self.connector, interaction_state=self.surface_interaction
+        )
         self.lens_editor_dock = self._create_dock(
             self.lens_editor, "LensEditorDock", "Lens Data Editor"
         )

--- a/optiland_gui/surface_interaction.py
+++ b/optiland_gui/surface_interaction.py
@@ -1,0 +1,159 @@
+"""GUI-only surface identity and editor pointer state.
+
+These references belong to the live document. A computed scene maps its surface
+indices through the tuple captured when that scene was requested; workers must
+never receive this QObject or the live surface references.
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject, QTimer, Signal
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import QApplication, QWidget
+
+
+class SurfaceInteractionState(QObject):
+    """Selection and hover, independent of optical edits and renderer objects."""
+
+    changed = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.document = None
+        self.surfaces = ()
+        self.selected_surfaces = ()
+        self.hovered_surface = None
+        self.hovered_column = None
+
+    def sync_document(self, document):
+        """Prune deleted identities, or clear state for a different document."""
+        surfaces = tuple(document.surfaces) if document is not None else ()
+        old = self._signature()
+        if document is not self.document:
+            self.selected_surfaces = ()
+            self.hovered_surface = None
+            self.hovered_column = None
+        self.document, self.surfaces = document, surfaces
+        valid = {id(surface) for surface in surfaces}
+        self.selected_surfaces = tuple(
+            surface for surface in self.selected_surfaces if id(surface) in valid
+        )
+        if id(self.hovered_surface) not in valid:
+            self.hovered_surface = None
+            self.hovered_column = None
+        if old != self._signature():
+            self.changed.emit()
+
+    def surface_at(self, index):
+        return self.surfaces[index] if 0 <= index < len(self.surfaces) else None
+
+    def index_of(self, surface):
+        return next(
+            (i for i, value in enumerate(self.surfaces) if value is surface), -1
+        )
+
+    def set_selected_indices(self, indices):
+        selected = tuple(
+            self.surfaces[i]
+            for i in sorted(set(indices))
+            if 0 <= i < len(self.surfaces)
+        )
+        if tuple(map(id, selected)) != tuple(map(id, self.selected_surfaces)):
+            self.selected_surfaces = selected
+            self.changed.emit()
+
+    def set_hover(self, index=-1, column=None):
+        surface = self.surface_at(index)
+        column = column if surface is not None else None
+        if surface is not self.hovered_surface or column != self.hovered_column:
+            self.hovered_surface, self.hovered_column = surface, column
+            self.changed.emit()
+
+    def state_for(self, surfaces):
+        """Resolve selected > hovered > normal for a surface or shared body."""
+        identities = {id(surface) for surface in surfaces}
+        if any(id(surface) in identities for surface in self.selected_surfaces):
+            return "selected"
+        if self.hovered_surface is not None and id(self.hovered_surface) in identities:
+            return "hovered"
+        return "normal"
+
+    def _signature(self):
+        return (
+            id(self.document),
+            tuple(map(id, self.surfaces)),
+            tuple(map(id, self.selected_surfaces)),
+            id(self.hovered_surface),
+            self.hovered_column,
+        )
+
+
+class EditorHoverTracker(QObject):
+    """Observe pointer events without consuming input from embedded cell widgets."""
+
+    def __init__(self, editor):
+        super().__init__(editor)
+        self.editor = editor
+        self.table = editor.tableWidget
+        self.table.setMouseTracking(True)
+        self.table.viewport().setMouseTracking(True)
+        self.table.verticalHeader().setMouseTracking(True)
+        self._enable_tracking()
+        # Application filtering also sees active cell editors and newly inserted
+        # child controls; a viewport-only filter misses their mouse events.
+        QApplication.instance().installEventFilter(self)
+        self.table.verticalScrollBar().valueChanged.connect(self.refresh)
+        self.table.horizontalScrollBar().valueChanged.connect(self.refresh)
+
+    def eventFilter(self, source, event):
+        kind = event.type()
+        if kind in (QEvent.MouseMove, QEvent.Enter):
+            if hasattr(event, "globalPosition"):
+                self.update_at(event.globalPosition().toPoint())
+        elif kind in (QEvent.Leave, QEvent.Hide, QEvent.Resize, QEvent.LayoutRequest):
+            if source is self.table or source is self.table.viewport():
+                QTimer.singleShot(0, self.refresh)
+        elif (
+            kind == QEvent.ChildAdded
+            and isinstance(source, QWidget)
+            and self.table.isAncestorOf(source)
+        ):
+            QTimer.singleShot(0, self._enable_tracking)
+        return False
+
+    def _enable_tracking(self):
+        for widget in self.table.findChildren(QWidget):
+            widget.setMouseTracking(True)
+
+    def refresh(self, *args):
+        self.update_at(QCursor.pos())
+
+    def update_at(self, global_position):
+        state = self.editor.interaction_state
+        if not self.table.isVisible():
+            state.set_hover()
+            return
+        viewport = self.table.viewport()
+        position = viewport.mapFromGlobal(global_position)
+        header = self.table.verticalHeader()
+        header_position = header.viewport().mapFromGlobal(global_position)
+        column = None
+        if viewport.rect().contains(position):
+            row = self.table.rowAt(position.y())
+            column = self.table.columnAt(position.x())
+            if column < 0:
+                row = -1
+        elif header.viewport().rect().contains(header_position):
+            row = header.logicalIndexAt(header_position)
+        else:
+            row = -1
+        if row < 0:
+            state.set_hover()
+            return
+        surface_index = self.editor.map_ui_row_to_surface_index(row)
+        if (
+            self.editor.open_prop_source_row >= 0
+            and row == self.editor.open_prop_source_row + 1
+        ):
+            column = None
+        state.set_hover(surface_index, column)

--- a/optiland_gui/surface_interaction.py
+++ b/optiland_gui/surface_interaction.py
@@ -95,6 +95,12 @@ class EditorHoverTracker(QObject):
         super().__init__(editor)
         self.editor = editor
         self.table = editor.tableWidget
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setSingleShot(True)
+        self._refresh_timer.timeout.connect(self.refresh)
+        self._tracking_timer = QTimer(self)
+        self._tracking_timer.setSingleShot(True)
+        self._tracking_timer.timeout.connect(self._enable_tracking)
         self.table.setMouseTracking(True)
         self.table.viewport().setMouseTracking(True)
         self.table.verticalHeader().setMouseTracking(True)
@@ -112,13 +118,13 @@ class EditorHoverTracker(QObject):
                 self.update_at(event.globalPosition().toPoint())
         elif kind in (QEvent.Leave, QEvent.Hide, QEvent.Resize, QEvent.LayoutRequest):
             if source is self.table or source is self.table.viewport():
-                QTimer.singleShot(0, self.refresh)
+                self._refresh_timer.start(0)
         elif (
             kind == QEvent.ChildAdded
             and isinstance(source, QWidget)
             and self.table.isAncestorOf(source)
         ):
-            QTimer.singleShot(0, self._enable_tracking)
+            self._tracking_timer.start(0)
         return False
 
     def _enable_tracking(self):
@@ -131,6 +137,12 @@ class EditorHoverTracker(QObject):
     def update_at(self, global_position):
         state = self.editor.interaction_state
         if not self.table.isVisible():
+            state.set_hover()
+            return
+        target = QApplication.widgetAt(global_position)
+        if target is None or (
+            target is not self.table and not self.table.isAncestorOf(target)
+        ):
             state.set_hover()
             return
         viewport = self.table.viewport()

--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING
 
 from . import gui_plot_utils
 from .analysis_panel import CustomMatplotlibToolbar
+from .layout_highlighting import LayoutHighlightController
 from .layout_presenter import present_2d, present_3d, present_sag
 from .widgets.layout_job_view import LayoutJobView
 
@@ -370,6 +371,9 @@ class MatplotlibViewer(QWidget):
         self.canvas = FigureCanvas(self.figure)
         plot_layout.addWidget(self.canvas)
         self.ax = self.figure.add_subplot(111)
+        self.interaction_state = None
+        self.highlight_controller = None
+        self._highlight_bindings = None
 
         self._is_plotting = False
         self._user_initiated_view_change = False
@@ -569,6 +573,39 @@ class MatplotlibViewer(QWidget):
             gui_plot_utils.apply_gui_matplotlib_styles(theme=self.current_theme)
             self.layout_job.redraw()
         self.settings_toggle_btn.setIcon(QIcon(f":/icons/{theme}/settings.svg"))
+
+    def set_interaction_state(self, state):
+        """Attach shared editor state without recomputing the existing scene."""
+        if self.highlight_controller is not None:
+            self.interaction_state.changed.disconnect(self.highlight_controller.apply)
+            self.highlight_controller.clear()
+            self.highlight_controller.deleteLater()
+        self.interaction_state = state
+        self.highlight_controller = LayoutHighlightController(
+            self.ax, self.canvas, state, lambda: self.current_theme
+        )
+        if self._highlight_bindings is not None:
+            self.install_2d_highlight_bindings(*self._highlight_bindings)
+
+    def clear_2d_highlights(self):
+        """Forget artist references before replacing the axes contents."""
+        self._highlight_bindings = None
+        if self.highlight_controller is not None:
+            self.highlight_controller.clear()
+
+    def install_2d_highlight_bindings(
+        self, body_artists, surface_artists, boundary_coordinates, reference_coordinates
+    ):
+        """Install GUI-local ownership of an accepted worker-prepared scene."""
+        self._highlight_bindings = (
+            body_artists,
+            surface_artists,
+            boundary_coordinates,
+            reference_coordinates,
+        )
+        if self.highlight_controller is not None:
+            self.interaction_state.sync_document(self.connector.get_optic())
+            self.highlight_controller.install_bindings(*self._highlight_bindings)
 
     def _layout_parameters(self):
         return {

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -18,6 +18,23 @@ def qapp():
     yield app
 
 
+@pytest.fixture
+def highlighting_connector(qapp, minimal_optic):
+    """Real document and worker service for selection/presentation integration."""
+    from PySide6.QtCore import QCoreApplication, QEvent
+
+    from optiland_gui.optiland_connector import OptilandConnector
+    from tests.gui.test_calculation_jobs import wait_for
+
+    connector = OptilandConnector()
+    connector.load_optic_from_object(minimal_optic)
+    yield connector
+    connector.calculation_jobs.shutdown()
+    wait_for(qapp, lambda: connector.calculation_jobs._process is None)
+    connector.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+
 @pytest.fixture()
 def minimal_optic():
     """A 4-surface singlet (object, lens front, lens back/stop, image).

--- a/tests/gui/test_highlighting_async.py
+++ b/tests/gui/test_highlighting_async.py
@@ -1,0 +1,75 @@
+"""Worker acceptance binds retained artists to the current editor identities."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import QCoreApplication, QEvent
+
+from optiland.optic import Optic
+from optiland_gui.surface_interaction import SurfaceInteractionState
+from optiland_gui.viewer_panel import MatplotlibViewer
+from tests.gui.test_calculation_jobs import wait_for
+
+
+def test_worker_uses_latest_selection_and_rejects_previous_document(
+    qapp, highlighting_connector, monkeypatch
+):
+    connector = highlighting_connector
+    optic = connector.get_optic()
+    viewer = MatplotlibViewer(connector)
+    state = SurfaceInteractionState()
+    state.sync_document(optic)
+    viewer.set_interaction_state(state)
+    connector.opticLoaded.connect(lambda: state.sync_document(connector.get_optic()))
+    completed = []
+    connector.calculation_jobs.finished.connect(completed.append)
+    trace = MagicMock(side_effect=AssertionError("GUI traced the live document"))
+    monkeypatch.setattr(type(optic), "trace", trace)
+    viewer.show()
+    viewer.plot_optic()
+    # A real QProcess request has captured its snapshot; change only UI state
+    # before servicing worker output. The presenter must use this latest state.
+    assert viewer.layout_job._job_id is not None
+    state.set_selected_indices([2])
+    state.set_hover(1)
+    wait_for(qapp, lambda: viewer.layout_job.data is not None)
+    controller = viewer.highlight_controller
+    faces = {b.surfaces[0]: b.artist for b in controller.bindings if b.overlay}
+    assert faces[optic.surfaces[2]].get_linewidth() == 2.4
+    assert faces[optic.surfaces[1]].get_linewidth() == 2.1
+    old_artists = [b.artist for b in controller.bindings]
+    old_result = completed[-1]
+    old_data = viewer.layout_job.data
+
+    replacement = Optic.from_dict(optic.to_dict())
+    replacement.name = "Replacement document"
+    connector.load_optic_from_object(replacement)
+    replacement = connector.get_optic()
+    state.set_selected_indices([1])
+    # Stale data may stay visible during calculation, but must never pick up
+    # another document's selection, including a theme redraw of retained data.
+    viewer.update_theme("light")
+    assert all(not b.artist.get_visible() for b in controller.bindings if b.overlay)
+    viewer.layout_job._finished(old_result)
+    assert viewer.layout_job.data is old_data
+    wait_for(qapp, lambda: viewer.layout_job.data is not old_data)
+    assert all(artist.axes is None for artist in old_artists)
+    assert controller.document is replacement
+    assert all(
+        state.index_of(surface) >= 0
+        for binding in controller.bindings
+        for surface in binding.surfaces
+    )
+    face = next(
+        b.artist
+        for b in controller.bindings
+        if b.overlay and b.surfaces == (replacement.surfaces[1],)
+    )
+    assert face.get_visible() and face.get_linewidth() == 2.4
+    trace.assert_not_called()
+    viewer.close()
+    viewer.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+    # QObject destruction must disconnect the controller from the shared state.
+    state.set_selected_indices([2])

--- a/tests/gui/test_highlighting_lifecycle.py
+++ b/tests/gui/test_highlighting_lifecycle.py
@@ -1,0 +1,130 @@
+"""Scene replacement and panel wiring preserve presentation-only interaction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+from matplotlib.patches import Polygon
+from PySide6.QtWidgets import QMainWindow, QVBoxLayout, QWidget
+
+from optiland_gui.surface_interaction import SurfaceInteractionState
+from optiland_gui.viewer_panel import MatplotlibViewer
+
+
+def test_prepared_scene_before_state_and_state_replacement(qapp, minimal_optic):
+    connector = MagicMock()
+    connector.get_optic.return_value = minimal_optic
+    viewer = MatplotlibViewer(connector)
+    viewer.clear_2d_highlights()
+    viewer.ax.clear()
+    body = Polygon([(0, 0), (1, 0), (1, 1)], facecolor="grey")
+    viewer.ax.add_patch(body)
+    normal_width = body.get_linewidth()
+    surfaces = tuple(minimal_optic.surfaces)
+    coordinates = (np.array([0, 0]), np.array([0, 1]))
+    viewer.install_2d_highlight_bindings(
+        {body: surfaces[1:3]},
+        {},
+        {surfaces[1]: coordinates},
+        {surfaces[3]: (np.array([2, 2]), np.array([0, 0]))},
+    )
+    first = SurfaceInteractionState(viewer)
+    first.sync_document(minimal_optic)
+    first.set_selected_indices([1])
+    viewer.set_interaction_state(first)
+    assert body.get_linewidth() > normal_width
+    assert any(
+        binding.artist.get_marker() == "+"
+        for binding in viewer.highlight_controller.bindings
+        if binding.overlay
+    )
+
+    second = SurfaceInteractionState(viewer)
+    second.sync_document(minimal_optic)
+    viewer.set_interaction_state(second)
+    assert body.get_linewidth() == normal_width
+    first.set_hover(2)
+    assert body.get_linewidth() == normal_width  # Old document signals are detached.
+    second.set_hover(1)
+    assert body.get_linewidth() > normal_width
+    viewer.clear_2d_highlights()
+    assert body.get_linewidth() == normal_width
+    assert viewer.highlight_controller.bindings == []
+    assert len(viewer.ax.lines) == 0
+    viewer.close()
+
+
+def test_reject_mismatched_scene_identity_and_nonfinite_reference(
+    qapp, minimal_optic, monkeypatch
+):
+    from optiland_gui.layout_highlighting import Surface2D
+
+    connector = MagicMock()
+    connector.get_optic.return_value = minimal_optic
+    viewer = MatplotlibViewer(connector)
+    state = SurfaceInteractionState(viewer)
+    state.sync_document(minimal_optic)
+    viewer.set_interaction_state(state)
+    state.set_selected_indices([1])
+    viewer.highlight_controller.install({}, minimal_optic, (object(),))
+    assert viewer.highlight_controller.bindings == []
+    monkeypatch.setattr(
+        Surface2D,
+        "_compute_sag",
+        lambda *_: tuple(np.full(3, np.nan) for _ in range(3)),
+    )
+    viewer.highlight_controller.install({}, minimal_optic)
+    assert viewer.highlight_controller.bindings == []
+    viewer.close()
+
+
+def test_panel_manager_connects_actual_editor_and_2d_viewer_to_one_state(
+    qapp, minimal_optic, monkeypatch
+):
+    from optiland_gui import panel_manager
+    from optiland_gui.optiland_connector import OptilandConnector
+
+    # Unrelated panels must not start VTK windows or an IPython kernel here.
+    class PassivePanel(QWidget):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    class TwoDimensionalPanel(QWidget):
+        def __init__(self, connector):
+            super().__init__()
+            self.viewer2D = MatplotlibViewer(connector)
+            QVBoxLayout(self).addWidget(self.viewer2D)
+
+    for name in (
+        "SidebarWidget",
+        "SystemPropertiesPanel",
+        "AnalysisPanel",
+        "OptimizationPanel",
+        "PythonTerminalWidget",
+    ):
+        monkeypatch.setattr(panel_manager, name, PassivePanel)
+    monkeypatch.setattr(panel_manager, "ViewerPanel", TwoDimensionalPanel)
+    connector = OptilandConnector()
+    connector.load_optic_from_object(minimal_optic)
+    window = QMainWindow()
+    window.iface = SimpleNamespace()
+    manager = panel_manager.PanelManager(window, connector)
+    manager.create_all_panels(window)
+    state = manager.surface_interaction
+    assert manager.lens_editor.interaction_state is state
+    assert manager.viewer_panel.viewer2D.interaction_state is state
+    changed = MagicMock()
+    connector.opticChanged.connect(changed)
+    manager.lens_editor.tableWidget.selectRow(1)
+    assert state.selected_surfaces == (connector.get_optic().surfaces[1],)
+    bodies = [
+        binding
+        for binding in manager.viewer_panel.viewer2D.highlight_controller.bindings
+        if binding.body
+    ]
+    assert bodies and all(binding.artist.get_linewidth() == 1.5 for binding in bodies)
+    changed.assert_not_called()
+    window.close()
+    window.deleteLater()

--- a/tests/gui/test_highlighting_lifecycle.py
+++ b/tests/gui/test_highlighting_lifecycle.py
@@ -81,10 +81,10 @@ def test_reject_mismatched_scene_identity_and_nonfinite_reference(
 
 
 def test_panel_manager_connects_actual_editor_and_2d_viewer_to_one_state(
-    qapp, minimal_optic, monkeypatch
+    qapp, highlighting_connector, monkeypatch
 ):
     from optiland_gui import panel_manager
-    from optiland_gui.optiland_connector import OptilandConnector
+    from tests.gui.test_calculation_jobs import wait_for
 
     # Unrelated panels must not start VTK windows or an IPython kernel here.
     class PassivePanel(QWidget):
@@ -106,12 +106,15 @@ def test_panel_manager_connects_actual_editor_and_2d_viewer_to_one_state(
     ):
         monkeypatch.setattr(panel_manager, name, PassivePanel)
     monkeypatch.setattr(panel_manager, "ViewerPanel", TwoDimensionalPanel)
-    connector = OptilandConnector()
-    connector.load_optic_from_object(minimal_optic)
+    connector = highlighting_connector
     window = QMainWindow()
     window.iface = SimpleNamespace()
     manager = panel_manager.PanelManager(window, connector)
     manager.create_all_panels(window)
+    viewer = manager.viewer_panel.viewer2D
+    window.show()
+    manager.viewer_panel.show()
+    wait_for(qapp, lambda: viewer.layout_job.data is not None)
     state = manager.surface_interaction
     assert manager.lens_editor.interaction_state is state
     assert manager.viewer_panel.viewer2D.interaction_state is state
@@ -126,5 +129,7 @@ def test_panel_manager_connects_actual_editor_and_2d_viewer_to_one_state(
     ]
     assert bodies and all(binding.artist.get_linewidth() == 1.5 for binding in bodies)
     changed.assert_not_called()
+    manager.viewer_panel.close()
+    manager.viewer_panel.deleteLater()
     window.close()
     window.deleteLater()

--- a/tests/gui/test_layout_highlighting.py
+++ b/tests/gui/test_layout_highlighting.py
@@ -1,0 +1,220 @@
+"""Retained 2D artists identify exact faces without optical recomputation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
+from matplotlib.figure import Figure
+
+from optiland.optic import Optic
+from optiland.physical_apertures import RadialAperture
+from optiland.visualization.system.system import OpticalSystem
+from optiland_gui.layout_highlighting import LayoutHighlightController
+from optiland_gui.surface_interaction import SurfaceInteractionState
+
+
+def scene(optic, qapp):
+    figure = Figure()
+    canvas = FigureCanvasQTAgg(figure)
+    ax = figure.add_subplot()
+    system = OpticalSystem(
+        optic, SimpleNamespace(r_extent=np.full(len(optic.surfaces), 5.0))
+    )
+    artists = system.plot(ax)
+    state = SurfaceInteractionState(canvas)
+    state.sync_document(optic)
+    controller = LayoutHighlightController(ax, canvas, state, lambda: "dark")
+    limits = ax.get_xlim(), ax.get_ylim()
+    controller.install(artists, optic)
+    assert (ax.get_xlim(), ax.get_ylim()) == limits
+    return canvas, ax, state, controller
+
+
+def test_exact_faces_and_body_have_independent_styles(qapp, minimal_optic, monkeypatch):
+    canvas, ax, state, controller = scene(minimal_optic, qapp)
+    body = next(binding for binding in controller.bindings if binding.body)
+    faces = {
+        state.index_of(binding.surfaces[0]): binding
+        for binding in controller.bindings
+        if binding.overlay
+    }
+    original = dict(body.normal)
+    indicator = next(line for line in ax.lines if line.get_linewidth() == 0.3)
+    limits = ax.get_xlim(), ax.get_ylim()
+    trace = MagicMock(side_effect=AssertionError("Hover retraced rays"))
+    monkeypatch.setattr(minimal_optic, "trace", trace)
+    state.set_selected_indices([1])
+    selected_fill = body.artist.get_facecolor()
+    selected_line = faces[1].artist.get_color()
+    assert selected_fill[3] < original["facecolor"][3]
+    assert faces[1].artist.get_linewidth() > body.artist.get_linewidth()
+    assert indicator.get_linewidth() == 0.3
+    state.set_hover(2, 3)
+    assert body.artist.get_facecolor() == selected_fill
+    assert faces[1].artist.get_color() == selected_line
+    assert faces[2].artist.get_color() != selected_line
+    assert faces[2].artist.get_linewidth() > body.artist.get_linewidth()
+    state.set_hover(1, 3)
+    assert faces[1].artist.get_color() == selected_line
+    assert not faces[2].artist.get_visible()
+    state.set_selected_indices([2])
+    assert body.artist.get_facecolor() == selected_fill
+    assert faces[2].artist.get_color() == selected_line
+    state.set_hover()
+    assert not faces[1].artist.get_visible()
+    state.set_selected_indices([])
+    assert body.artist.get_facecolor() == original["facecolor"]
+    assert body.artist.get_edgecolor() == original["edgecolor"]
+    assert (ax.get_xlim(), ax.get_ylim()) == limits
+    trace.assert_not_called()
+    canvas.close()
+
+
+def test_standalone_surface_and_reference_marker(qapp):
+    optic = Optic()
+    optic.wavelengths.add(value=0.55, is_primary=True)
+    optic.surfaces.add(index=0, radius=np.inf, thickness=10)
+    optic.surfaces.add(index=1, radius=np.inf, thickness=5)  # neutral reference
+    optic.surfaces.add(index=2, radius=np.inf, thickness=-5, material="mirror")
+    optic.surfaces.add(index=3, radius=np.inf)
+    canvas, ax, state, controller = scene(optic, qapp)
+    assert not any(binding.body for binding in controller.bindings)
+    mirror = next(
+        binding
+        for binding in controller.bindings
+        if binding.surfaces == (optic.surfaces[2],)
+    )
+    marker = next(
+        binding
+        for binding in controller.bindings
+        if binding.surfaces == (optic.surfaces[1],)
+    )
+    assert marker.overlay and not marker.artist.get_visible()
+    limits = ax.get_xlim(), ax.get_ylim()
+    state.set_selected_indices([2])
+    assert mirror.artist.get_linewidth() > mirror.normal["linewidth"]
+    state.set_hover(1)
+    assert marker.artist.get_visible()
+    assert marker.artist.get_linestyle() == "--"
+    assert (ax.get_xlim(), ax.get_ylim()) == limits
+    canvas.close()
+
+
+def test_cemented_interface_highlights_adjoining_bodies_and_annular_patches(qapp):
+    optic = Optic()
+    optic.wavelengths.add(value=0.55, is_primary=True)
+    optic.surfaces.add(index=0, radius=np.inf, thickness=10)
+    optic.surfaces.add(
+        index=1,
+        radius=np.inf,
+        thickness=3,
+        material="N-BK7",
+        aperture=RadialAperture(r_max=5, r_min=1),
+    )
+    optic.surfaces.add(
+        index=2,
+        radius=np.inf,
+        thickness=3,
+        material="F2",
+        aperture=RadialAperture(r_max=5, r_min=1),
+    )
+    optic.surfaces.add(
+        index=3, radius=np.inf, thickness=10, aperture=RadialAperture(r_max=5, r_min=1)
+    )
+    optic.surfaces.add(index=4, radius=np.inf)
+    canvas, _, state, controller = scene(optic, qapp)
+    bodies = [binding for binding in controller.bindings if binding.body]
+    assert len(bodies) >= 4  # split patches, including both adjoining glass regions
+    assert {tuple(state.index_of(s) for s in b.surfaces) for b in bodies} == {
+        (1, 2),
+        (2, 3),
+    }
+    state.set_selected_indices([2])
+    assert all(binding.artist.get_linewidth() == 1.5 for binding in bodies)
+    interface = [
+        binding
+        for binding in controller.bindings
+        if binding.overlay and binding.surfaces == (optic.surfaces[2],)
+    ]
+    assert len(interface) == 1
+    assert interface[0].artist.get_linewidth() > bodies[0].artist.get_linewidth()
+    canvas.close()
+
+
+def test_snapshot_maps_to_live_identity_and_uses_latest_state(qapp, minimal_optic):
+    canvas, ax, state, controller = scene(minimal_optic, qapp)
+    captured = tuple(minimal_optic.surfaces)
+    snapshot = Optic.from_dict(minimal_optic.to_dict())
+    controller.clear()
+    ax.clear()
+    system = OpticalSystem(snapshot, SimpleNamespace(r_extent=np.full(4, 5.0)))
+    artists = system.plot(ax)
+    state.set_selected_indices([2])
+    controller.install(artists, snapshot, captured)
+    body = next(binding for binding in controller.bindings if binding.body)
+    assert body.surfaces == captured[1:3]
+    assert body.artist.get_linewidth() == 1.5
+    state.sync_document(Optic())
+    assert body.artist.get_linewidth() == body.normal["linewidth"]
+    canvas.close()
+
+
+def test_prepared_bindings_install_and_clear_without_reconstructing_optic(
+    qapp, minimal_optic
+):
+    canvas, ax, state, controller = scene(minimal_optic, qapp)
+    body = next(binding for binding in controller.bindings if binding.body)
+    front = next(
+        binding
+        for binding in controller.bindings
+        if binding.overlay and binding.surfaces == (minimal_optic.surfaces[1],)
+    )
+    coordinates = tuple(np.copy(value) for value in front.artist.get_data())
+    body_artist, owned = body.artist, body.surfaces
+    controller.clear()
+    baseline_lines = len(ax.lines)
+    state.set_selected_indices([1])
+    controller.install_bindings({body_artist: owned}, {}, {owned[0]: coordinates}, {})
+    assert body_artist.get_linewidth() == 1.5
+    assert len(ax.lines) == baseline_lines + 1
+    controller.install_bindings({body_artist: owned}, {}, {owned[0]: coordinates}, {})
+    assert len(ax.lines) == baseline_lines + 1  # Reinstallation removes old overlays.
+    controller.clear()
+    assert len(ax.lines) == baseline_lines
+    assert body_artist.get_linewidth() == body.normal["linewidth"]
+    canvas.close()
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_viewer_reuses_current_artists_on_hover_and_restores_after_rebuild(
+    qapp, minimal_optic, monkeypatch, theme
+):
+    from optiland_gui.viewer_panel import MatplotlibViewer
+
+    connector = MagicMock()
+    connector.get_optic.return_value = minimal_optic
+    viewer = MatplotlibViewer(connector)
+    state = SurfaceInteractionState(viewer)
+    state.sync_document(minimal_optic)
+    viewer.set_interaction_state(state)
+    viewer.update_theme(theme)
+    limits = viewer.ax.get_xlim(), viewer.ax.get_ylim()
+    original_artist = viewer.highlight_controller.bindings[0].artist
+    original_plot = viewer.plot_optic
+    spy = MagicMock(side_effect=AssertionError("Selection rebuilt the plot"))
+    monkeypatch.setattr(viewer, "plot_optic", spy)
+    state.set_selected_indices([1])
+    state.set_hover(2, 4)
+    assert viewer.highlight_controller.bindings[0].artist is original_artist
+    assert (viewer.ax.get_xlim(), viewer.ax.get_ylim()) == limits
+    original_plot(preserve_zoom=True)
+    assert state.selected_surfaces == (minimal_optic.surfaces[1],)
+    body = next(b for b in viewer.highlight_controller.bindings if b.body)
+    assert body.artist.get_linewidth() == 1.5
+    spy.assert_not_called()
+    connector.opticChanged.emit.assert_not_called()
+    viewer.close()

--- a/tests/gui/test_layout_highlighting.py
+++ b/tests/gui/test_layout_highlighting.py
@@ -191,17 +191,22 @@ def test_prepared_bindings_install_and_clear_without_reconstructing_optic(
 
 @pytest.mark.parametrize("theme", ["light", "dark"])
 def test_viewer_reuses_current_artists_on_hover_and_restores_after_rebuild(
-    qapp, minimal_optic, monkeypatch, theme
+    qapp, highlighting_connector, monkeypatch, theme
 ):
     from optiland_gui.viewer_panel import MatplotlibViewer
+    from tests.gui.test_calculation_jobs import wait_for
 
-    connector = MagicMock()
-    connector.get_optic.return_value = minimal_optic
+    connector = highlighting_connector
+    optic = connector.get_optic()
     viewer = MatplotlibViewer(connector)
     state = SurfaceInteractionState(viewer)
-    state.sync_document(minimal_optic)
+    state.sync_document(optic)
     viewer.set_interaction_state(state)
+    viewer.show()
+    wait_for(qapp, lambda: viewer.layout_job.data is not None)
     viewer.update_theme(theme)
+    changed = MagicMock()
+    connector.opticChanged.connect(changed)
     limits = viewer.ax.get_xlim(), viewer.ax.get_ylim()
     original_artist = viewer.highlight_controller.bindings[0].artist
     original_plot = viewer.plot_optic
@@ -211,10 +216,17 @@ def test_viewer_reuses_current_artists_on_hover_and_restores_after_rebuild(
     state.set_hover(2, 4)
     assert viewer.highlight_controller.bindings[0].artist is original_artist
     assert (viewer.ax.get_xlim(), viewer.ax.get_ylim()) == limits
+    old_data = viewer.layout_job.data
+    viewer.num_rays_spinbox.setValue(7)
     original_plot(preserve_zoom=True)
-    assert state.selected_surfaces == (minimal_optic.surfaces[1],)
+    wait_for(qapp, lambda: viewer.layout_job.data is not old_data)
+    assert state.selected_surfaces == (optic.surfaces[1],)
+    assert viewer.highlight_controller.bindings[0].artist is not original_artist
+    assert original_artist.axes is None
+    np.testing.assert_allclose((viewer.ax.get_xlim(), viewer.ax.get_ylim()), limits)
     body = next(b for b in viewer.highlight_controller.bindings if b.body)
     assert body.artist.get_linewidth() == 1.5
     spy.assert_not_called()
-    connector.opticChanged.emit.assert_not_called()
+    changed.assert_not_called()
     viewer.close()
+    viewer.deleteLater()

--- a/tests/gui/test_surface_interaction.py
+++ b/tests/gui/test_surface_interaction.py
@@ -77,8 +77,14 @@ def make_editor(minimal_optic):
     conn.get_surface_data.return_value = "0"
     editor = LensEditor(conn)
     editor.resize(850, 400)
+    # Native desktop tools can retain foreground focus over a test window.
+    # Keep this fixture unobscured so widgetAt tests the intended target.
+    editor.setWindowFlag(Qt.WindowStaysOnTopHint)
     editor.show()
+    editor.raise_()
+    editor.activateWindow()
     QTest.qWaitForWindowExposed(editor)
+    QTest.qWaitForWindowActive(editor)
     QTest.qWait(100)
     return editor, conn
 
@@ -117,6 +123,19 @@ def test_editor_hover_selection_embedded_header_and_leave(qapp, minimal_optic):
         )
         assert state.hovered_surface is selected
         assert state.hovered_column is None
+        horizontal_header = table.horizontalHeader().viewport()
+        move_pointer(horizontal_header, horizontal_header.rect().center())
+        assert state.hovered_surface is None
+        for column in range(table.columnCount()):
+            table.setColumnWidth(column, 60)
+        QTest.qWait(5)
+        blank_position = QPoint(
+            table.horizontalHeader().length() + 10, table.rowViewportPosition(1) + 10
+        )
+        assert table.viewport().rect().contains(blank_position)
+        assert table.columnAt(blank_position.x()) == -1
+        move_pointer(table.viewport(), blank_position)
+        assert state.hovered_surface is None  # Empty space to the right of columns.
         move_pointer(table.viewport(), QPoint(20, table.viewport().height() - 5))
         assert state.hovered_surface is None
         assert state.selected_surfaces == (selected,)
@@ -165,6 +184,7 @@ def test_overlapping_window_and_pending_pointer_callbacks(qapp, minimal_optic):
     move_to_cell(editor, 1, 2)
     assert editor.interaction_state.hovered_surface is minimal_optic.surfaces[1]
     overlay = QWidget()
+    overlay.setWindowFlag(Qt.WindowStaysOnTopHint)
     overlay.resize(editor.size())
     overlay.move(editor.mapToGlobal(QPoint(0, 0)))
     overlay.show()

--- a/tests/gui/test_surface_interaction.py
+++ b/tests/gui/test_surface_interaction.py
@@ -1,0 +1,151 @@
+"""Surface identity and real editor pointer/selection behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import QItemSelectionModel, QPoint
+from PySide6.QtTest import QTest
+
+from optiland_gui.lens_editor import LensEditor
+from optiland_gui.surface_interaction import SurfaceInteractionState
+
+
+def test_identity_survives_insertion_and_prunes_deletion(qapp):
+    a, b, c = object(), object(), object()
+    optic = SimpleNamespace(surfaces=[a, b, c])
+    state = SurfaceInteractionState()
+    state.sync_document(optic)
+    state.set_selected_indices([1])
+    state.set_hover(2, 3)
+    optic.surfaces.insert(0, object())
+    state.sync_document(optic)
+    assert state.selected_surfaces == (b,)
+    assert state.index_of(b) == 2
+    assert state.hovered_surface is c
+    optic.surfaces.remove(b)
+    state.sync_document(optic)
+    assert state.selected_surfaces == ()
+    state.sync_document(SimpleNamespace(surfaces=[a, c]))
+    assert state.hovered_surface is None
+
+
+def test_surface_and_body_precedence_are_independent(qapp):
+    a, b, c = object(), object(), object()
+    state = SurfaceInteractionState()
+    state.sync_document(SimpleNamespace(surfaces=[a, b, c]))
+    state.set_selected_indices([0])
+    state.set_hover(1, 2)
+    assert state.state_for([a, b]) == "selected"
+    assert state.state_for([a]) == "selected"
+    assert state.state_for([b]) == "hovered"
+    assert state.state_for([c]) == "normal"
+    state.set_hover(0, 4)
+    assert state.state_for([a]) == "selected"
+    state.set_selected_indices([])
+    assert state.state_for([a]) == "hovered"
+    state.set_hover()
+    assert state.state_for([a]) == "normal"
+
+
+def make_editor(minimal_optic):
+    conn = MagicMock()
+    conn.get_optic.return_value = minimal_optic
+    conn.COL_TYPE, conn.COL_COMMENT, conn.COL_RADIUS = 0, 1, 2
+    conn.COL_THICKNESS, conn.COL_MATERIAL, conn.COL_CONIC = 3, 4, 5
+    conn.COL_SEMI_DIAMETER = 6
+    conn.get_column_headers.return_value = [
+        "Type",
+        "Comment",
+        "Radius",
+        "Thickness",
+        "Material",
+        "Conic",
+        "Semi-Diameter",
+    ]
+    conn.get_surface_count.side_effect = lambda: len(minimal_optic.surfaces)
+    conn.get_optimization_variables.return_value = []
+    conn.get_surface_type_info.return_value = {
+        "display_text": "Standard",
+        "is_changeable": True,
+        "has_extra_params": False,
+    }
+    conn.get_surface_geometry_params.return_value = {}
+    conn.get_available_surface_types.return_value = ["standard"]
+    conn.get_surface_data.return_value = "0"
+    editor = LensEditor(conn)
+    editor.resize(850, 400)
+    editor.show()
+    QTest.qWait(10)
+    return editor, conn
+
+
+def move_to_cell(editor, row, column):
+    rect = editor.tableWidget.visualRect(editor.tableWidget.model().index(row, column))
+    QTest.mouseMove(editor.tableWidget.viewport(), rect.center())
+
+
+def test_editor_hover_selection_embedded_header_and_leave(qapp, minimal_optic):
+    editor, conn = make_editor(minimal_optic)
+    state = editor.interaction_state
+    table = editor.tableWidget
+    try:
+        table.selectRow(1)
+        selected = minimal_optic.surfaces[1]
+        assert state.selected_surfaces == (selected,)
+        move_to_cell(editor, 2, 3)
+        assert state.hovered_surface is minimal_optic.surfaces[2]
+        assert state.hovered_column == 3
+        assert state.selected_surfaces == (selected,)
+        embedded = table.cellWidget(2, 0).type_edit
+        QTest.mouseMove(embedded, embedded.rect().center())
+        assert state.hovered_surface is minimal_optic.surfaces[2]
+        assert state.hovered_column == 0
+        header = table.verticalHeader()
+        QTest.mouseMove(
+            header.viewport(), QPoint(5, header.sectionViewportPosition(1) + 10)
+        )
+        assert state.hovered_surface is selected
+        assert state.hovered_column is None
+        QTest.mouseMove(table.viewport(), QPoint(20, table.viewport().height() - 5))
+        assert state.hovered_surface is None
+        assert state.selected_surfaces == (selected,)
+        table.clearSelection()
+        assert state.selected_surfaces == ()
+        conn.set_surface_data.assert_not_called()
+        conn.opticChanged.emit.assert_not_called()
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_selection_and_hover_survive_expanded_property_rows(qapp, minimal_optic):
+    editor, conn = make_editor(minimal_optic)
+    table = editor.tableWidget
+    state = editor.interaction_state
+    try:
+        table.selectRow(2)
+        editor.toggle_properties_widget(1)
+        assert state.selected_surfaces == (minimal_optic.surfaces[2],)
+        assert table.selectionModel().selectedRows()[0].row() == 3
+        move_to_cell(editor, 3, 2)
+        assert state.hovered_surface is minimal_optic.surfaces[2]
+        props = table.cellWidget(2, 0)
+        QTest.mouseMove(props, QPoint(15, 15))
+        assert state.hovered_surface is minimal_optic.surfaces[1]
+        assert state.hovered_column is None
+        editor.load_data()
+        assert state.selected_surfaces == (minimal_optic.surfaces[2],)
+        table.selectionModel().select(
+            table.model().index(1, 0),
+            QItemSelectionModel.Select | QItemSelectionModel.Rows,
+        )
+        assert state.selected_surfaces == (
+            minimal_optic.surfaces[1],
+            minimal_optic.surfaces[2],
+        )
+        conn.set_surface_data.assert_not_called()
+    finally:
+        editor.close()
+        editor.deleteLater()

--- a/tests/gui/test_surface_interaction.py
+++ b/tests/gui/test_surface_interaction.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from PySide6.QtCore import QItemSelectionModel, QPoint
+from PySide6.QtCore import QItemSelectionModel, QPoint, Qt
 from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QWidget
 
 from optiland_gui.lens_editor import LensEditor
 from optiland_gui.surface_interaction import SurfaceInteractionState
@@ -77,13 +78,21 @@ def make_editor(minimal_optic):
     editor = LensEditor(conn)
     editor.resize(850, 400)
     editor.show()
-    QTest.qWait(10)
+    QTest.qWaitForWindowExposed(editor)
+    QTest.qWait(100)
     return editor, conn
 
 
 def move_to_cell(editor, row, column):
     rect = editor.tableWidget.visualRect(editor.tableWidget.model().index(row, column))
-    QTest.mouseMove(editor.tableWidget.viewport(), rect.center())
+    move_pointer(editor.tableWidget.viewport(), rect.center())
+
+
+def move_pointer(widget, position):
+    QTest.mouseMove(widget, position)
+    # Native Windows delivers synthesized cursor motion through its event
+    # queue; offscreen dispatches synchronously. Wait for the former too.
+    QTest.qWait(100)
 
 
 def test_editor_hover_selection_embedded_header_and_leave(qapp, minimal_optic):
@@ -99,16 +108,16 @@ def test_editor_hover_selection_embedded_header_and_leave(qapp, minimal_optic):
         assert state.hovered_column == 3
         assert state.selected_surfaces == (selected,)
         embedded = table.cellWidget(2, 0).type_edit
-        QTest.mouseMove(embedded, embedded.rect().center())
+        move_pointer(embedded, embedded.rect().center())
         assert state.hovered_surface is minimal_optic.surfaces[2]
         assert state.hovered_column == 0
         header = table.verticalHeader()
-        QTest.mouseMove(
+        move_pointer(
             header.viewport(), QPoint(5, header.sectionViewportPosition(1) + 10)
         )
         assert state.hovered_surface is selected
         assert state.hovered_column is None
-        QTest.mouseMove(table.viewport(), QPoint(20, table.viewport().height() - 5))
+        move_pointer(table.viewport(), QPoint(20, table.viewport().height() - 5))
         assert state.hovered_surface is None
         assert state.selected_surfaces == (selected,)
         table.clearSelection()
@@ -132,7 +141,7 @@ def test_selection_and_hover_survive_expanded_property_rows(qapp, minimal_optic)
         move_to_cell(editor, 3, 2)
         assert state.hovered_surface is minimal_optic.surfaces[2]
         props = table.cellWidget(2, 0)
-        QTest.mouseMove(props, QPoint(15, 15))
+        move_pointer(props, QPoint(15, 15))
         assert state.hovered_surface is minimal_optic.surfaces[1]
         assert state.hovered_column is None
         editor.load_data()
@@ -145,6 +154,51 @@ def test_selection_and_hover_survive_expanded_property_rows(qapp, minimal_optic)
             minimal_optic.surfaces[1],
             minimal_optic.surfaces[2],
         )
+        conn.set_surface_data.assert_not_called()
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_overlapping_window_and_pending_pointer_callbacks(qapp, minimal_optic):
+    editor, _ = make_editor(minimal_optic)
+    move_to_cell(editor, 1, 2)
+    assert editor.interaction_state.hovered_surface is minimal_optic.surfaces[1]
+    overlay = QWidget()
+    overlay.resize(editor.size())
+    overlay.move(editor.mapToGlobal(QPoint(0, 0)))
+    overlay.show()
+    overlay.raise_()
+    QTest.qWait(5)
+    move_pointer(overlay, QPoint(150, 60))
+    assert editor.interaction_state.hovered_surface is None
+    overlay.close()
+    editor.hover_tracker._refresh_timer.start(0)
+    editor.hover_tracker._tracking_timer.start(0)
+    editor.close()
+    editor.deleteLater()
+    QTest.qWait(5)  # Owned timers must not access widgets after destruction.
+
+
+def test_keyboard_selection_scroll_and_pointer_leave(qapp, minimal_optic):
+    editor, conn = make_editor(minimal_optic)
+    table = editor.tableWidget
+    state = editor.interaction_state
+    try:
+        table.setCurrentCell(1, 2)
+        table.setFocus()
+        QTest.keyClick(table, Qt.Key_Down)
+        assert state.selected_surfaces == (minimal_optic.surfaces[2],)
+        table.setFixedHeight(110)
+        QTest.qWait(5)
+        table.scrollToTop()
+        move_to_cell(editor, 0, 2)
+        assert state.hovered_surface is minimal_optic.surfaces[0]
+        table.verticalScrollBar().setValue(table.rowHeight(0))
+        assert state.hovered_surface is minimal_optic.surfaces[1]
+        move_pointer(editor.btnAddSurface, editor.btnAddSurface.rect().center())
+        assert state.hovered_surface is None
+        assert state.selected_surfaces == (minimal_optic.surfaces[2],)
         conn.set_surface_data.assert_not_called()
     finally:
         editor.close()

--- a/tests/visualization/system/test_lens2d_ownership.py
+++ b/tests/visualization/system/test_lens2d_ownership.py
@@ -1,0 +1,63 @@
+"""Lens ownership metadata stays exact across projections and redraws."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from optiland.materials import IdealMaterial
+from optiland.optic import Optic
+from optiland.physical_apertures import RadialAperture
+from optiland.visualization.system.lens import Lens2D
+from optiland.visualization.system.surface import Surface2D
+
+
+@pytest.mark.parametrize("projection", ["XZ", "YZ"])
+def test_cemented_annular_bodies_keep_exact_surface_ownership(
+    set_test_backend, projection
+):
+    optic = Optic()
+    optic.surfaces.add(index=0, radius=np.inf, thickness=10)
+    for index, material in enumerate(
+        (IdealMaterial(1.5), IdealMaterial(1.6), IdealMaterial(1.0))
+    ):
+        optic.surfaces.add(
+            index=index + 1,
+            radius=np.inf,
+            thickness=3,
+            material=material,
+            aperture=RadialAperture(r_max=5, r_min=1),
+        )
+    optic.surfaces.add(index=4, radius=np.inf)
+    surfaces = tuple(optic.surfaces)[1:4]
+    lens = Lens2D([Surface2D(surface, 5) for surface in surfaces])
+    ax = Figure().add_subplot()
+    artists = lens.plot(ax, projection=projection)
+
+    assert len(artists) == 4  # Each of the two glass regions is split at the hole.
+    assert all(component is lens for component in artists.values())
+    assert set(lens.artist_surfaces) == set(artists)
+    assert set(lens.artist_surfaces.values()) == {
+        surfaces[:2],
+        surfaces[1:],
+    }
+    assert set(lens.boundary_coordinates) == set(surfaces)
+    for surface, (z, height) in lens.boundary_coordinates.items():
+        finite = np.isfinite(z) & np.isfinite(height)
+        np.testing.assert_allclose(z[finite], float(surface.geometry.cs.z))
+        assert np.min(np.abs(height[finite])) >= 1
+        assert np.max(np.abs(height[finite])) == pytest.approx(5)
+
+    previous_artists = set(artists)
+    ax.clear()
+    face_on = lens.plot(ax, projection="XY")
+    assert set(lens.artist_surfaces) == set(face_on)
+    assert not previous_artists.intersection(lens.artist_surfaces)
+    assert list(lens.artist_surfaces.values()) == [surfaces]
+    assert lens.boundary_coordinates == {}
+
+    ax.clear()
+    redrawn = lens.plot(ax, projection=projection)
+    assert set(lens.artist_surfaces) == set(redrawn)
+    assert set(lens.boundary_coordinates) == set(surfaces)


### PR DESCRIPTION
Selecting or hovering a Lens Data Editor row now identifies the corresponding
2D surface and its lens body. Selected faces have a stronger outline, hover uses
a lighter style, and selection takes precedence on shared bodies. Highlights
update retained artists without retracing or changing the view.

The change adds GUI-owned surface identity and precise ownership metadata while
preserving the renderer's existing artist-to-component mapping. Tests cover
cemented and annular components, scene/state replacement, editor events and
panel wiring using synthetic optics.

Validation: 66 focused tests passed; 22 native Qt tests passed, with the final
six pointer cases rerun after fixture refinement. All 7 Codecov-relevant patch
lines are covered. An additional local audit covers all 291 GUI patch lines;
the repository's coverage configuration is unchanged.

Closes #817
