### PR TITLE
Preserve physical face extents and aperture-shaped lens walls

### DIFF
--- a/optiland/physical_apertures/elliptical.py
+++ b/optiland/physical_apertures/elliptical.py
@@ -37,7 +37,12 @@ class EllipticalAperture(BaseAperture):
             tuple: The extent of the aperture in the x and y directions.
 
         """
-        return -self.a, self.a, -self.b, self.b
+        return (
+            self.offset_x - self.a,
+            self.offset_x + self.a,
+            self.offset_y - self.b,
+            self.offset_y + self.b,
+        )
 
     def contains(self, x, y):
         """Checks if the given point is inside the aperture.

--- a/optiland/visualization/system/lens.py
+++ b/optiland/visualization/system/lens.py
@@ -16,6 +16,12 @@ import vtk
 from matplotlib.patches import Polygon
 
 import optiland.backend as be
+from optiland.physical_apertures import (
+    EllipticalAperture,
+    OffsetRadialAperture,
+    RadialAperture,
+    RectangularAperture,
+)
 from optiland.visualization.system.utils import revolve_contour, transform, transform_3d
 
 
@@ -404,6 +410,8 @@ class Lens3D(Lens2D):
             bool: True if all surfaces are symmetric, False otherwise.
 
         """
+        if not self._has_circular_apertures():
+            return False
         for surf in self.surfaces:
             geometry = surf.surf.geometry
             if not geometry.is_symmetric:
@@ -416,6 +424,20 @@ class Lens3D(Lens2D):
             ):
                 return False
         return True
+
+    def _has_circular_apertures(self):
+        """Whether a centered, uninterrupted circular rim describes every face."""
+        return all(
+            surface.surf.aperture is None
+            or (
+                type(surface.surf.aperture) is RadialAperture
+                and surface.surf.aperture.r_min == 0
+            )
+            for surface in self.surfaces
+        )
+
+    def _has_shared_circular_rim(self):
+        return self._has_circular_apertures() and self._has_common_axis()
 
     def plot(self, renderer, theme=None, *args, **kwargs):
         """Plots the lens or surfaces using the provided renderer.
@@ -497,7 +519,7 @@ class Lens3D(Lens2D):
 
         """
         max_extent = self._get_max_extent()
-        common_axis = self._has_common_axis()
+        common_axis = self._has_shared_circular_rim()
         for (
             surface_3d_obj
         ) in self.surfaces:  # surface_3d_obj is an instance of e.g. Surface3D
@@ -664,9 +686,8 @@ class Lens3D(Lens2D):
     def _plot_surface_edges(self, renderer, theme=None):
         """Plots the edges of surfaces in a 3D renderer.
 
-        This method generates circular edges for each surface. It then
-        transforms these edges into the appropriate coordinate system and adds
-        them to the renderer.
+        Face perimeters are transformed to global coordinates before joining.
+        Rectangular corners are retained, including for folded components.
 
         Args:
             renderer: The 3D renderer object where the surface edges will be
@@ -685,8 +706,29 @@ class Lens3D(Lens2D):
         for k in range(len(circles) - 1):
             circle1 = circles[k]
             circle2 = circles[k + 1]
+            rectangular = any(
+                type(surface.surf.aperture) is RectangularAperture
+                for surface in self.surfaces[k : k + 2]
+            )
+            circle2 = self._align_perimeters(circle1, circle2, rectangular)
             actor = self._get_edge_surface(circle1, circle2, theme=theme)
             renderer.AddActor(actor)
+
+    @staticmethod
+    def _align_perimeters(first, second, rectangular):
+        """Match winding/start points without twisting reversed surface frames.
+
+        Rectangular loops have four equally sampled sides. Shift only by whole
+        sides so a rectangle's corner cannot be joined to an edge interior.
+        """
+        step = len(second) // 4 if rectangular else 1
+        reversed_loop = np.roll(second[::-1], 1, axis=0)
+        candidates = (
+            np.roll(loop, shift, axis=0)
+            for loop in (second, reversed_loop)
+            for shift in range(0, len(second), step)
+        )
+        return min(candidates, key=lambda loop: np.sum((first - loop) ** 2))
 
     def _get_edge_points(self, surface_obj):
         """Computes the (x, y, z) local coordinates of the edges of the lens.
@@ -698,11 +740,41 @@ class Lens3D(Lens2D):
             tuple: A tuple containing arrays of x, y, and z
                 coordinates in the local coordinate system of surface_obj.
         """
