### PR TITLE
Keep image-plane markers stable and exclude extinct ray extents

### DIFF
--- a/optiland/visualization/info/providers.py
+++ b/optiland/visualization/info/providers.py
@@ -47,6 +47,8 @@ class SurfaceInfoProvider(BaseInfoProvider):
 
         if hasattr(surface, "comment") and surface.comment:
             info.append(f"Comment: {surface.comment}")
+        if obj.extent_source == "schematic":
+            info.append("Image plane marker: schematic; physical size unspecified")
         if hasattr(surface, "geometry") and hasattr(surface.geometry, "radius"):
             info.append(f"Radius: {surface.geometry.radius:.3f}")
         if hasattr(surface, "geometry") and hasattr(surface.geometry, "conic"):

--- a/optiland/visualization/system/optic_viewer.py
+++ b/optiland/visualization/system/optic_viewer.py
@@ -21,6 +21,7 @@ from optiland.visualization.system.lens import Lens2D
 from optiland.visualization.system.rays import Rays2D
 from optiland.visualization.system.surface import Surface2D
 from optiland.visualization.system.system import OpticalSystem
+from optiland.visualization.system.utils import transform
 
 
 class OpticViewer(BaseViewer2D):
@@ -197,23 +198,34 @@ class OpticViewer(BaseViewer2D):
             return None, None
         vertices = vertices[start_idx:]
 
-        z_min = float(vertices[:, 2].min())
-        z_max = float(vertices[:, 2].max())
+        # Resolve bounds from the components that will actually be drawn. In
+        # particular, a ray's first blocking hit can be far outside a finite
+        # physical aperture and must not enlarge the auto-fit region.
+        surfaces = []
+        for component in self.system.components:
+            if isinstance(component, Surface2D):
+                surfaces.append(component)
+            elif isinstance(component, Lens2D):
+                surfaces.extend(component.surfaces)
+        r_extent = (
+            np.asarray([float(be.to_numpy(surface.extent)) for surface in surfaces])
+            if surfaces
+            else be.to_numpy(self.rays.r_extent)[start_idx:]
+        )
+
+        # A tilted image marker can extend past the first/last vertex along Z.
+        # Include its transformed outline, without tracing any additional rays.
+        z_bounds = [vertices[:, 2].ravel()]
+        for surface in surfaces:
+            x, y, z = surface._compute_sag(projection)
+            _, _, z = transform(x, y, z, surface.surf, is_global=False)
+            z = be.to_numpy(z)
+            z_bounds.append(z[np.isfinite(z)])
+        z_bounds = np.concatenate(z_bounds)
+        z_min, z_max = float(z_bounds.min()), float(z_bounds.max())
         z_margin = max(0.15 * (z_max - z_min), 1e-6)
         auto_xlim = (z_min - z_margin, z_max + z_margin)
 
-        r_extent = be.to_numpy(self.rays.r_extent)[start_idx:]
-        # Include the actual drawn boundaries: an explicit aperture or a
-        # schematic image marker can be larger than its illuminated samples.
-        drawn_extents = []
-        for component in self.system.components:
-            if isinstance(component, Surface2D):
-                drawn_extents.append(float(be.to_numpy(component.extent)))
-            elif isinstance(component, Lens2D):
-                drawn_extents.extend(
-                    float(be.to_numpy(surface.extent)) for surface in component.surfaces
-                )
-        r_extent = np.concatenate((r_extent, np.asarray(drawn_extents)))
         r_extent = r_extent[np.isfinite(r_extent)]
         if r_extent.size == 0:
             return auto_xlim, None

--- a/optiland/visualization/system/optic_viewer.py
+++ b/optiland/visualization/system/optic_viewer.py
@@ -17,7 +17,9 @@ import numpy as np
 import optiland.backend as be
 from optiland.visualization.base import BaseViewer2D
 from optiland.visualization.system.interaction import InteractionManager
+from optiland.visualization.system.lens import Lens2D
 from optiland.visualization.system.rays import Rays2D
