### PR TITLE
Keep rectangle zoom independent from default drag panning

### DIFF
--- a/docs/gui_quickstart.rst
+++ b/docs/gui_quickstart.rst
@@ -64,6 +64,11 @@ When you first open the Optiland GUI, you'll see a main window containing severa
     *   **2D View**: Shows a 2D cross-section of the lens, with options to display rays.
     *   **3D View**: Renders a 3D model of the system (if VTK is installed and working).
 
+    In the 2D view, select **Zoom to rectangle** and drag around the area to
+    inspect. The drawing stays fixed while the rectangle is drawn; releasing
+    the mouse applies the zoom. Toolbar pan and ordinary drag-pan use separate
+    gestures. **Back** and **Forward** navigate the resulting view history.
+
     .. image:: _static/gui_viewer_panel.png
        :alt: Viewer Panel (2D/3D)
        :align: center

--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
-from PySide6.QtCore import Qt, QTimer, Slot
+from PySide6.QtCore import QEvent, Qt, QTimer, Slot
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -440,6 +440,8 @@ class MatplotlibViewer(QWidget):
         self._pan_start_x = None
         self._pan_start_y = None
         self._is_panning = False
+        self._pan_moved = False
+        self.canvas.installEventFilter(self)
 
         self._preserve_next = False
         self.layout_job = LayoutJobView(
@@ -469,10 +471,19 @@ class MatplotlibViewer(QWidget):
         Args:
             event: The Matplotlib mouse button press event.
         """
-        if event.button == 1 and event.inaxes:  # Left mouse button
+        if (
+            event.button == 1
+            and event.inaxes is self.ax
+            and event.xdata is not None
+            and event.ydata is not None
+            and self._default_pan_available()
+        ):
+            self._finish_default_pan()
+            self.toolbar.push_current()
             self._pan_start_x = event.xdata
             self._pan_start_y = event.ydata
             self._is_panning = True
+            self._pan_moved = False
             self.canvas.setCursor(
                 Qt.ClosedHandCursor
             )  # Change cursor to indicate panning
@@ -484,11 +495,34 @@ class MatplotlibViewer(QWidget):
         Args:
             event: The Matplotlib mouse button release event.
         """
-        if event.button == 1:  # Left mouse button
-            self._is_panning = False
-            self._pan_start_x = None
-            self._pan_start_y = None
-            self.canvas.setCursor(Qt.ArrowCursor)  # Reset cursor
+        if event.button == 1:
+            self._finish_default_pan()
+
+    def _default_pan_available(self) -> bool:
+        """Leave toolbar and interactive-widget gestures to their owner."""
+        return not self.toolbar.mode and self.canvas.widgetlock.available(self)
+
+    def _finish_default_pan(self) -> None:
+        """End only our own drag, without replacing a toolbar tool's cursor."""
+        if not self._is_panning:
+            return
+        self._is_panning = False
+        self._pan_start_x = None
+        self._pan_start_y = None
+        if self._pan_moved:
+            self.toolbar.push_current()
+        self._pan_moved = False
+        if self._default_pan_available():
+            self.canvas.unsetCursor()
+
+    def eventFilter(self, watched, event):
+        """Discard an interrupted custom drag while preserving normal Qt events."""
+        if watched is self.canvas and (
+            event.type() in (QEvent.FocusOut, QEvent.Hide, QEvent.WindowDeactivate)
+            or (event.type() == QEvent.KeyPress and event.key() == Qt.Key_Escape)
+        ):
+            self._finish_default_pan()
+        return super().eventFilter(watched, event)
 
     def on_mouse_move_on_plot(self, event):
         """
@@ -497,7 +531,15 @@ class MatplotlibViewer(QWidget):
         Args:
             event: The Matplotlib motion notify event.
         """
-        if self._is_panning and event.inaxes and self._pan_start_x is not None:
+        if self._is_panning and not self._default_pan_available():
+            self._finish_default_pan()
+
+        has_coordinates = (
+            event.inaxes is self.ax
+            and event.xdata is not None
+            and event.ydata is not None
+        )
+        if self._is_panning and has_coordinates and self._pan_start_x is not None:
             # Calculate the distance moved
             dx = self._pan_start_x - event.xdata
             dy = self._pan_start_y - event.ydata
@@ -510,13 +552,14 @@ class MatplotlibViewer(QWidget):
             # Update the limits by the distance moved
             ax.set_xlim(xlim[0] + dx, xlim[1] + dx)
             ax.set_ylim(ylim[0] + dy, ylim[1] + dy)
+            self._pan_moved = self._pan_moved or dx != 0 or dy != 0
 
             # Redraw the canvas
             self.canvas.draw_idle()
             return  # Skip the coordinate display when panning
 
         # Original coordinate display code
-        if event.inaxes:
+        if has_coordinates:
             x_coord = f"{event.xdata:.3f}"
             y_coord = f"{event.ydata:.3f}"
             self.cursor_coord_label.setText(f"(Z, Y) = ({x_coord}, {y_coord})")
@@ -581,6 +624,7 @@ class MatplotlibViewer(QWidget):
 
     def plot_optic(self, preserve_zoom=False):
         """Request the latest visible layout; calculation belongs to its worker."""
+        self._finish_default_pan()
         self._preserve_next = bool(preserve_zoom)
         self.layout_job.request()
 

--- a/tests/gui/test_viewer_navigation.py
+++ b/tests/gui/test_viewer_navigation.py
@@ -1,0 +1,180 @@
+"""A navigation gesture has one owner and preserves the view until zoom release."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from matplotlib.backend_bases import MouseButton, MouseEvent
+from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication
+
+from optiland_gui.viewer_panel import MatplotlibViewer
+
+
+@pytest.fixture
+def viewer(qapp):
+    widget = MatplotlibViewer(SimpleNamespace(get_optic=lambda: None))
+    widget.ax.clear()
+    widget.ax.plot([0, 10], [0, 10])
+    widget.ax.set_xlim(0, 10)
+    widget.ax.set_ylim(0, 10)
+    widget.canvas.draw()
+    yield widget
+    widget.close()
+
+
+def limits(viewer):
+    return np.array([viewer.ax.get_xlim(), viewer.ax.get_ylim()])
+
+
+def emit(viewer, name, pixel, button=MouseButton.LEFT):
+    kwargs = {"buttons": {button}} if name == "motion_notify_event" else {}
+    event = MouseEvent(name, viewer.canvas, *pixel, button=button, **kwargs)
+    viewer.canvas.callbacks.process(name, event)
+    return event
+
+
+@pytest.mark.parametrize("start,end", [((3, 3), (7, 7)), ((7, 7), (3, 3))])
+def test_rectangle_zoom_changes_limits_only_on_release(viewer, start, end):
+    before = limits(viewer)
+    start_pixel, end_pixel = viewer.ax.transData.transform([start, end])
+    viewer.toolbar.zoom()
+    emit(viewer, "motion_notify_event", start_pixel)
+    cursor = viewer.canvas.cursor().shape()
+    emit(viewer, "button_press_event", start_pixel)
+    assert not viewer._is_panning
+    emit(viewer, "motion_notify_event", end_pixel)
+    np.testing.assert_array_equal(limits(viewer), before)
+    emit(viewer, "button_release_event", end_pixel)
+    assert not np.array_equal(limits(viewer), before)
+    assert viewer.canvas.cursor().shape() == cursor
+    after = limits(viewer)
+    viewer.toolbar.back()
+    np.testing.assert_allclose(limits(viewer), before)
+    viewer.toolbar.forward()
+    np.testing.assert_allclose(limits(viewer), after)
+
+
+def test_toolbar_pan_does_not_also_start_custom_pan(viewer):
+    viewer.toolbar.pan()
+    start, end = viewer.ax.transData.transform([(3, 3), (4, 4)])
+    before = limits(viewer)
+    emit(viewer, "button_press_event", start)
+    assert not viewer._is_panning
+    emit(viewer, "motion_notify_event", end)
+    emit(viewer, "button_release_event", end)
+    assert not np.array_equal(limits(viewer), before)
+    viewer.toolbar.back()
+    np.testing.assert_allclose(limits(viewer), before)
+
+
+def test_default_pan_has_history_and_stops_on_outside_release(viewer):
+    before = limits(viewer)
+    start, end = viewer.ax.transData.transform([(3, 3), (4, 4)])
+    emit(viewer, "button_press_event", start)
+    assert viewer._is_panning
+    emit(viewer, "motion_notify_event", end)
+    emit(viewer, "button_release_event", (-10, -10))
+    assert not viewer._is_panning
+    after = limits(viewer)
+    assert not np.array_equal(after, before)
+    emit(viewer, "motion_notify_event", start)
+    np.testing.assert_array_equal(limits(viewer), after)
+    viewer.toolbar.back()
+    np.testing.assert_allclose(limits(viewer), before)
+    viewer.toolbar.forward()
+    np.testing.assert_allclose(limits(viewer), after)
+
+
+def test_other_widget_lock_prevents_custom_pan(viewer):
+    owner = object()
+    before = limits(viewer)
+    start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
+    viewer.canvas.widgetlock(owner)
+    try:
+        emit(viewer, "button_press_event", start)
+        emit(viewer, "motion_notify_event", end)
+        emit(viewer, "button_release_event", end)
+        assert not viewer._is_panning
+        np.testing.assert_array_equal(limits(viewer), before)
+    finally:
+        viewer.canvas.widgetlock.release(owner)
+
+
+@pytest.mark.parametrize("interrupt", ["zoom", "lock", "focus_out", "hide"])
+def test_interrupted_default_drag_cannot_keep_panning(viewer, interrupt):
+    start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
+    before = limits(viewer)
+    emit(viewer, "button_press_event", start)
+    assert viewer._is_panning
+    owner = object()
+    if interrupt == "zoom":
+        viewer.toolbar.zoom()
+    elif interrupt == "lock":
+        viewer.canvas.widgetlock(owner)
+    else:
+        event_type = QEvent.Type.FocusOut if interrupt == "focus_out" else QEvent.Type.Hide
+        QApplication.sendEvent(viewer.canvas, QEvent(event_type))
+    try:
+        emit(viewer, "motion_notify_event", end)
+        assert not viewer._is_panning
+        np.testing.assert_array_equal(limits(viewer), before)
+    finally:
+        if interrupt == "lock":
+            viewer.canvas.widgetlock.release(owner)
+    emit(viewer, "button_release_event", end)
+
+
+def test_click_without_drag_and_missing_coordinates_do_not_move_view(viewer):
+    pixel = viewer.ax.transData.transform((3, 3))
+    before = limits(viewer)
+    viewer.toolbar.zoom()
+    emit(viewer, "button_press_event", pixel)
+    emit(viewer, "button_release_event", pixel)
+    np.testing.assert_array_equal(limits(viewer), before)
+    viewer.on_mouse_move_on_plot(SimpleNamespace(inaxes=viewer.ax, xdata=None, ydata=None))
+    assert not viewer.cursor_coord_label.isVisible()
+
+
+def test_navigation_does_not_replot_optic(viewer, monkeypatch):
+    def unexpected(*args, **kwargs):
+        pytest.fail("Navigation must not recalculate the optical plot")
+
+    monkeypatch.setattr(viewer, "plot_optic", unexpected)
+    start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
+    viewer.toolbar.zoom()
+    emit(viewer, "button_press_event", start)
+    emit(viewer, "motion_notify_event", end)
+    emit(viewer, "button_release_event", end)
+    viewer.toolbar.back()
+    viewer.toolbar.forward()
+
+
+def test_native_qt_rectangle_drag(viewer, qapp):
+    if qapp.platformName() in ("offscreen", "minimal"):
+        pytest.skip("Requires the native Qt window platform")
+    viewer.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+    viewer.resize(800, 600)
+    viewer.show()
+    qapp.processEvents()
+    viewer.canvas.draw()
+    before = limits(viewer)
+    start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
+    ratio = viewer.canvas.device_pixel_ratio
+
+    def qt_point(pixel):
+        return QPoint(
+            round(pixel[0] / ratio),
+            round(viewer.canvas.height() - pixel[1] / ratio),
+        )
+
+    viewer.toolbar.zoom()
+    QTest.mousePress(viewer.canvas, Qt.MouseButton.LeftButton, pos=qt_point(start))
+    QTest.mouseMove(viewer.canvas, qt_point(end))
+    np.testing.assert_array_equal(limits(viewer), before)
+    assert not viewer._is_panning
+    QTest.mouseRelease(viewer.canvas, Qt.MouseButton.LeftButton, pos=qt_point(end))
+    assert not np.array_equal(limits(viewer), before)

--- a/tests/gui/test_viewer_navigation.py
+++ b/tests/gui/test_viewer_navigation.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from matplotlib.backend_bases import MouseButton, MouseEvent
 from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtGui import QKeyEvent
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 
@@ -104,7 +105,10 @@ def test_other_widget_lock_prevents_custom_pan(viewer):
         viewer.canvas.widgetlock.release(owner)
 
 
-@pytest.mark.parametrize("interrupt", ["zoom", "lock", "focus_out", "hide"])
+@pytest.mark.parametrize(
+    "interrupt",
+    ["zoom", "lock", "focus_out", "hide", "deactivate", "escape", "rebuild"],
+)
 def test_interrupted_default_drag_cannot_keep_panning(viewer, interrupt):
     start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
     before = limits(viewer)
@@ -115,8 +119,20 @@ def test_interrupted_default_drag_cannot_keep_panning(viewer, interrupt):
         viewer.toolbar.zoom()
     elif interrupt == "lock":
         viewer.canvas.widgetlock(owner)
+    elif interrupt == "escape":
+        QApplication.sendEvent(
+            viewer.canvas, QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
+        )
+    elif interrupt == "rebuild":
+        viewer.plot_optic(preserve_zoom=True)
+        # This fixture has no optic; rebuilding installs the empty-scene axes.
+        before = limits(viewer)
     else:
-        event_type = QEvent.Type.FocusOut if interrupt == "focus_out" else QEvent.Type.Hide
+        event_type = {
+            "focus_out": QEvent.Type.FocusOut,
+            "hide": QEvent.Type.Hide,
+            "deactivate": QEvent.Type.WindowDeactivate,
+        }[interrupt]
         QApplication.sendEvent(viewer.canvas, QEvent(event_type))
     try:
         emit(viewer, "motion_notify_event", end)
@@ -135,7 +151,9 @@ def test_click_without_drag_and_missing_coordinates_do_not_move_view(viewer):
     emit(viewer, "button_press_event", pixel)
     emit(viewer, "button_release_event", pixel)
     np.testing.assert_array_equal(limits(viewer), before)
-    viewer.on_mouse_move_on_plot(SimpleNamespace(inaxes=viewer.ax, xdata=None, ydata=None))
+    viewer.on_mouse_move_on_plot(
+        SimpleNamespace(inaxes=viewer.ax, xdata=None, ydata=None)
+    )
     assert not viewer.cursor_coord_label.isVisible()
 
 
@@ -151,6 +169,37 @@ def test_navigation_does_not_replot_optic(viewer, monkeypatch):
     emit(viewer, "button_release_event", end)
     viewer.toolbar.back()
     viewer.toolbar.forward()
+
+
+def test_default_pan_is_anchored_through_multiple_motion_events(viewer):
+    before = limits(viewer)
+    start, middle, end = viewer.ax.transData.transform([(3, 3), (4, 4), (5, 5)])
+    emit(viewer, "button_press_event", start)
+    emit(viewer, "motion_notify_event", middle)
+    emit(viewer, "motion_notify_event", end)
+    emit(viewer, "button_release_event", end)
+    np.testing.assert_allclose(limits(viewer), before - 2)
+    viewer.toolbar.back()
+    np.testing.assert_allclose(limits(viewer), before)
+    viewer.toolbar.forward()
+    np.testing.assert_allclose(limits(viewer), before - 2)
+    viewer.toolbar.home()
+    np.testing.assert_allclose(limits(viewer), before)
+
+
+def test_scroll_zoom_and_coordinate_readout_keep_working(viewer):
+    pixel = viewer.ax.transData.transform((3, 3))
+    emit(viewer, "motion_notify_event", pixel)
+    assert "3.000" in viewer.cursor_coord_label.text()
+    before = limits(viewer)
+    viewer.canvas.callbacks.process(
+        "scroll_event", MouseEvent("scroll_event", viewer.canvas, *pixel, step=1)
+    )
+    np.testing.assert_allclose(np.diff(limits(viewer)), np.diff(before) / 1.1)
+    viewer.canvas.callbacks.process(
+        "scroll_event", MouseEvent("scroll_event", viewer.canvas, *pixel, step=-1)
+    )
+    np.testing.assert_allclose(limits(viewer), before, atol=1e-12)
 
 
 def test_native_qt_rectangle_drag(viewer, qapp):

--- a/tests/gui/test_viewer_navigation.py
+++ b/tests/gui/test_viewer_navigation.py
@@ -7,24 +7,45 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 from matplotlib.backend_bases import MouseButton, MouseEvent
-from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtCore import QCoreApplication, QEvent, QPoint, Qt
 from PySide6.QtGui import QKeyEvent
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 
+from optiland_gui.optiland_connector import OptilandConnector
 from optiland_gui.viewer_panel import MatplotlibViewer
+from tests.gui.test_calculation_jobs import wait_for
+
+
+@pytest.fixture(scope="module")
+def navigation_connector(qapp):
+    connector = OptilandConnector()
+    yield connector
+    connector.calculation_jobs.shutdown()
+    wait_for(qapp, lambda: connector.calculation_jobs._process is None)
+    connector.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
 
 @pytest.fixture
-def viewer(qapp):
-    widget = MatplotlibViewer(SimpleNamespace(get_optic=lambda: None))
-    widget.ax.clear()
-    widget.ax.plot([0, 10], [0, 10])
+def viewer(qapp, minimal_optic, navigation_connector):
+    navigation_connector.load_optic_from_object(minimal_optic)
+    widget = MatplotlibViewer(navigation_connector)
+    widget.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+    widget.resize(800, 600)
+    widget.show()
+    wait_for(qapp, lambda: widget.layout_job.data is not None)
+    assert widget.layout_job.label.text() == "Layout is up to date."
+    widget.ax.set_aspect("auto")
     widget.ax.set_xlim(0, 10)
     widget.ax.set_ylim(0, 10)
     widget.canvas.draw()
     yield widget
+    widget.layout_job.cancel()
     widget.close()
+    wait_for(qapp, lambda: not navigation_connector.calculation_jobs.running)
+    widget.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
 
 def limits(viewer):
@@ -107,7 +128,7 @@ def test_other_widget_lock_prevents_custom_pan(viewer):
 
 @pytest.mark.parametrize(
     "interrupt",
-    ["zoom", "lock", "focus_out", "hide", "deactivate", "escape", "rebuild"],
+    ["zoom", "lock", "focus_out", "hide", "deactivate", "escape", "request", "theme"],
 )
 def test_interrupted_default_drag_cannot_keep_panning(viewer, interrupt):
     start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
@@ -123,10 +144,12 @@ def test_interrupted_default_drag_cannot_keep_panning(viewer, interrupt):
         QApplication.sendEvent(
             viewer.canvas, QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
         )
-    elif interrupt == "rebuild":
+    elif interrupt == "request":
         viewer.plot_optic(preserve_zoom=True)
-        # This fixture has no optic; rebuilding installs the empty-scene axes.
-        before = limits(viewer)
+    elif interrupt == "theme":
+        serial = viewer.connector.calculation_jobs._serial
+        viewer.update_theme("light")
+        assert viewer.connector.calculation_jobs._serial == serial
     else:
         event_type = {
             "focus_out": QEvent.Type.FocusOut,
@@ -162,6 +185,7 @@ def test_navigation_does_not_replot_optic(viewer, monkeypatch):
         pytest.fail("Navigation must not recalculate the optical plot")
 
     monkeypatch.setattr(viewer, "plot_optic", unexpected)
+    serial = viewer.connector.calculation_jobs._serial
     start, end = viewer.ax.transData.transform([(3, 3), (7, 7)])
     viewer.toolbar.zoom()
     emit(viewer, "button_press_event", start)
@@ -169,6 +193,36 @@ def test_navigation_does_not_replot_optic(viewer, monkeypatch):
     emit(viewer, "button_release_event", end)
     viewer.toolbar.back()
     viewer.toolbar.forward()
+    assert viewer.connector.calculation_jobs._serial == serial
+
+
+def test_async_scene_presentation_finishes_drag_started_while_calculating(viewer, qapp):
+    previous_data = viewer.layout_job.data
+    serial = viewer.connector.calculation_jobs._serial
+    viewer.num_rays_spinbox.setValue(5)
+    viewer.plot_optic(preserve_zoom=True)
+    assert viewer.connector.calculation_jobs._serial == serial + 1
+    assert viewer.layout_job.data is previous_data  # Last good scene stays visible.
+    before = limits(viewer)
+    start, end = viewer.ax.transData.transform([(3, 3), (4, 4)])
+    emit(viewer, "button_press_event", start)
+    emit(viewer, "motion_notify_event", end)
+    assert viewer._is_panning
+    dragged = limits(viewer)
+    assert not np.array_equal(dragged, before)
+
+    wait_for(qapp, lambda: viewer.layout_job.data is not previous_data)
+    assert not viewer._is_panning
+    assert viewer._pan_start_x is None and viewer._pan_start_y is None
+    np.testing.assert_allclose(limits(viewer), dragged)
+    emit(viewer, "motion_notify_event", start)
+    np.testing.assert_allclose(limits(viewer), dragged)
+    emit(viewer, "button_release_event", start)
+    viewer.toolbar.back()
+    np.testing.assert_allclose(limits(viewer), before)
+    viewer.toolbar.forward()
+    np.testing.assert_allclose(limits(viewer), dragged)
+    assert viewer.connector.calculation_jobs._serial == serial + 1
 
 
 def test_default_pan_is_anchored_through_multiple_motion_events(viewer):


### PR DESCRIPTION
The 2D viewer's default drag-pan handler now respects the active toolbar mode and
canvas widget lock, so drawing a zoom rectangle keeps the layout fixed until
release. Default pan maintains navigation history and clears its own state on
release, focus loss, Escape, window deactivation or scene replacement without
overwriting the toolbar's cursor.

Validation: 17 native Qt navigation tests passed; offscreen 16 passed with the
native-input case skipped. Tests cover both rectangle directions, pan ownership,
interruption, Home/Back/Forward, wheel zoom and unchanged optical calculations.
All 33 changed GUI executable lines are covered in an additional local audit;
the repository's existing coverage exclusions and thresholds are unchanged.

Closes #821