-        max_extent_lens = self._get_max_extent()
-        theta = be.linspace(0, 2 * be.pi, 256)  # 256 points for smooth edge
-
-        x_local = max_extent_lens * be.cos(theta)
-        y_local = max_extent_lens * be.sin(theta)
+        aperture = surface_obj.surf.aperture
+        # Equal samples per side retain exact rectangle corners and support
+        # curved sags. Do not duplicate the first vertex at the closing seam.
+        if type(aperture) is RectangularAperture:
+            left, right, bottom, top = aperture.extent
+            corners = np.array(
+                [(right, top), (left, top), (left, bottom), (right, bottom)]
+            )
+            fractions = np.arange(64)[:, None] / 64
+            points = np.concatenate(
+                [
+                    start + fractions * (end - start)
+                    for start, end in zip(
+                        corners, np.roll(corners, -1, axis=0), strict=True
+                    )
+                ]
+            )
+            x_local, y_local = be.array(points[:, 0]), be.array(points[:, 1])
+        else:
+            theta = be.array(np.arange(256) * (2 * np.pi / 256) + np.pi / 4)
+            offset_x = offset_y = 0
+            if type(aperture) is EllipticalAperture:
+                a, b = aperture.a, aperture.b
+                offset_x, offset_y = aperture.offset_x, aperture.offset_y
+            elif type(aperture) is OffsetRadialAperture:
+                a = b = aperture.r_max
+                offset_x, offset_y = aperture.offset_x, aperture.offset_y
+            else:
+                a = b = (
+                    self._get_max_extent()
+                    if self._has_shared_circular_rim()
+                    else surface_obj.extent
+                )
+            x_local = offset_x + a * be.cos(theta)
+            y_local = offset_y + b * be.sin(theta)
         z_local = surface_obj.surf.geometry.sag(x_local, y_local)
 
         return x_local, y_local, z_local

--- a/optiland/visualization/system/lens.py
+++ b/optiland/visualization/system/lens.py
@@ -189,12 +189,13 @@ class Lens2D:
 
         """
         max_extent = self._get_max_extent()
+        common_axis = self._has_common_axis()
         sags = []
         for surf in self.surfaces:
             x, y, z = surf._compute_sag(projection)
 
             # extend surface to max extent
-            if surf.extent < max_extent:
+            if common_axis and surf.extent < max_extent:
                 x, y, z = self._extend_surface(
                     x, y, z, surf.surf, max_extent, projection
                 )
@@ -206,6 +207,28 @@ class Lens2D:
             sags.append((x, y, z))
 
         return sags
+
+    def _has_common_axis(self):
+        """Whether local radii can define a shared coaxial lens rim.
+
+        A diagonal prism face has a longer local extent than its projected
+        height. Borrowing that extent for the other faces invents extra glass.
+        Decentered faces likewise have distinct radial origins.
+        """
+        if len(self.surfaces) < 2:
+            return True
+        origin, rotation = self.surfaces[0].surf.geometry.cs.get_effective_transform()
+        origin = be.to_numpy(origin)
+        axis = be.to_numpy(rotation)[:, 2]
+        for surface in self.surfaces[1:]:
+            position, rotation = surface.surf.geometry.cs.get_effective_transform()
+            normal = be.to_numpy(rotation)[:, 2]
+            displacement = be.to_numpy(position) - origin
+            if not np.allclose(np.cross(axis, normal), 0, atol=1e-9, rtol=0):
+                return False
+            if not np.allclose(np.cross(axis, displacement), 0, atol=1e-9, rtol=0):
+                return False
+        return True
 
     def _get_max_extent(self):
         """Gets the maximum radial extent of all surfaces in the lens in global