+from optiland.visualization.system.surface import Surface2D
 from optiland.visualization.system.system import OpticalSystem
 
 
@@ -201,6 +203,17 @@ class OpticViewer(BaseViewer2D):
         auto_xlim = (z_min - z_margin, z_max + z_margin)
 
         r_extent = be.to_numpy(self.rays.r_extent)[start_idx:]
+        # Include the actual drawn boundaries: an explicit aperture or a
+        # schematic image marker can be larger than its illuminated samples.
+        drawn_extents = []
+        for component in self.system.components:
+            if isinstance(component, Surface2D):
+                drawn_extents.append(float(be.to_numpy(component.extent)))
+            elif isinstance(component, Lens2D):
+                drawn_extents.extend(
+                    float(be.to_numpy(surface.extent)) for surface in component.surfaces
+                )
+        r_extent = np.concatenate((r_extent, np.asarray(drawn_extents)))
         r_extent = r_extent[np.isfinite(r_extent)]
         if r_extent.size == 0:
             return auto_xlim, None

--- a/optiland/visualization/system/rays.py
+++ b/optiland/visualization/system/rays.py
@@ -87,6 +87,7 @@ class Rays2D:
         fields_coords = [fp.coord for fp in field_points]
         wavelengths_vals = [wp.value for wp in wl_points]
 
+        self.r_extent = be.zeros(self.optic.surfaces.num_surfaces)
         artists = {}
 
         for i, field in enumerate(fields_coords):
@@ -177,15 +178,38 @@ class Rays2D:
     def _update_surface_extents(self):
         """Updates the extents of the surfaces in the optic's surface group."""
         r_extent_new = be.copy(be.zeros_like(self.r_extent))
+        alive_before = be.ones_like(self.i[0]) > 0
         for i, surf in enumerate(self.optic.surfaces):
             x_surf = self.x[i]
             y_surf = self.y[i]
             z_surf = self.z[i]
 
-            # Convert to local coordinate system
-            x, y, _ = transform(x_surf, y_surf, z_surf, surf, is_global=True)
+            finite_points = (
+                be.isfinite(x_surf) & be.isfinite(y_surf) & be.isfinite(z_surf)
+            )
+            # Replace invalid inputs before rotating them, avoiding inf * 0
+            # warnings. The validity mask still excludes these placeholder hits.
+            x, y, _ = transform(
+                be.where(finite_points, x_surf, 0.0),
+                be.where(finite_points, y_surf, 0.0),
+                be.where(finite_points, z_surf, 0.0),
+                surf,
+                is_global=True,
+            )
 
