### PR TITLE
Reserve native spinbox arrow hit areas in both themes

### DIFF
--- a/optiland_gui/resources/styles/dark_theme.qss
+++ b/optiland_gui/resources/styles/dark_theme.qss
@@ -721,3 +721,9 @@ QDoubleSpinBox:focus {
 QWidget#CommandPaletteOverlay {
     background: rgba(0, 0, 0, 120);
 }
+
+/* Reserve text padding for both native Windows 11 arrow hit areas, scaling
+   with the control's font metrics. Keep arrow painting with the native style. */
+QSpinBox, QDoubleSpinBox {
+    padding-right: 2em;
+}

--- a/optiland_gui/resources/styles/light_theme.qss
+++ b/optiland_gui/resources/styles/light_theme.qss
@@ -295,15 +295,6 @@ QLineEdit:focus, QDoubleSpinBox:focus, QComboBox:focus {
 QLineEdit:read-only {
     background-color: #E9ECEF; /* --toolbar-sidebar-bg: Background for read-only fields */
 }
-QDoubleSpinBox::up-button, QDoubleSpinBox::down-button { /* Buttons for QDoubleSpinBox */
-    border: 1px solid #CED4DA; /* --border-pressed-bg */
-    background-color: #E9ECEF; /* --toolbar-sidebar-bg */
-    min-width: 16px;
-}
-QDoubleSpinBox::up-arrow, QDoubleSpinBox::down-arrow { /* Arrows within spinbox buttons */
-     width: 7px; height: 7px;
-     /* Consider using themed SVG icons */
-}
 QComboBox::down-arrow { /* Style for the dropdown arrow area of QComboBox */
     border: 1px solid #CED4DA; /* --border-pressed-bg */
     background-color: #E9ECEF; /* --toolbar-sidebar-bg */
@@ -768,4 +759,10 @@ QSpinBox:focus,
 QDoubleSpinBox:focus {
     border: 1.5px solid #007ACC;
     outline: none;
+}
+
+/* Reserve text padding for both native Windows 11 arrow hit areas, scaling
+   with the control's font metrics. Keep arrow painting with the native style. */
+QSpinBox, QDoubleSpinBox {
+    padding-right: 2em;
 }

--- a/tests/gui/test_spinbox_hit_areas.py
+++ b/tests/gui/test_spinbox_hit_areas.py
@@ -20,7 +20,8 @@ from PySide6.QtWidgets import (
 
 @pytest.fixture(params=["windows11", "fusion"])
 def styled_app(qapp, request):
-    names = {name.lower(): name for name in QStyleFactory.keys()}
+    # QStyleFactory is Qt's factory class, not a mapping.
+    names = {name.lower(): name for name in QStyleFactory.keys()}  # noqa: SIM118
     if request.param not in names:
         pytest.skip(f"Qt style {request.param} is unavailable")
     previous_style = qapp.style().objectName()
@@ -34,14 +35,20 @@ def styled_app(qapp, request):
 def button_rect(spin, control):
     option = QStyleOptionSpinBox()
     spin.initStyleOption(option)
-    return spin.style().subControlRect(QStyle.ComplexControl.CC_SpinBox, option, control, spin)
+    return spin.style().subControlRect(
+        QStyle.ComplexControl.CC_SpinBox, option, control, spin
+    )
 
 
 @pytest.mark.parametrize("theme", ["dark", "light"])
 @pytest.mark.parametrize("spin_type", [QSpinBox, QDoubleSpinBox])
 @pytest.mark.parametrize("width", [100, 180])
 def test_arrows_are_separate_and_clickable(styled_app, theme, spin_type, width):
-    theme_path = Path(__file__).parents[2] / "optiland_gui/resources/styles" / f"{theme}_theme.qss"
+    theme_path = (
+        Path(__file__).parents[2]
+        / "optiland_gui/resources/styles"
+        / f"{theme}_theme.qss"
+    )
     styled_app.setStyleSheet(theme_path.read_text(encoding="utf-8"))
     container = QWidget()
     container.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
@@ -66,7 +73,11 @@ def test_arrows_are_separate_and_clickable(styled_app, theme, spin_type, width):
                 rect = button_rect(spin, control)
                 assert not rect.isEmpty()
                 assert not spin.lineEdit().geometry().intersects(rect)
-                for point in (rect.center(), rect.topLeft() + QPoint(2, 2), rect.bottomRight() - QPoint(2, 2)):
+                for point in (
+                    rect.center(),
+                    rect.topLeft() + QPoint(2, 2),
+                    rect.bottomRight() - QPoint(2, 2),
+                ):
                     spin.setValue(50)
                     target = spin.childAt(point) or spin
                     assert target is spin
@@ -86,7 +97,9 @@ def test_arrows_are_separate_and_clickable(styled_app, theme, spin_type, width):
             (0, QStyle.SubControl.SC_SpinBoxDown),
         ):
             spin.setValue(value)
-            QTest.mouseClick(spin, Qt.MouseButton.LeftButton, pos=button_rect(spin, control).center())
+            QTest.mouseClick(
+                spin, Qt.MouseButton.LeftButton, pos=button_rect(spin, control).center()
+            )
             assert spin.value() == value
     finally:
         container.close()

--- a/tests/gui/test_spinbox_hit_areas.py
+++ b/tests/gui/test_spinbox_hit_areas.py
@@ -1,0 +1,92 @@
+"""Spin-box arrow clicks must reach the control rather than its text editor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import (
+    QDoubleSpinBox,
+    QSpinBox,
+    QStyle,
+    QStyleFactory,
+    QStyleOptionSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+@pytest.fixture(params=["windows11", "fusion"])
+def styled_app(qapp, request):
+    names = {name.lower(): name for name in QStyleFactory.keys()}
+    if request.param not in names:
+        pytest.skip(f"Qt style {request.param} is unavailable")
+    previous_style = qapp.style().objectName()
+    previous_sheet = qapp.styleSheet()
+    qapp.setStyle(names[request.param])
+    yield qapp
+    qapp.setStyleSheet(previous_sheet)
+    qapp.setStyle(previous_style)
+
+
+def button_rect(spin, control):
+    option = QStyleOptionSpinBox()
+    spin.initStyleOption(option)
+    return spin.style().subControlRect(QStyle.ComplexControl.CC_SpinBox, option, control, spin)
+
+
+@pytest.mark.parametrize("theme", ["dark", "light"])
+@pytest.mark.parametrize("spin_type", [QSpinBox, QDoubleSpinBox])
+@pytest.mark.parametrize("width", [100, 180])
+def test_arrows_are_separate_and_clickable(styled_app, theme, spin_type, width):
+    theme_path = Path(__file__).parents[2] / "optiland_gui/resources/styles" / f"{theme}_theme.qss"
+    styled_app.setStyleSheet(theme_path.read_text(encoding="utf-8"))
+    container = QWidget()
+    container.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+    layout = QVBoxLayout(container)
+    spin = spin_type()
+    spin.setRange(0, 100)
+    spin.setFixedWidth(width)
+    spin.setValue(50)
+    other = QSpinBox()
+    layout.addWidget(spin)
+    layout.addWidget(other)
+    container.show()
+    styled_app.processEvents()
+    try:
+        for focused in (False, True):
+            (spin if focused else other).setFocus()
+            styled_app.processEvents()
+            for control, delta in (
+                (QStyle.SubControl.SC_SpinBoxUp, 1),
+                (QStyle.SubControl.SC_SpinBoxDown, -1),
+            ):
+                rect = button_rect(spin, control)
+                assert not rect.isEmpty()
+                assert not spin.lineEdit().geometry().intersects(rect)
+                for point in (rect.center(), rect.topLeft() + QPoint(2, 2), rect.bottomRight() - QPoint(2, 2)):
+                    spin.setValue(50)
+                    target = spin.childAt(point) or spin
+                    assert target is spin
+                    QTest.mouseClick(target, Qt.MouseButton.LeftButton, pos=point)
+                    assert spin.value() == 50 + delta
+        spin.setValue(50)
+        QTest.keyClick(spin.lineEdit(), Qt.Key.Key_Up)
+        assert spin.value() == 51
+        QTest.keyClick(spin.lineEdit(), Qt.Key.Key_Down)
+        assert spin.value() == 50
+        spin.lineEdit().selectAll()
+        QTest.keyClicks(spin.lineEdit(), "42")
+        QTest.keyClick(spin.lineEdit(), Qt.Key.Key_Return)
+        assert spin.value() == 42
+        for value, control in (
+            (100, QStyle.SubControl.SC_SpinBoxUp),
+            (0, QStyle.SubControl.SC_SpinBoxDown),
+        ):
+            spin.setValue(value)
+            QTest.mouseClick(spin, Qt.MouseButton.LeftButton, pos=button_rect(spin, control).center())
+            assert spin.value() == value
+    finally:
+        container.close()


### PR DESCRIPTION
Reserve font-relative space for both native arrow subcontrols so the embedded
line editor cannot intercept up-arrow clicks. Remove the partial light-theme
button overrides so the native style owns arrow painting and hit geometry.

Validation: 16 regression cases cover integer/decimal controls, both themes,
Windows 11/Fusion styles, focus, widths, arrow corners, keyboard input and limits.
All pass natively at 100%, 150% and 200% scale and with the offscreen platform.
Ruff and formatting pass. This asset-only production change is excluded by the
existing Codecov GUI policy; no coverage configuration was changed.

Closes #825