@@ -474,6 +497,7 @@ class Lens3D(Lens2D):
 
         """
         max_extent = self._get_max_extent()
+        common_axis = self._has_common_axis()
         for (
             surface_3d_obj
         ) in self.surfaces:  # surface_3d_obj is an instance of e.g. Surface3D
@@ -484,7 +508,7 @@ class Lens3D(Lens2D):
             renderer.AddActor(actor)
 
             # Add annulus if surface extent does not extend to lens edge
-            if surface_3d_obj.extent < max_extent:
+            if common_axis and surface_3d_obj.extent < max_extent:
                 self._plot_annulus(
                     surface_3d_obj, renderer, theme=theme
                 )  # Pass renderer

--- a/tests/visualization/system/test_folded_lens_extents.py
+++ b/tests/visualization/system/test_folded_lens_extents.py
@@ -1,0 +1,96 @@
+"""Local diagonal radii must not enlarge other prism/lens faces."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import vtk
+from matplotlib.figure import Figure
+
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.optic import Optic
+from optiland.physical_apertures import RadialAperture, RectangularAperture
+from optiland.visualization.system.lens import Lens2D, Lens3D
+from optiland.visualization.system.surface import Surface2D, Surface3D
+
+
+def _folded_faces(view_type=Surface2D):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=-10)
+    optic.surfaces.add(index=1, z=0, aperture=RectangularAperture(-5, 5, -5, 5))
+    optic.surfaces.add(
+        index=2,
+        z=5,
+        rx=np.pi / 4,
+        material="mirror",
+        aperture=RectangularAperture(-5, 5, -5 * np.sqrt(2), 5 * np.sqrt(2)),
+    )
+    return optic, [view_type(surface, 1) for surface in list(optic.surfaces)[1:]]
+
+
+def test_folded_outline_stays_inside_analytic_prism(set_test_backend):
+    optic, faces = _folded_faces()
+    before = json.dumps(optic.to_dict(), sort_keys=True)
+    component = Lens2D(faces)
+    figure = Figure()
+    axes = figure.add_subplot()
+    component.plot(axes)
+    assert axes.patches
+    for patch in axes.patches:
+        vertices = patch.get_xy()
+        assert np.isfinite(vertices).all()
+        np.testing.assert_allclose(vertices.min(axis=0), [0, -5], atol=1e-10)
+        np.testing.assert_allclose(vertices.max(axis=0), [10, 5], atol=1e-10)
+    local = component._compute_sag(apply_transform=False)
+    np.testing.assert_allclose(be.to_numpy(local[0][1])[[0, -1]], [-5, 5])
+    np.testing.assert_allclose(
+        be.to_numpy(local[1][1])[[0, -1]], [-5 * np.sqrt(2), 5 * np.sqrt(2)]
+    )
+    assert json.dumps(optic.to_dict(), sort_keys=True) == before
+
+
+@pytest.mark.parametrize("decenter,reverse", [(0, False), (0, True), (2, False)])
+def test_shared_rim_requires_coaxial_faces(set_test_backend, decenter, reverse):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=-10)
+    optic.surfaces.add(index=1, z=0, aperture=RadialAperture(3))
+    optic.surfaces.add(
+        index=2,
+        z=5,
+        y=decenter,
+        rx=np.pi if reverse else 0,
+        aperture=RadialAperture(5),
+    )
+    # A common rigid parent transform must not change the coaxial decision.
+    parent = CoordinateSystem(x=7, y=11, z=-13, rx=0.4, ry=0.2)
+    for surface in optic.surfaces:
+        surface.geometry.cs.reference_cs = parent
+    component = Lens2D([Surface2D(s, 1) for s in list(optic.surfaces)[1:]])
+    local = component._compute_sag(apply_transform=False)
+    expected = 3 if decenter else 5
+    np.testing.assert_allclose(be.to_numpy(local[0][1])[[0, -1]], [-expected, expected])
+
+
+def test_3d_fold_does_not_add_a_circular_annulus(set_test_backend):
+    _, faces = _folded_faces(Surface3D)
+    component = Lens3D(faces)
+    component._plot_annulus = Mock(side_effect=AssertionError("False prism rim"))
+    renderer = vtk.vtkRenderer()
+    component._plot_surfaces(renderer)
+    assert renderer.GetActors().GetNumberOfItems() == 2
+    component._plot_annulus.assert_not_called()
+
+
+def test_3d_coaxial_rim_still_extends(set_test_backend):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=-10)
+    optic.surfaces.add(index=1, z=0, aperture=RadialAperture(3))
+    optic.surfaces.add(index=2, z=5, aperture=RadialAperture(5))
+    component = Lens3D([Surface3D(s, 1) for s in list(optic.surfaces)[1:]])
+    component._plot_annulus = Mock()
+    component._plot_surfaces(vtk.vtkRenderer())
+    component._plot_annulus.assert_called_once()

--- a/tests/visualization/system/test_folded_lens_extents.py
+++ b/tests/visualization/system/test_folded_lens_extents.py
@@ -94,3 +94,15 @@ def test_3d_coaxial_rim_still_extends(set_test_backend):
     component._plot_annulus = Mock()
     component._plot_surfaces(vtk.vtkRenderer())
     component._plot_annulus.assert_called_once()
+
+
+def test_single_face_keeps_its_own_extent(set_test_backend):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=-10)
+    optic.surfaces.add(index=1, z=5, aperture=RadialAperture(3))
+    face = Surface2D(optic.surfaces[1], 1)
+    component = Lens2D([face])
+    x, y, z = component._compute_sag()[0]
+    np.testing.assert_allclose(be.to_numpy(x), 0)
+    np.testing.assert_allclose(be.to_numpy(y)[[0, -1]], [-3, 3])
+    np.testing.assert_allclose(be.to_numpy(z), 5)