-            r_extent_new[i] = be.nanmax(be.hypot(x, y))
+            radius = be.hypot(x, y)
+            # Retain the incident hit at the first blocking surface, but never
+            # use an already-extinguished ray's later mathematical coordinates.
+            valid = (
+                alive_before
+                & finite_points
+                & be.isfinite(self.i[i])
+                & (self.i[i] >= 0)
+                & be.isfinite(radius)
+            )
+            if be.size(radius):
+                r_extent_new[i] = be.max(be.where(valid, radius, 0.0))
+            alive_before = alive_before & be.isfinite(self.i[i]) & (self.i[i] > 0)
         self.r_extent = be.fmax(self.r_extent, r_extent_new)
 
     def _plot_lines(
@@ -338,6 +362,7 @@ class Rays3D(Rays2D):
         fields_coords = [fp.coord for fp in field_points]
         wavelengths_vals = [wp.value for wp in wl_points]
 
+        self.r_extent = be.zeros(self.optic.surfaces.num_surfaces)
         for i, field in enumerate(fields_coords):
             for j, wavelength in enumerate(wavelengths_vals):
                 # if only one field, use different colors for each wavelength

--- a/optiland/visualization/system/surface.py
+++ b/optiland/visualization/system/surface.py
@@ -21,16 +21,41 @@ from optiland.visualization.system.utils import revolve_contour, transform, tran
 _FACE_ON_THRESHOLD = 0.5  # |cos(60°)|
 
 
+def _finite_aperture_extent(surface) -> float | None:
+    """Return a finite physical drawing bound in the surface's local frame."""
+    if surface.aperture is not None:
+        bounds = be.to_numpy(be.array(surface.aperture.extent))
+        if np.all(np.isfinite(bounds)):
+            return float(np.max(np.abs(bounds)))
+    # semi_aperture can be a paraxial ray-height estimate; it does not establish
+    # a physical aperture or detector dimension.
+    return None
+
+
+def _schematic_image_extent(surface) -> float:
+    """Choose a drawing scale, never a physical image or detector dimension."""
+    previous = surface.previous_surface
+    while previous is not None:
+        radius = _finite_aperture_extent(previous)
+        if radius is not None and radius > 0:
+            return radius
+        previous = previous.previous_surface
+    return 1.0  # mm: deterministic schematic radius without any finite aperture
+
+
 class Surface2D:
     """A class used to represent a 2D surface for visualization.
 
     Args:
-        surf (Surface): The surface object containing the geometry.
-        extent (tuple): The extent of the surface in the x and y directions.
+        surface (Surface): The surface object containing the geometry.
+        ray_extent (float): Local radial extent of valid incident ray samples.
+        is_image_plane (bool): Use a schematic marker if this image endpoint
+            has no finite physical aperture. Defaults to False.
 
     Attributes:
         surf (Surface): The surface object containing the geometry.
-        ray_extent (tuple): The extent of rays on the surface.
+        extent (float): Resolved local radial drawing extent.
+        extent_source (str): Physical aperture, ray samples or schematic sizing.
 
     Methods:
         plot(ax):
@@ -38,21 +63,19 @@ class Surface2D:
 
     """
 
-    def __init__(self, surface, ray_extent):
+    def __init__(self, surface, ray_extent, *, is_image_plane: bool = False):
         self.surf = surface
-
-        if self.surf.aperture:
-            x_min, x_max, y_min, y_max = self.surf.aperture.extent
-            # Use the largest absolute bound so that apertures offset from
-            # the surface vertex (e.g. OffsetRadialAperture) are fully
-            # covered by the symmetric [-extent, extent] sampling window
-            # used in _compute_sag; a plain max() would collapse to the
-            # aperture radius and miss the offset region entirely.
-            extent = be.max(be.abs(be.array([x_min, x_max, y_min, y_max])))
-            # Fall back to ray extent if aperture extent is infinite
-            self.extent = extent if be.isfinite(be.array(extent)) else ray_extent
+        self.is_image_plane = is_image_plane
+        extent = _finite_aperture_extent(surface)
+        if extent is not None:
+            self.extent = extent
+            self.extent_source = "physical_aperture"
+        elif is_image_plane:
+            self.extent = _schematic_image_extent(surface)
+            self.extent_source = "schematic"
         else:
-            self.extent = ray_extent
+            self.extent = ray_extent if be.isfinite(be.array(ray_extent)) else 0.0
+            self.extent_source = "ray_samples"
 
     # Maps projection name to the index of the viewing axis in global normal.
     # e.g. for "YZ" the view is along X (index 0); "XZ" along Y (index 1); etc.
@@ -98,12 +121,15 @@ class Surface2D:
         if theme:
             color = theme.parameters.get("axes.edgecolor", color)
 
+        label = f"Surface {self.surf.comment}"
+        if self.extent_source == "schematic":
+            label += " (schematic image plane)"
         if projection == "XY":
-            (line,) = ax.plot(x, y, color=color, label=f"Surface {self.surf.comment}")
+            (line,) = ax.plot(x, y, color=color, label=label)
         elif projection == "XZ":
-            (line,) = ax.plot(z, x, color=color, label=f"Surface {self.surf.comment}")
+            (line,) = ax.plot(z, x, color=color, label=label)
         else:  # YZ
-            (line,) = ax.plot(z, y, color=color, label=f"Surface {self.surf.comment}")
+            (line,) = ax.plot(z, y, color=color, label=label)
         return {line: self}
 
     def _compute_sag(self, projection="YZ"):
@@ -166,8 +192,8 @@ class Surface3D(Surface2D):
 
     """
 
-    def __init__(self, surface, extent):
-        super().__init__(surface, extent)
+    def __init__(self, surface, extent, *, is_image_plane: bool = False):
+        super().__init__(surface, extent, is_image_plane=is_image_plane)
 
     def plot(self, renderer, theme=None, *args, **kwargs):
         """Plots the surface on the given renderer.

--- a/optiland/visualization/system/system.py
+++ b/optiland/visualization/system/system.py
@@ -151,8 +151,13 @@ class OpticalSystem:
             if k == 0 and surf.is_infinite:
                 continue
 
-            # Object, image, or paraxial surface
-            if k == 0 or k == num_surf - 1 or surf.surface_type == "paraxial":
+            # Unbounded image planes have a schematic, ray-count-independent
+            # marker. Explicit physical apertures remain authoritative.
+            if k == num_surf - 1:
+                self._add_component("surface", surf, extent, is_image_plane=True)
+
+            # Object or paraxial surface
+            elif k == 0 or surf.surface_type == "paraxial":
                 self._add_component("surface", surf, extent)
 
             # Surface is a mirror
@@ -198,18 +203,20 @@ class OpticalSystem:
             return []
         return lens_surfaces
 
-    def _add_component(self, component_name, *args):
+    def _add_component(self, component_name, *args, **kwargs):
         """Adds a component to the list of components."""
         if component_name in _CUSTOM_RENDERER_REGISTRY:
             renderer = _CUSTOM_RENDERER_REGISTRY[component_name]
             component_data = {"args": args, "projection": self.projection}
+            if kwargs:
+                component_data["kwargs"] = kwargs
             self.components.append(
                 _CustomRendererAdapter(renderer, component_data, self.projection)
             )
             return
         if component_name in self.component_registry:
             component_class = self.component_registry[component_name][self.projection]
-            self.components.append(component_class(*args))
+            self.components.append(component_class(*args, **kwargs))
             return
         raise ValueError(f"Component {component_name} not found in registry.")
 

--- a/tests/gui/test_image_marker_preparation.py
+++ b/tests/gui/test_image_marker_preparation.py
@@ -1,0 +1,53 @@
+"""Image marker sizing survives detached 2D and 3D layout preparation."""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+import optiland.backend as be
+from optiland.physical_apertures import RadialAperture
+from optiland_gui.services.job_records import OpticSnapshot
+from optiland_gui.services.layout_tasks import prepare_2d, prepare_3d
+
+
+def test_prepared_image_marker_retains_schematic_extent_and_provenance(
+    set_test_backend, minimal_optic
+):
+    minimal_optic.surfaces[2].aperture = RadialAperture(3)
+    snapshot = OpticSnapshot.capture(minimal_optic)
+
+    def progress(*args):
+        pass
+
+    for count in (3, 9):
+        data = prepare_2d(
+            snapshot,
+            {"num_rays": count, "distribution": "line_y"},
+            progress,
+            threading.Event(),
+        )
+        image = next(
+            primitive
+            for primitive in data["primitives"]
+            if primitive["role"] == "surface" and primitive["surfaces"] == (3,)
+        )
+        assert "schematic image plane" in image["label"]
+        assert data["extent_sources"][3] == "schematic"
+        np.testing.assert_allclose(image["xy"][:, 1][[0, -1]], [-3, 3])
+        np.testing.assert_allclose(data["references"][3][1][[0, -1]], [-3, 3])
+
+    data = prepare_3d(snapshot, {}, progress, threading.Event())
+    image = next(mesh for mesh in data["meshes"] if mesh["surfaces"] == (3,))
+    # Mesh points are local; the matrix supplies the unchanged image vertex.
+    np.testing.assert_allclose(
+        [image["points"][:, 1].min(), image["points"][:, 1].max()], [-3, 3]
+    )
+    np.testing.assert_allclose(
+        image["matrix"][:3, 3],
+        be.to_numpy(
+            minimal_optic.surfaces[-1].geometry.cs.get_effective_transform()[0]
+        ).ravel(),
+    )
+    assert minimal_optic.surfaces[-1].aperture is None

--- a/tests/visualization/system/test_ray_extents.py
+++ b/tests/visualization/system/test_ray_extents.py
@@ -83,8 +83,9 @@ def test_display_mask_does_not_modify_trace_arrays(
 
     monkeypatch.setattr(rays, "_plot_single_line", capture_line)
     rays._plot_lines(None, 0, (0, 0))
-    assert np.isnan(plotted[1][1][2:]).all()
-    assert np.isfinite(plotted[1][1][1])
+    # The shared physical-path renderer truncates at the first blocking hit.
+    # Assert the exact retained segment rather than an empty downstream slice.
+    np.testing.assert_array_equal(np.column_stack(plotted[1]), [[0, 1, 0], [0, 2, 1]])
     for original, current in zip(originals, (rays.x, rays.y, rays.z), strict=True):
         np.testing.assert_array_equal(be.to_numpy(current), original)
 

--- a/tests/visualization/system/test_ray_extents.py
+++ b/tests/visualization/system/test_ray_extents.py
@@ -1,0 +1,237 @@
+"""Incident-ray extent and schematic image-plane display regressions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.optic import Optic
+from optiland.physical_apertures import (
+    OffsetRadialAperture,
+    RadialAperture,
+    RectangularAperture,
+)
+from optiland.visualization.info.providers import SurfaceInfoProvider
+from optiland.visualization.system.optic_viewer import OpticViewer
+from optiland.visualization.system.rays import Rays2D, Rays3D
+from optiland.visualization.system.surface import Surface2D, Surface3D
+from optiland.visualization.system.system import OpticalSystem
+
+
+def _optic():
+    optic = Optic()
+    for index in range(4):
+        optic.surfaces.add(index=index, z=float(index), is_stop=index == 1)
+    optic.set_aperture("EPD", 1)
+    optic.fields.set_type("angle")
+    optic.fields.add(0, 0)
+    optic.wavelengths.add(0.55)
+    return optic
+
+
+def _recorded_rays(ray_type=Rays2D):
+    rays = ray_type(_optic())
+    rays.x = be.zeros((4, 3))
+    rays.y = be.array([[0, 1, 2], [0, 2, 4], [0, 1e6, 6], [0.1, 1e9, 1e8]])
+    rays.z = be.array([[0] * 3, [1] * 3, [2] * 3, [3] * 3])
+    rays.i = be.array([[1, 1, 1], [1, 0, 1], [1, 0, 0], [1, 0, 0]])
+    return rays
+
+
+def test_extents_include_first_blocking_hit_but_exclude_later_coordinates(
+    set_test_backend,
+):
+    rays = _recorded_rays()
+    rays._update_surface_extents()
+    np.testing.assert_allclose(be.to_numpy(rays.r_extent), [2, 4, 6, 0.1])
+
+
+def test_invalid_or_extinguished_samples_cannot_regain_liveness(set_test_backend):
+    rays = _recorded_rays()
+    rays.i = be.array([[1, 1, 1], [1, be.nan, 1], [1, 0, 0], [1, 1, 1]])
+    rays._update_surface_extents()
+    np.testing.assert_allclose(be.to_numpy(rays.r_extent), [2, 4, 6, 0.1])
+
+
+@pytest.mark.parametrize("case", ["empty", "nan", "infinity"])
+def test_empty_and_nonfinite_bundles_have_zero_sample_extent(set_test_backend, case):
+    rays = _recorded_rays()
+    if case == "empty":
+        rays.x = rays.y = rays.z = rays.i = be.zeros((4, 0))
+    else:
+        rays.y = be.full((4, 3), be.nan if case == "nan" else be.inf)
+    with np.errstate(all="raise"):
+        rays._update_surface_extents()
+    np.testing.assert_array_equal(be.to_numpy(rays.r_extent), np.zeros(4))
+
+
+@pytest.mark.parametrize("ray_type", [Rays2D, Rays3D])
+def test_display_mask_does_not_modify_trace_arrays(
+    set_test_backend, ray_type, monkeypatch
+):
+    rays = _recorded_rays(ray_type)
+    originals = [be.to_numpy(value).copy() for value in (rays.x, rays.y, rays.z)]
+    plotted = []
+
+    def capture_line(ax, x, y, z, *args, **kwargs):
+        plotted.append((x.copy(), y.copy(), z.copy()))
+        return object(), SimpleNamespace()
+
+    monkeypatch.setattr(rays, "_plot_single_line", capture_line)
+    rays._plot_lines(None, 0, (0, 0))
+    assert np.isnan(plotted[1][1][2:]).all()
+    assert np.isfinite(plotted[1][1][1])
+    for original, current in zip(originals, (rays.x, rays.y, rays.z), strict=True):
+        np.testing.assert_array_equal(be.to_numpy(current), original)
+
+
+@pytest.mark.parametrize("ray_type", [Rays2D, Rays3D])
+def test_new_plot_resets_old_extents(set_test_backend, ray_type, monkeypatch):
+    rays = _recorded_rays(ray_type)
+    monkeypatch.setattr(rays, "_trace", lambda *args: rays._update_surface_extents())
+    rays.plot(None, distribution=None)
+    assert float(be.to_numpy(rays.r_extent[2])) == 6
+    rays.y = be.full((4, 3), 0.25)
+    rays.plot(None, distribution=None)
+    np.testing.assert_allclose(be.to_numpy(rays.r_extent), [0.25] * 4)
+
+
+@pytest.mark.parametrize("component_type", [Surface2D, Surface3D])
+def test_unbounded_image_uses_nearest_finite_aperture_only_as_display_scale(
+    set_test_backend, component_type
+):
+    optic = _optic()
+    optic.surfaces[1].aperture = RadialAperture(9)
+    optic.surfaces[2].aperture = RadialAperture(2.5)
+    for sampled_extent in (0, 0.1, 1e6, be.nan):
+        component = component_type(
+            optic.surfaces[-1], sampled_extent, is_image_plane=True
+        )
+        assert component.extent == 2.5
+        assert component.extent_source == "schematic"
+        assert component.surf is optic.surfaces[-1]
+    assert optic.surfaces[-1].aperture is None
+    assert optic.surfaces[-1].semi_aperture is None
+
+
+def test_image_without_finite_apertures_has_documented_fallback(set_test_backend):
+    optic = _optic()
+    optic.surfaces[2].aperture = RadialAperture(be.inf, r_min=0.25)
+    component = Surface2D(optic.surfaces[-1], 1e9, is_image_plane=True)
+    assert component.extent == 1.0
+    assert component.extent_source == "schematic"
+    info = SurfaceInfoProvider(optic.surfaces).get_info(component)
+    assert "schematic; physical size unspecified" in info
+
+
+@pytest.mark.parametrize("aperture_kind", ["radial", "offset", "rectangular"])
+def test_explicit_image_bounds_override_samples_and_schematic_policy(
+    set_test_backend, aperture_kind
+):
+    optic = _optic()
+    image = optic.surfaces[-1]
+    optic.surfaces[2].aperture = RadialAperture(20)
+    if aperture_kind == "radial":
+        image.aperture = RadialAperture(3)
+        expected = 3
+    elif aperture_kind == "offset":
+        image.aperture = OffsetRadialAperture(2, offset_y=-5)
+        expected = 7
+    else:
+        image.aperture = RectangularAperture(-2, 2, -4, 4)
+        expected = 4
+    component = Surface2D(image, 1e9, is_image_plane=True)
+    assert component.extent == expected
+    assert component.extent_source == "physical_aperture"
+
+
+def test_computed_semi_aperture_does_not_define_physical_image_size(set_test_backend):
+    optic = _optic()
+    # update_paraxial() stores sampled marginal/chief heights in this field.
+    optic.surfaces[-1].semi_aperture = 1e9
+    optic.surfaces[-2].semi_aperture = 1e8
+    component = Surface2D(optic.surfaces[-1], 1e6, is_image_plane=True)
+    assert component.extent == 1.0
+    assert component.extent_source == "schematic"
+
+
+@pytest.mark.parametrize("num_rays", [3, 5, 8, 14])
+def test_image_marker_is_stable_and_included_in_default_limits(
+    set_test_backend, num_rays
+):
+    optic = _optic()
+    optic.surfaces[2].aperture = RadialAperture(3)
+    viewer = OpticViewer(optic)
+    fig, ax, _ = viewer.view(num_rays=num_rays, show=False)
+    try:
+        image = next(
+            component
+            for component in viewer.system.components
+            if isinstance(component, Surface2D) and component.surf is optic.surfaces[-1]
+        )
+        assert image.extent == 3
+        line = next(
+            line for line in ax.lines if "schematic image plane" in line.get_label()
+        )
+        np.testing.assert_allclose(
+            [line.get_ydata().min(), line.get_ydata().max()], [-3, 3]
+        )
+        assert ax.get_ylim()[0] < -3 and ax.get_ylim()[1] > 3
+        np.testing.assert_allclose(line.get_xdata(), 3)
+        assert optic.surfaces[-1].aperture is None
+    finally:
+        plt.close(fig)
+
+
+def test_dead_image_coordinates_do_not_expand_default_limits(set_test_backend):
+    rays = _recorded_rays()
+    rays._update_surface_extents()
+    viewer = OpticViewer(rays.optic)
+    viewer.rays = rays
+    viewer.system = OpticalSystem(rays.optic, rays)
+    viewer.system._identify_components()
+    _, limits = viewer._default_axis_limits("YZ")
+    assert -10 < limits[0] < 0 < limits[1] < 10
+
+
+def test_three_dimensional_image_actor_uses_schematic_extent(set_test_backend):
+    optic = _optic()
+    optic.surfaces[2].aperture = RadialAperture(3)
+    rays = Rays3D(optic)
+    rays.r_extent = be.full(4, 1e6)
+    system = OpticalSystem(optic, rays, projection="3d")
+    system._identify_components()
+    image = next(
+        component
+        for component in system.components
+        if component.surf is optic.surfaces[-1]
+    )
+    assert isinstance(image, Surface3D)
+    assert image.extent_source == "schematic"
+    bounds = image.get_surface().GetBounds()
+    np.testing.assert_allclose(bounds[4:], [3, 3])
+    assert max(abs(value) for value in bounds[:4]) == pytest.approx(3)
+
+
+def test_custom_surface_renderer_keeps_existing_positional_data(
+    set_test_backend, monkeypatch
+):
+    from optiland.visualization.system import system as system_module
+
+    optic = _optic()
+    rays = Rays2D(optic)
+    calls = []
+    custom = SimpleNamespace(render_2d=lambda ax, data: calls.append(data))
+    monkeypatch.setitem(system_module._CUSTOM_RENDERER_REGISTRY, "surface", custom)
+    fig, ax = plt.subplots()
+    try:
+        OpticalSystem(optic, rays).plot(ax, show_apertures=False)
+        assert calls[-1]["args"][0] is optic.surfaces[-1]
+        assert calls[-1]["args"][1] == 0
+        assert calls[-1]["kwargs"] == {"is_image_plane": True}
+    finally:
+        plt.close(fig)

--- a/tests/visualization/system/test_ray_extents.py
+++ b/tests/visualization/system/test_ray_extents.py
@@ -235,3 +235,47 @@ def test_custom_surface_renderer_keeps_existing_positional_data(
         assert calls[-1]["kwargs"] == {"is_image_plane": True}
     finally:
         plt.close(fig)
+
+
+@pytest.mark.parametrize("projection", ["YZ", "XZ"])
+def test_first_blocking_hit_cannot_override_physical_aperture_fit(
+    set_test_backend, projection
+):
+    rays = _recorded_rays()
+    for surface in rays.optic.surfaces:
+        surface.aperture = RadialAperture(1)
+    rays.y = be.array([[0, 1, 1], [0, 1e6, 1], [0, 1e9, 1], [0, 1e9, 1]])
+    rays._update_surface_extents()
+    assert float(be.to_numpy(rays.r_extent[1])) == 1e6
+    viewer = OpticViewer(rays.optic)
+    viewer.rays = rays
+    viewer.system = OpticalSystem(rays.optic, rays)
+    viewer.system._identify_components()
+    _, limits = viewer._default_axis_limits(projection)
+    np.testing.assert_allclose(limits, [-1.15, 1.15])
+
+
+@pytest.mark.parametrize("projection,tilt", [("YZ", "rx"), ("XZ", "ry")])
+def test_tilted_image_marker_is_not_cropped_at_vertex_z_limits(
+    set_test_backend, projection, tilt
+):
+    optic = _optic()
+    optic.surfaces[-2].aperture = RadialAperture(8)
+    setattr(optic.surfaces[-1].geometry.cs, tilt, np.pi / 3)
+    viewer = OpticViewer(optic)
+    fig, ax, _ = viewer.view(num_rays=3, projection=projection, show=False)
+    try:
+        line = next(
+            line for line in ax.lines if "schematic image plane" in line.get_label()
+        )
+        assert np.ptp(line.get_xdata()) > 10
+        assert ax.get_xlim()[0] < np.min(line.get_xdata())
+        assert ax.get_xlim()[1] > np.max(line.get_xdata())
+    finally:
+        plt.close(fig)
+
+
+def test_nonimage_invalid_sample_extent_is_zero(set_test_backend):
+    component = Surface2D(_optic().surfaces[1], be.nan)
+    assert component.extent == 0
+    assert component.extent_source == "ray_samples"

--- a/tests/visualization/test_visualization_extended.py
+++ b/tests/visualization/test_visualization_extended.py
@@ -35,6 +35,7 @@ class TestInfoProviders:
         real_surf.thickness = 5.0
         real_surf.material_post.name = "Glass"
         surf_2d.surf = real_surf
+        surf_2d.extent_source = "physical_aperture"
 
         # Add to group so index can be found
         mock_optic.surfaces = [real_surf]
@@ -83,7 +84,7 @@ class TestInteractionManager:
     def test_init(self, mock_fig_ax, mock_optic):
         fig, ax = mock_fig_ax
         manager = interaction.InteractionManager(fig, ax, mock_optic)
-        assert manager.tooltip.get_visible() == False
+        assert not manager.tooltip.get_visible()
 
     def test_register_artist(self, mock_fig_ax, mock_optic):
         fig, ax = mock_fig_ax
@@ -146,7 +147,7 @@ class TestInteractionManager:
         ):
             manager.show_tooltip(artist, event)
             assert manager.tooltip.get_text() == "Tooltip Info"
-            assert manager.tooltip.get_visible() == True
+            assert manager.tooltip.get_visible()
 
     def test_info_panel(self, mock_fig_ax, mock_optic):
         fig, ax = mock_fig_ax


### PR DESCRIPTION
Downstream coordinates of already extinguished rays currently enlarge image-plane drawings and layout limits. Compute sampled extents from finite incident hits with cumulative ray liveness, retaining the first blocking endpoint while excluding later coordinates. Reset sampling between plots and copy coordinates before display masking.

Keep finite physical apertures authoritative. Give an unbounded image endpoint a ray-count-independent schematic marker based on the nearest preceding finite aperture, or a 1 mm fallback, and identify its schematic meaning in labels and surface information. Use resolved component extents for auto-fit and include transformed outlines so tilted markers are visible. The prescription and detector/aperture settings are unchanged.

Validation: 307 affected tests passed on NumPy/Torch, including 3D actor bounds; 100% of changed executable production lines covered; Ruff and formatting passed. Full CI/Codecov results will be checked on this PR.

Closes #823