--- a/tests/visualization/system/test_lens3d_aperture_edges.py
+++ b/tests/visualization/system/test_lens3d_aperture_edges.py
@@ -1,0 +1,129 @@
+"""3D body walls must follow their faces, including rectangular folded optics."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import vtk
+from vtk.util.numpy_support import vtk_to_numpy
+
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.optic import Optic
+from optiland.physical_apertures import (
+    EllipticalAperture,
+    OffsetRadialAperture,
+    RadialAperture,
+    RectangularAperture,
+)
+from optiland.visualization.system.lens import Lens3D
+from optiland.visualization.system.surface import Surface3D
+
+
+def _lens(apertures, **last_position):
+    optic = Optic()
+    optic.surfaces.add(index=0, z=-10)
+    optic.surfaces.add(index=1, z=0, aperture=apertures[0])
+    optic.surfaces.add(index=2, **{"z": 10, **last_position}, aperture=apertures[1])
+    return optic, Lens3D([Surface3D(s, 1) for s in list(optic.surfaces)[1:]])
+
+
+def _world_points(actor):
+    actor.GetMapper().Update()
+    points = vtk_to_numpy(actor.GetMapper().GetInput().GetPoints().GetData())
+    matrix = actor.GetMatrix()
+    matrix = np.array([[matrix.GetElement(i, j) for j in range(4)] for i in range(4)])
+    return np.column_stack((points, np.ones(len(points)))) @ matrix.T
+
+
+@pytest.mark.parametrize("folded", [False, True])
+def test_rectangular_complete_body_has_no_circular_shell(set_test_backend, folded):
+    optic, lens = _lens(
+        [
+            RectangularAperture(-5, 5, -5, 5),
+            RectangularAperture(-5, 5, -5 * np.sqrt(2), 5 * np.sqrt(2))
+            if folded
+            else RectangularAperture(-5, 5, -5, 5),
+        ],
+        z=5 if folded else 10,
+        rx=np.pi / 4 if folded else 0,
+    )
+    before = json.dumps(optic.to_dict(), sort_keys=True)
+    renderer = vtk.vtkRenderer()
+    lens.plot(renderer)
+    points = np.vstack([_world_points(a)[:, :3] for a in renderer.GetActors()])
+    assert np.isfinite(points).all()
+    np.testing.assert_allclose(points.min(axis=0), [-5, -5, 0], atol=1e-6)
+    np.testing.assert_allclose(points.max(axis=0), [5, 5, 10], atol=1e-6)
+    # The wall contains the rectangular corners, not just an inscribed circle.
+    for x in (-5, 5):
+        for y in (-5, 5):
+            assert np.any(np.all(np.isclose(points, [x, y, 0], atol=1e-6), axis=1))
+    assert json.dumps(optic.to_dict(), sort_keys=True) == before
+
+
+def test_rectangular_walls_follow_offsets_and_reversed_frames(set_test_backend):
+    optic, lens = _lens(
+        [RectangularAperture(1, 5, -3, 3), RectangularAperture(1, 5, -3, 3)],
+        rx=np.pi,
+    )
+    parent = CoordinateSystem(x=7, y=-2, z=13, rx=0.3, ry=0.4)
+    for s in list(optic.surfaces)[1:]:
+        s.geometry.cs.reference_cs = parent
+    renderer = vtk.vtkRenderer()
+    lens._plot_surface_edges(renderer)
+    assert renderer.GetActors().GetNumberOfItems() == 1
+    points = _world_points(next(iter(renderer.GetActors())))[:, :3]
+    origin, rotation = parent.get_effective_transform()
+    local = (points - be.to_numpy(origin)) @ be.to_numpy(rotation)
+    first, second = np.split(local, 2)
+    # Every connecting segment is axial; reversed local normals must not twist it.
+    np.testing.assert_allclose(first[:, :2], second[:, :2], atol=2e-6)
+    np.testing.assert_allclose(second[:, 2] - first[:, 2], 10, atol=2e-6)
+
+
+@pytest.mark.parametrize("decenter", [0, 2])
+def test_circular_rim_is_shared_only_on_common_axis(set_test_backend, decenter):
+    _, lens = _lens([RadialAperture(3), RadialAperture(5)], x=decenter)
+    x, y, _ = lens._get_edge_points(lens.surfaces[0])
+    np.testing.assert_allclose(
+        np.hypot(be.to_numpy(x), be.to_numpy(y)), 3 if decenter else 5
+    )
+
+
+@pytest.mark.parametrize(
+    "aperture",
+    [
+        RectangularAperture(1, 5, -3, 3),
+        EllipticalAperture(4, 2, offset_x=1, offset_y=-1),
+        OffsetRadialAperture(3, offset_x=2, offset_y=-1),
+    ],
+)
+def test_local_side_wall_boundary_matches_aperture(set_test_backend, aperture):
+    _, lens = _lens([aperture, aperture])
+    x, y, z = (be.to_numpy(a) for a in lens._get_edge_points(lens.surfaces[0]))
+    assert len(x) == 256
+    assert np.isfinite(np.column_stack((x, y, z))).all()
+    assert not np.allclose([x[0], y[0]], [x[-1], y[-1]])
+    if isinstance(aperture, RectangularAperture):
+        assert np.all(
+            np.isclose(x, 1) | np.isclose(x, 5) | np.isclose(y, -3) | np.isclose(y, 3)
+        )
+        np.testing.assert_allclose(
+            [x.min(), x.max(), y.min(), y.max()], aperture.extent
+        )
+    elif isinstance(aperture, EllipticalAperture):
+        np.testing.assert_allclose(((x - 1) / 4) ** 2 + ((y + 1) / 2) ** 2, 1)
+    else:
+        np.testing.assert_allclose((x - 2) ** 2 + (y + 1) ** 2, 9)
+
+
+def test_rectangular_faces_do_not_acquire_an_annulus(set_test_backend):
+    _, lens = _lens(
+        [RectangularAperture(-3, 3, -3, 3), RectangularAperture(-5, 5, -5, 5)]
+    )
+    renderer = vtk.vtkRenderer()
+    lens._plot_surfaces(renderer)
+    assert renderer.GetActors().GetNumberOfItems() == 2

--- a/tests/visualization/system/test_lens3d_aperture_edges.py
+++ b/tests/visualization/system/test_lens3d_aperture_edges.py
@@ -127,3 +127,30 @@ def test_rectangular_faces_do_not_acquire_an_annulus(set_test_backend):
     renderer = vtk.vtkRenderer()
     lens._plot_surfaces(renderer)
     assert renderer.GetActors().GetNumberOfItems() == 2
+
+
+@pytest.mark.parametrize("offset", [(5, -3), (-5, 3)])
+def test_offset_elliptical_faces_meet_body_walls(set_test_backend, offset):
+    aperture = EllipticalAperture(4, 2, offset_x=offset[0], offset_y=offset[1])
+    optic, lens = _lens([aperture, aperture])
+    before = json.dumps(optic.to_dict(), sort_keys=True)
+    renderer = vtk.vtkRenderer()
+    lens.plot(renderer)
+    actors = list(renderer.GetActors())
+    assert len(actors) == 3
+    expected = np.array([offset[0] - 4, offset[1] - 2, offset[0] + 4, offset[1] + 2])
+    for actor in actors[:2]:
+        mesh = actor.GetMapper().GetInput()
+        # Bounds of unreferenced grid points can hide missing face geometry.
+        used = np.unique(vtk_to_numpy(mesh.GetPolys().GetConnectivityArray()))
+        assert used.size > 0
+        points = _world_points(actor)[used, :2]
+        actual = np.concatenate((points.min(axis=0), points.max(axis=0)))
+        np.testing.assert_allclose(actual, expected, atol=0.07)
+    wall_points = _world_points(actors[2])[:, :2]
+    np.testing.assert_allclose(
+        np.concatenate((wall_points.min(axis=0), wall_points.max(axis=0))),
+        expected,
+        atol=1e-6,
+    )
+    assert json.dumps(optic.to_dict(), sort_keys=True) == before


### PR DESCRIPTION
Folded components currently borrow the diagonal face's larger local radius,
creating oversized plates and wedges. Allow shared-radius extension only for
coaxial faces. Restrict rotational body construction to circular apertures and
sample rectangular, elliptical and offset-circular side-wall boundaries explicitly.
Align transformed perimeter winding and start points while preserving rectangle
corners.

Correct offset elliptical aperture bounds so the sampled end faces reach the
same boundary as their side walls. Add synthetic 2D/VTK regressions for prism
bounds, reversed/inherited frames, decenter, ordinary coaxial rims, offset faces,
and preservation of the optical prescription. This single delivery covers the
related 2D and 3D drawing defects without an importer or GUI-worker dependency.

Validation: 287 visualization and aperture tests passed on NumPy/Torch; all 53
changed executable production lines covered. Ruff, formatting and whitespace
checks pass. No coverage exclusions or thresholds were changed.

Closes #829
