### PR TITLE
Keep GUI analyses responsive with cancellable calculation jobs

### DIFF
--- a/optiland_gui/analysis_panel.py
+++ b/optiland_gui/analysis_panel.py
@@ -15,12 +15,11 @@ import contextlib
 import copy
 import inspect
 import json
+import uuid
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, get_args, get_origin, get_type_hints
 
 import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib.axes import Axes
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
@@ -46,6 +45,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMenu,
     QMessageBox,
+    QProgressBar,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -74,6 +74,8 @@ from optiland.analysis import (
 from optiland.mtf import FFTMTF, GeometricMTF
 
 from . import gui_plot_utils
+from .services.analysis_plots import draw_analysis_plot
+from .services.job_records import BackendConfig
 
 if TYPE_CHECKING:
     from .optiland_connector import OptilandConnector
@@ -176,6 +178,9 @@ class AnalysisPanel(QWidget):
         self.current_settings_widgets = {}
         # Mapping of display name → class, built from the registry at init.
         self._analysis_class_map: dict[str, type] = {}
+        self.runner = connector._analysis_runner
+        self._page_limit = 16
+        self._result_budget = 128 * 1024 * 1024
 
     def _setup_main_layout(self):
         """Sets up the main QVBoxLayout for the panel."""
@@ -325,6 +330,12 @@ class AnalysisPanel(QWidget):
         )
         self.mpl_toolbar_in_titlebar_container.setVisible(False)
         self.plot_area_title_bar_layout.addStretch()
+        self.analysisProgress = QProgressBar()
+        self.analysisProgress.setRange(0, 0)
+        self.analysisProgress.setMaximumWidth(90)
+        self.analysisProgress.setTextVisible(False)
+        self.analysisProgress.hide()
+        self.plot_area_title_bar_layout.addWidget(self.analysisProgress)
 
         self.btnRefreshPlot = QPushButton()
         self.btnRefreshPlot.setObjectName("RefreshPlotButton")
@@ -437,6 +448,11 @@ class AnalysisPanel(QWidget):
 
     def _connect_signals(self):
         """Connects all widget signals to their corresponding slots."""
+        self.runner.state_changed.connect(self._analysis_state_changed)
+        self.runner.finished.connect(self._analysis_finished)
+        self.runner.progress.connect(self._analysis_progress)
+        self.runner.busy_changed.connect(self._update_analysis_controls)
+        self.connector.document_state.changed.connect(self.mark_results_stale)
         self.btnRun.clicked.connect(self.run_analysis_slot)
         self.btnRunAll.clicked.connect(self.run_all_analysis_slot)
         self.btnStop.clicked.connect(self.stop_analysis_slot)
@@ -720,11 +736,42 @@ class AnalysisPanel(QWidget):
         widget = self._create_widget_for_param(param_name, annotation, default_value)
 
         if widget:
+            if param_name == "num_rays":
+                family = self.analysisTypeCombo.currentText()
+                per_axis = "PSF" in family or family == "FFT MTF"
+                widget.setToolTip(
+                    "Pupil samples per axis; work grows with the square of this value."
+                    if per_axis
+                    else "Sampling count; available memory is checked before Run."
+                )
+            if (
+                isinstance(widget, (QSpinBox, QDoubleSpinBox))
+                and param_info.get("default") is None
+            ):
+                widget.setProperty("allowNone", True)
+                widget.setMinimum(0)
+                widget.setSpecialValueText("Auto")
+                widget.setValue(0)
+            if isinstance(widget, QDoubleSpinBox) and param_name == "pixel_pitch":
+                widget.setDecimals(9)
             if isinstance(widget, QCheckBox):
                 self.settings_form_layout.addRow(widget)
             else:
                 self.settings_form_layout.addRow(QLabel(label_text), widget)
             self.current_settings_widgets[param_name] = widget
+            signal = (
+                widget.valueChanged
+                if isinstance(widget, (QSpinBox, QDoubleSpinBox))
+                else widget.toggled
+                if isinstance(widget, QCheckBox)
+                else widget.currentIndexChanged
+                if isinstance(widget, QComboBox)
+                else widget.textEdited
+                if isinstance(widget, QLineEdit)
+                else None
+            )
+            if signal is not None:
+                signal.connect(self._settings_edited)
         else:
             print(
                 f"Warning: No widget created for '{param_name}' "
@@ -828,6 +875,12 @@ class AnalysisPanel(QWidget):
         Sets the value of a widget by dispatching to the correct handler
         based on its type.
         """
+        if value is None:
+            if isinstance(widget, (QSpinBox, QDoubleSpinBox)) and widget.property(
+                "allowNone"
+            ):
+                widget.setValue(widget.minimum())
+            return
         # A dictionary mapping widget types to their value-setting functions
         handler_map = {
             QSpinBox: lambda w, v, p: w.setValue(v),
@@ -890,8 +943,8 @@ class AnalysisPanel(QWidget):
         self.btnSaveSettings.setIcon(QIcon(f":/icons/{theme_name}/save_settings.svg"))
         self.btnLoadSettings.setIcon(QIcon(f":/icons/{theme_name}/load_settings.svg"))
 
-        # This new line will refresh the plot using the new theme
-        self._refresh_current_plot_page_slot()
+        # Reinstall detached results only; changing theme never runs optics.
+        self.display_plot_page(self.current_plot_page_index, update_settings=False)
 
     def update_pagination_ui(self):
         self._clear_layout(self.vertical_page_buttons_layout)
@@ -911,6 +964,7 @@ class AnalysisPanel(QWidget):
             )
             self.vertical_page_buttons_layout.addWidget(btn_page)
         self.vertical_page_buttons_layout.addStretch()
+        self._update_analysis_controls()
 
     def _show_page_button_context_menu(self, position, button, page_index):
         """Creates and shows the right-click menu for a page button."""
@@ -928,31 +982,31 @@ class AnalysisPanel(QWidget):
             self._remove_analysis_page(page_index)
 
     def _clone_analysis_page(self, page_index):
-        """Clones an existing analysis page."""
-        if not (0 <= page_index < len(self.analysis_results_pages)):
+        """Clone configuration and share immutable completed data, never an optic."""
+        if not 0 <= page_index < len(self.analysis_results_pages):
             return
-
-        original_page_data = self.analysis_results_pages[page_index]
-        cloned_page_data = {
-            "name": original_page_data["name"],
-            "analysis_instance": copy.deepcopy(original_page_data["analysis_instance"]),
-            "plot_type": original_page_data["plot_type"],
-            "view_args": copy.deepcopy(original_page_data["view_args"]),
-            "constructor_args_used": copy.deepcopy(
-                original_page_data["constructor_args_used"]
-            ),
-            "figsize": original_page_data.get("figsize"),
+        if len(self.analysis_results_pages) >= self._page_limit:
+            self._notify_analysis_error(
+                "Close a page before adding another (limit 16)."
+            )
+            return
+        original = self.analysis_results_pages[page_index]
+        cloned = {
+            **original,
+            "page_id": uuid.uuid4().hex,
+            "constructor_args_used": copy.deepcopy(original["constructor_args_used"]),
+            "view_args": copy.deepcopy(original["view_args"]),
+            "state": "succeeded" if original.get("prepared") else "idle",
+            "error": "",
         }
-
-        self.analysis_results_pages.append(cloned_page_data)
-        self.update_pagination_ui()
+        self.analysis_results_pages.append(cloned)
         self.switch_plot_page(len(self.analysis_results_pages) - 1)
-        self.logArea.append("Analysis cloned successfully.")
 
     def _remove_analysis_page(self, page_index):
         """Removes an analysis page from the analysis results."""
         if 0 <= page_index < len(self.analysis_results_pages):
-            self.analysis_results_pages.pop(page_index)
+            removed = self.analysis_results_pages.pop(page_index)
+            self.runner.cancel(removed["page_id"])
 
             # If the current page was removed, switch to the nearest available page
             if self.current_plot_page_index == page_index:
@@ -975,16 +1029,9 @@ class AnalysisPanel(QWidget):
         self.resize_timer.start()
 
     def handle_resize_finished(self):
-        """
-        Called after the user has finished resizing the window.
-        Applies tight_layout to the current plot.
-        """
+        """Repaint retained plots after resizing without recalculation."""
         if self.active_mpl_canvas_widget:
-            try:
-                self.active_mpl_canvas_widget.figure.tight_layout()
-                self.active_mpl_canvas_widget.draw_idle()
-            except Exception as e:
-                print(f"Error applying tight_layout on resize: {e}")
+            self.active_mpl_canvas_widget.draw_idle()
 
     def switch_plot_page(self, page_index):
         if 0 <= page_index < len(self.analysis_results_pages):
@@ -1055,7 +1102,9 @@ class AnalysisPanel(QWidget):
         }
         for param_name, widget in self.current_settings_widgets.items():
             if param_name in page_args:
+                widget.blockSignals(True)
                 self._set_widget_value(widget, page_args[param_name], param_name)
+                widget.blockSignals(False)
 
     # --- Load/Save Settings ---
     def _apply_loaded_settings_to_ui(self, loaded_settings):
@@ -1117,34 +1166,10 @@ class AnalysisPanel(QWidget):
         canvas._event_cids = cids
         return canvas
 
-    def _draw_plot_on_canvas(self, analysis_instance, canvas, view_args):
-        """Invokes the analysis's view method to draw the plot on the canvas."""
-        axs = analysis_instance.view(fig_to_plot_on=canvas.figure, **view_args)
-
-        # Add summary text overlay if available
-        if hasattr(analysis_instance, "get_summary_text"):
-            summary_text = analysis_instance.get_summary_text()
-            ax_to_use = None
-            if isinstance(axs, np.ndarray):
-                ax_to_use = axs.flatten()[-1]
-            elif isinstance(axs, Axes):
-                ax_to_use = axs
-
-            if ax_to_use:
-                props = dict(boxstyle="round,pad=0.4", facecolor="black", alpha=0.6)
-                ax_to_use.text(
-                    0.97,
-                    0.03,
-                    summary_text,
-                    transform=ax_to_use.transAxes,
-                    fontsize=7,
-                    verticalalignment="bottom",
-                    horizontalalignment="right",
-                    bbox=props,
-                    color="white",
-                )
-
-        canvas.figure.tight_layout(rect=[0, 0.05, 1, 1])
+    def _draw_plot_on_canvas(self, prepared, canvas, view_args):
+        """Draw completed plain data. No analysis or optical object reaches here."""
+        draw_analysis_plot(canvas.figure, prepared, self.current_theme)
+        canvas.draw_idle()
 
     def _setup_plot_toolbar(self, canvas):
         """Creates and attaches a new custom Matplotlib toolbar."""
@@ -1161,43 +1186,167 @@ class AnalysisPanel(QWidget):
         layout.addWidget(QLabel("Select or Run an Analysis"))
         self._update_settings_ui(self.analysisTypeCombo.currentText())
 
-    def display_plot_page(self, page_index):
-        """
-        Displays a specific analysis result page, orchestrating
-        UI cleanup and redrawing.
-        """
+    def display_plot_page(self, page_index, *, update_settings=True):
+        """Display a pending or completed stable page without rerunning analysis."""
         plot_layout = self._cleanup_plot_area()
-
-        if not (0 <= page_index < len(self.analysis_results_pages)):
+        if not 0 <= page_index < len(self.analysis_results_pages):
             self._display_placeholder(plot_layout)
+            self._update_analysis_controls()
             return
-
-        page_data = self.analysis_results_pages[page_index]
-        analysis_name = page_data.get("name", "Analysis")
-        analysis_instance = page_data.get("analysis_instance")
-
-        # Update UI text elements
-        self.plotTitleLabel.setText(analysis_name)
-        self.dataInfoLabel.setText(
-            page_data.get("result_summary", f"Results for {analysis_name}")
-        )
-
-        # Update settings panel to reflect this analysis
-        self._update_settings_ui(analysis_name)
-        self._populate_settings_from_page_data(page_data)
-
-        if page_data.get("plot_type") == "embedded_mpl" and analysis_instance:
-            self.active_mpl_canvas_widget = self._create_new_plot_canvas(page_data)
+        page = self.analysis_results_pages[page_index]
+        self.plotTitleLabel.setText(page["name"])
+        self._update_page_status(page)
+        if update_settings:
+            self.analysisTypeCombo.blockSignals(True)
+            self.analysisTypeCombo.setCurrentText(page["name"])
+            self.analysisTypeCombo.blockSignals(False)
+            self._update_settings_ui(page["name"])
+            self._populate_settings_from_page_data(page)
+        if page.get("prepared"):
+            self.active_mpl_canvas_widget = self._create_new_plot_canvas(page)
             self._draw_plot_on_canvas(
-                analysis_instance,
-                self.active_mpl_canvas_widget,
-                page_data.get("view_args", {}),
+                page["prepared"], self.active_mpl_canvas_widget, {}
             )
             self._setup_plot_toolbar(self.active_mpl_canvas_widget)
             plot_layout.addWidget(self.active_mpl_canvas_widget)
-            self._fade_in_canvas(self.active_mpl_canvas_widget)
+            # The toolbar exports this completed revision even while a rerun is pending.
+            self.active_mpl_toolbar_widget.setToolTip(self.dataInfoLabel.text())
         else:
-            plot_layout.addWidget(QLabel(f"Cannot embed plot for {analysis_name}"))
+            plot_layout.addWidget(QLabel("Waiting for analysis result."))
+        self._update_analysis_controls()
+
+    def _update_page_status(self, page):
+        state = page.get("state", "idle")
+        token = page.get("result_token")
+        parts = [state.capitalize()]
+        if state == "running" and page.get("stage"):
+            parts.append(page["stage"])
+        if token:
+            stale = (
+                token != self.connector.document_state.token
+                or page.get("result_backend") != BackendConfig.capture()
+            )
+            parts.append(
+                f"{'Out of date — ' if stale else ''}result revision {token.revision}"
+            )
+        if state in ("queued", "running", "cancelling") and page.get("prepared"):
+            parts.append("Showing previous completed result")
+        if page.get("error"):
+            parts.append(page["error"].splitlines()[-1])
+        if page.get("result_summary"):
+            parts.append(page["result_summary"])
+        if page.get("warnings"):
+            parts.append("Warning: " + " ".join(page["warnings"]))
+        if page.get("settings_dirty"):
+            parts.append("Settings changed — Apply to recalculate")
+        elif page.get("result_settings") and (
+            page["result_settings"]["constructor_args"] != page["constructor_args_used"]
+            or page["result_settings"]["view_args"] != page["view_args"]
+        ):
+            parts.append("Result uses previous settings")
+        self.dataInfoLabel.setText(" · ".join(parts))
+        self.dataInfoLabel.setWordWrap(True)
+        self.analysisProgress.setVisible(state in ("queued", "running", "cancelling"))
+
+    @Slot()
+    def _update_analysis_controls(self, *args):
+        busy = self.runner.busy
+        self.btnStop.setEnabled(busy)
+        self.btnRunAll.setEnabled(bool(self.analysis_results_pages) and not busy)
+        self.btnRunAll.setToolTip(
+            "Run all configured pages against one design revision"
+            if self.analysis_results_pages
+            else "Create analysis pages before Run All"
+        )
+        self.btnRun.setEnabled(len(self.analysis_results_pages) < self._page_limit)
+        selected = 0 <= self.current_plot_page_index < len(self.analysis_results_pages)
+        self.btnRefreshPlot.setEnabled(selected)
+        self.btnApplySettings.setEnabled(selected)
+
+    @Slot(str, str)
+    def _analysis_state_changed(self, page_id, state):
+        for index, page in enumerate(self.analysis_results_pages):
+            if page["page_id"] == page_id:
+                page["state"] = state
+                if index == self.current_plot_page_index:
+                    self._update_page_status(page)
+                break
+        self._update_analysis_controls()
+
+    @Slot(str, str)
+    def _analysis_progress(self, page_id, stage):
+        for index, page in enumerate(self.analysis_results_pages):
+            if page["page_id"] == page_id:
+                page["stage"] = stage
+                if index == self.current_plot_page_index:
+                    self._update_page_status(page)
+                break
+
+    @Slot(str, object)
+    def _analysis_finished(self, page_id, result):
+        page = next(
+            (p for p in self.analysis_results_pages if p["page_id"] == page_id), None
+        )
+        if page is None:
+            return
+        page["state"] = result.status
+        page["error"] = result.error if result.status == "failed" else ""
+        if result.status == "succeeded":
+            retained = {
+                id(p.get("prepared")): p.get("size_bytes", 0)
+                for p in self.analysis_results_pages
+                if p is not page
+            }
+            size = result.data["size_bytes"]
+            if sum(retained.values()) + size > self._result_budget:
+                page["state"] = "failed"
+                page["error"] = (
+                    "Analysis result budget exceeded (128 MiB); "
+                    "close completed pages and retry."
+                )
+            else:
+                page.update(
+                    prepared=result.data["plot"],
+                    size_bytes=size,
+                    result_token=result.request.document,
+                    result_backend=result.request.snapshot.backend,
+                    result_summary=result.data["summary"],
+                    warnings=result.data.get("warnings", []),
+                    result_settings=copy.deepcopy(result.request.parameters),
+                    figsize=result.data["plot"]["figsize"],
+                )
+        if page["error"]:
+            self._notify_analysis_error(page["error"].splitlines()[-1])
+        # Completion must never switch the user's current page or overwrite edits.
+        if self.analysis_results_pages.index(page) == self.current_plot_page_index:
+            self.display_plot_page(self.current_plot_page_index, update_settings=False)
+        self._update_analysis_controls()
+
+    @Slot(object)
+    def mark_results_stale(self, token):
+        """Optical revisions invalidate labels, not the retained historical plots."""
+        if 0 <= self.current_plot_page_index < len(self.analysis_results_pages):
+            self._update_page_status(
+                self.analysis_results_pages[self.current_plot_page_index]
+            )
+
+    def _notify_analysis_error(self, message):
+        self.logArea.append(message)
+        manager = getattr(self.connector, "toast_manager", None)
+        if manager:
+            manager.notify(message, "error")
+
+    @Slot()
+    def _settings_edited(self, *args):
+        if 0 <= self.current_plot_page_index < len(self.analysis_results_pages):
+            page = self.analysis_results_pages[self.current_plot_page_index]
+            if page["name"] == self.analysisTypeCombo.currentText():
+                page["settings_dirty"] = True
+                self._update_page_status(page)
+
+    def closeEvent(self, event):
+        self.runner.stop()
+        super().closeEvent(event)
 
     def _fade_in_canvas(self, canvas, duration_ms: int = 250) -> None:
         """Fade a newly-rendered canvas from transparent to fully opaque.
@@ -1225,8 +1374,6 @@ class AnalysisPanel(QWidget):
     def toggle_settings_panel_slot(self):
         is_visible = self.settings_area_widget.isVisible()
         self.settings_area_widget.setVisible(not is_visible)
-        if not is_visible:
-            self.display_plot_page(self.current_plot_page_index)
 
     def _parse_tuple_str(self, s, expected_type=float, expected_len=2):
         if not s or not isinstance(s, str):
@@ -1239,6 +1386,8 @@ class AnalysisPanel(QWidget):
 
     def _get_value_from_spinbox(self, widget):
         """Extracts the value from a QSpinBox or QDoubleSpinBox."""
+        if widget.property("allowNone") and widget.value() == widget.minimum():
+            return None
         return widget.value()
 
     def _get_value_from_checkbox(self, widget):
@@ -1340,7 +1489,7 @@ class AnalysisPanel(QWidget):
             True if the system is valid, False otherwise.
         """
         tm = getattr(self.connector, "toast_manager", None)
-        if not optic or optic.surface_group.num_surfaces < 2:
+        if not optic or optic.surfaces.num_surfaces < 2:
             if tm:
                 tm.notify(
                     "A minimal optical system (at least 2 surfaces) is required.",
@@ -1364,81 +1513,6 @@ class AnalysisPanel(QWidget):
                 )
             return False
         return True
-
-    def _run_and_package_analysis(
-        self, analysis_class, analysis_name, constructor_args, view_args
-    ):
-        """
-        Instantiates, runs, and packages the analysis results.
-
-        Args:
-            analysis_class: The class of the analysis to run.
-            analysis_name (str): The display name of the analysis.
-            constructor_args (dict): Arguments for the analysis class constructor.
-            view_args (dict): Arguments for the analysis view method.
-
-        Returns:
-            A dictionary containing the packaged page data for display,
-            or None on failure.
-        """
-        optic = self.connector.get_optic()
-        final_args = {"optic": optic, **constructor_args}
-
-        # Filter args to only those accepted by the constructor.
-        # For factory dispatch classes (e.g. FFTPSF) whose __init__ is
-        # *args/**kwargs, fall back to __new__ for the accepted-param list.
-        init_sig = inspect.signature(analysis_class.__init__)
-        init_params = init_sig.parameters
-        _variadic = frozenset(
-            {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
-        )
-        if all(
-            p.kind in _variadic for name, p in init_params.items() if name != "self"
-        ) and hasattr(analysis_class, "__new__"):
-            init_params = inspect.signature(analysis_class.__new__).parameters
-        valid_init_params = init_params
-        filtered_args = {k: v for k, v in final_args.items() if k in valid_init_params}
-
-        # Inject defaults for required args that may be absent when the
-        # settings panel has never been opened (e.g. field/wavelength for
-        # wavefront and PSF analyses).
-        _required_defaults = {"field": (0.0, 0.0), "wavelength": "primary"}
-        for _key, _default in _required_defaults.items():
-            if _key not in filtered_args and _key in valid_init_params:
-                filtered_args[_key] = _default
-
-        if (
-            analysis_name in [self.GEOMETRIC_MTF, self.FFT_MTF]
-            and "max_freq" in final_args
-            and "max_freq" not in filtered_args
-        ):
-            filtered_args["max_freq"] = final_args["max_freq"]
-
-        instance = analysis_class(**filtered_args)
-
-        # Check if the analysis can be plotted directly on a Matplotlib figure
-        can_embed = (
-            hasattr(instance, "view")
-            and "fig_to_plot_on" in inspect.signature(instance.view).parameters
-        )
-        if not can_embed:
-            instance.view(**view_args)  # Open in a separate window
-
-        page_data = {
-            "name": analysis_name,
-            "analysis_instance": instance,
-            "plot_type": "embedded_mpl" if can_embed else "external_window",
-            "view_args": view_args,
-            "constructor_args_used": constructor_args,
-        }
-
-        # Special case for sizing the plot figure for certain analyses
-        if analysis_name in ("Through-Focus Spot", "Through-Focus Spot Diagram"):
-            num_f = optic.fields.num_fields
-            num_s = final_args.get("num_steps", 5)
-            page_data["figsize"] = (max(1, num_s) * 3, max(1, num_f) * 3)
-
-        return page_data
 
     def _collect_current_settings(self):
         """
@@ -1473,76 +1547,74 @@ class AnalysisPanel(QWidget):
         return constructor_args, view_args
 
     def _execute_analysis(
-        self, analysis_class, analysis_name, constructor_args=None, view_args=None
+        self,
+        analysis_class,
+        analysis_name,
+        constructor_args=None,
+        view_args=None,
+        *,
+        page=None,
     ):
-        """
-        Main entry point for executing an analysis.
-
-        This method orchestrates the validation, settings collection, execution,
-        and error handling for running a single analysis.
-
-        Args:
-            analysis_class: The analysis class to instantiate.
-            analysis_name (str): The display name of the analysis.
-            constructor_args (dict, optional): Pre-collected args, used for cloning.
-            view_args (dict, optional): Pre-collected view args, used for cloning.
-
-        Returns:
-            A dictionary of page data, or None if the analysis fails.
-        """
+        """Validate settings and submit detached work without blocking the GUI."""
         optic = self.connector.get_optic()
         if not self._validate_system_for_analysis(optic):
             return None
-
-        # Validate UI inputs (ranges, tuples, etc)
-        valid, error_msg = self._validate_all_inputs()
-        if not valid:
-            tm = getattr(self.connector, "toast_manager", None)
-            if tm:
-                tm.notify(error_msg, "error")
-            else:
-                QMessageBox.warning(self, "Invalid Input", error_msg)
-            return None
-
-        try:
-            # If no args are provided, get them from the UI (standard run)
-            if constructor_args is None and view_args is None:
-                constructor_args, view_args = self._collect_current_settings()
-
-            return self._run_and_package_analysis(
-                analysis_class, analysis_name, constructor_args, view_args
-            )
-
-        except Exception as e:
-            msg = f"An error occurred during {analysis_name}:\n{e}"
-            tm = getattr(self.connector, "toast_manager", None)
-            if tm:
-                tm.notify(msg, "error")
-            else:
-                QMessageBox.critical(
-                    self,
-                    self.ANALYSIS_ERROR_TITLE,
-                    msg,
+        if constructor_args is None:
+            valid, message = self._validate_all_inputs()
+            if not valid:
+                self._notify_analysis_error(message)
+                return None
+            constructor_args, view_args = self._collect_current_settings()
+        new_page = page is None
+        if new_page:
+            if len(self.analysis_results_pages) >= self._page_limit:
+                self._notify_analysis_error(
+                    "Close a page before adding another (limit 16)."
                 )
-            import traceback
-
-            print(f"Analysis Panel Error: {e}\n{traceback.format_exc()}")
+                return None
+            page = {
+                "page_id": uuid.uuid4().hex,
+                "name": analysis_name,
+                "prepared": None,
+                "state": "idle",
+                "error": "",
+                "constructor_args_used": {},
+                "view_args": {},
+            }
+        try:
+            request = self.runner.run(
+                analysis_name,
+                constructor_args,
+                optic,
+                target=page["page_id"],
+                view_args=view_args or {},
+                theme=self.current_theme,
+            )
+        except Exception as exc:
+            self._notify_analysis_error(str(exc))
             return None
+        page.update(
+            constructor_args_used=copy.deepcopy(request.parameters["constructor_args"]),
+            view_args=copy.deepcopy(view_args or {}),
+            state="queued",
+            error="",
+            requested_token=request.document,
+            settings_dirty=False,
+        )
+        if new_page:
+            self.analysis_results_pages.append(page)
+        self._update_analysis_controls()
+        return page
 
     @Slot()
     def _apply_settings_and_rerun_analysis_slot(self):
-        if not (0 <= self.current_plot_page_index < len(self.analysis_results_pages)):
+        if not 0 <= self.current_plot_page_index < len(self.analysis_results_pages):
             return
-        page_data = self.analysis_results_pages[self.current_plot_page_index]
-        analysis_name = page_data.get("name")
-        self.logArea.setText(f"Rerunning {analysis_name} with new settings...")
-        new_page_data = self._execute_analysis(
-            self._analysis_class_map.get(analysis_name), analysis_name
+        page = self.analysis_results_pages[self.current_plot_page_index]
+        self._execute_analysis(
+            self._analysis_class_map.get(page["name"]), page["name"], page=page
         )
-        if new_page_data:
-            self.analysis_results_pages[self.current_plot_page_index] = new_page_data
-            self.display_plot_page(self.current_plot_page_index)
-            self.logArea.append(f"{analysis_name} reran successfully.")
+        self._update_page_status(page)
 
     @Slot()
     def _refresh_current_plot_page_slot(self):
@@ -1556,24 +1628,33 @@ class AnalysisPanel(QWidget):
 
     @Slot()
     def run_analysis_slot(self):
-        analysis_name = self.analysisTypeCombo.currentText()
-        analysis_class = self._analysis_class_map.get(analysis_name)
-        if not analysis_class:
+        name = self.analysisTypeCombo.currentText()
+        if name not in self._analysis_class_map:
             return
-        self.logArea.setText(f"Running {analysis_name}...")
-        page_data = self._execute_analysis(analysis_class, analysis_name)
-        if page_data:
-            self.analysis_results_pages.append(page_data)
+        page = self._execute_analysis(self._analysis_class_map[name], name)
+        if page is not None:
             self.switch_plot_page(len(self.analysis_results_pages) - 1)
-            self.logArea.append(f"{analysis_name} run complete.")
 
     @Slot()
     def run_all_analysis_slot(self):
-        self.logArea.append("Run All: Not yet implemented.")
+        entries = [
+            {
+                "target": p["page_id"],
+                "name": p["name"],
+                "constructor_args": p["constructor_args_used"],
+                "view_args": p["view_args"],
+                "theme": self.current_theme,
+            }
+            for p in self.analysis_results_pages
+        ]
+        try:
+            self.runner.run_batch(entries, self.connector.get_optic())
+        except Exception as exc:
+            self._notify_analysis_error(str(exc))
 
     @Slot()
     def stop_analysis_slot(self):
-        self.logArea.append("Stop: Not yet implemented.")
+        self.runner.stop()
 
     @Slot()
     def _save_analysis_settings_slot(self):

--- a/optiland_gui/analysis_panel.py
+++ b/optiland_gui/analysis_panel.py
@@ -923,6 +923,10 @@ class AnalysisPanel(QWidget):
         if analysis_name not in self._analysis_class_map:
             return  # category header or unrecognised item — skip
         self._update_settings_ui(analysis_name)
+        if 0 <= self.current_plot_page_index < len(self.analysis_results_pages):
+            page = self.analysis_results_pages[self.current_plot_page_index]
+            if page["name"] == analysis_name:
+                self._populate_settings_from_page_data(page)
         if self.current_plot_page_index == -1 or not self.analysis_results_pages:
             self.plotTitleLabel.setText(analysis_name)
 
@@ -996,6 +1000,7 @@ class AnalysisPanel(QWidget):
             "page_id": uuid.uuid4().hex,
             "constructor_args_used": copy.deepcopy(original["constructor_args_used"]),
             "view_args": copy.deepcopy(original["view_args"]),
+            "draft_settings": copy.deepcopy(original.get("draft_settings")),
             "state": "succeeded" if original.get("prepared") else "idle",
             "error": "",
         }
@@ -1105,6 +1110,47 @@ class AnalysisPanel(QWidget):
                 widget.blockSignals(True)
                 self._set_widget_value(widget, page_args[param_name], param_name)
                 widget.blockSignals(False)
+        self._restore_settings_draft(page_data.get("draft_settings") or {})
+
+    def _capture_settings_draft(self):
+        """Keep raw editor values, including incomplete text, without validation."""
+        draft = {}
+        for name, widget in self.current_settings_widgets.items():
+            if isinstance(widget, QLineEdit):
+                draft[name] = widget.text()
+            elif isinstance(widget, QComboBox):
+                draft[name] = (
+                    widget.currentText(),
+                    copy.deepcopy(widget.currentData()),
+                )
+            elif isinstance(widget, QCheckBox):
+                draft[name] = widget.isChecked()
+            elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
+                draft[name] = widget.value()
+        return draft
+
+    def _restore_settings_draft(self, draft):
+        """Restore pending inputs without changing submitted/result settings."""
+        for name, value in draft.items():
+            widget = self.current_settings_widgets.get(name)
+            if widget is None:
+                continue
+            blocked = widget.blockSignals(True)
+            try:
+                if isinstance(widget, QLineEdit):
+                    widget.setText(value)
+                elif isinstance(widget, QComboBox):
+                    text, data = value
+                    index = widget.findData(data) if data is not None else -1
+                    widget.setCurrentIndex(
+                        index if index != -1 else widget.findText(text)
+                    )
+                elif isinstance(widget, QCheckBox):
+                    widget.setChecked(value)
+                elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):
+                    widget.setValue(value)
+            finally:
+                widget.blockSignals(blocked)
 
     # --- Load/Save Settings ---
     def _apply_loaded_settings_to_ui(self, loaded_settings):
@@ -1342,6 +1388,7 @@ class AnalysisPanel(QWidget):
             page = self.analysis_results_pages[self.current_plot_page_index]
             if page["name"] == self.analysisTypeCombo.currentText():
                 page["settings_dirty"] = True
+                page["draft_settings"] = self._capture_settings_draft()
                 self._update_page_status(page)
 
     def closeEvent(self, event):
@@ -1600,6 +1647,7 @@ class AnalysisPanel(QWidget):
             error="",
             requested_token=request.document,
             settings_dirty=False,
+            draft_settings=None,
         )
         if new_page:
             self.analysis_results_pages.append(page)
@@ -1735,6 +1783,7 @@ class AnalysisPanel(QWidget):
                     f"Settings loaded from {filepath}. "
                     "Click 'Apply' or 'Run' to see results."
                 )
+                self._settings_edited()
 
             except Exception as e:
                 msg = f"Could not load or apply settings:\n{e}"

--- a/optiland_gui/analysis_panel.py
+++ b/optiland_gui/analysis_panel.py
@@ -845,13 +845,17 @@ class AnalysisPanel(QWidget):
 
     def _set_line_edit_value(self, widget, value):
         """Sets the text of a QLineEdit, handling tuples."""
-        text = ", ".join(map(str, value)) if isinstance(value, tuple) else str(value)
+        text = (
+            ", ".join(map(str, value))
+            if isinstance(value, (tuple, list))
+            else str(value)
+        )
         widget.setText(text)
 
     def _set_combobox_value(self, widget, value, param_name):
         """Sets the value of a QComboBox, dispatching to a special handler if needed."""
         if param_name in ["fields", "wavelengths", "wavelength"]:
-            self._set_special_combobox_value(widget, value)
+            self._set_special_combobox_value(widget, value, param_name)
         elif param_name == "axis":
             widget.setCurrentIndex(0 if value == 1 else 1)
         else:
@@ -859,16 +863,29 @@ class AnalysisPanel(QWidget):
             if index != -1:
                 widget.setCurrentIndex(index)
 
-    def _set_special_combobox_value(self, widget, value):
+    def _set_special_combobox_value(self, widget, value, param_name):
         """Sets the value for a QComboBox that uses itemData."""
+        if (
+            param_name == "fields"
+            and isinstance(value, list)
+            and all(isinstance(field, (list, tuple)) for field in value)
+        ):
+            # JSON arrays preserve the selected field coordinates but not tuple types.
+            value = [tuple(field) for field in value]
         for i in range(widget.count()):
             try:
                 item_data = ast.literal_eval(widget.itemData(i) or "None")
-                if item_data == value:
-                    widget.setCurrentIndex(i)
-                    return
             except (ValueError, SyntaxError):
-                continue
+                item_data = widget.itemData(i)
+            if (
+                param_name == "wavelength"
+                and isinstance(item_data, list)
+                and len(item_data) == 1
+            ):
+                item_data = item_data[0]
+            if item_data == value:
+                widget.setCurrentIndex(i)
+                return
 
     def _set_widget_value(self, widget, value, param_name: str):
         """
@@ -896,17 +913,6 @@ class AnalysisPanel(QWidget):
         # If a handler is found, call it with the required arguments
         if handler:
             handler(widget, value, param_name)
-
-    def _set_combobox_value(self, widget, value, param_name):
-        """Sets the value for a QComboBox based on parameter type."""
-        if param_name in ["fields", "wavelengths", "wavelength"]:
-            self._set_special_combobox_value(widget, value)
-        elif param_name == "axis":
-            widget.setCurrentIndex(0 if value == 1 else 1)
-        else:
-            index = widget.findText(str(value))
-            if index != -1:
-                widget.setCurrentIndex(index)
 
     @Slot(str)
     def on_analysis_type_changed(self, analysis_name: str):
@@ -1156,8 +1162,8 @@ class AnalysisPanel(QWidget):
     def _apply_loaded_settings_to_ui(self, loaded_settings):
         """Applies settings loaded from a file to the current UI widgets."""
         analysis_name = loaded_settings.get("analysis_name")
-        if not analysis_name:
-            raise ValueError("Settings file does not contain an 'analysis_name'.")
+        if analysis_name not in self._analysis_class_map:
+            raise ValueError("Settings file must name a supported analysis.")
 
         self.analysisTypeCombo.setCurrentText(analysis_name)
         self.on_analysis_type_changed(
@@ -1172,36 +1178,14 @@ class AnalysisPanel(QWidget):
         for param_name, value in all_args.items():
             if param_name in self.current_settings_widgets:
                 widget = self.current_settings_widgets[param_name]
-                self._set_widget_value(widget, value)
-
-    @Slot()
-    def _load_analysis_settings_slot(self):
-        """Loads and applies settings for an analysis from a JSON file."""
-        filepath, _ = QFileDialog.getOpenFileName(
-            self, "Load Analysis Settings", "", self.JSON_FILE_FILTER
-        )
-        if not filepath:
-            return
-
-        try:
-            with open(filepath, encoding="utf-8") as f:
-                loaded_settings = json.load(f)
-            self._apply_loaded_settings_to_ui(loaded_settings)
-            self.logArea.append(
-                f"Settings loaded from {filepath}. Click 'Apply' or 'Run' "
-                "to see results."
-            )
-        except Exception as e:
-            QMessageBox.critical(
-                self, "Load Error", f"Could not load or apply settings:\n{e}"
-            )
+                self._set_widget_value(widget, value, param_name)
+        self._settings_edited()
 
     def _create_new_plot_canvas(self, page_data):
         """Creates a new FigureCanvas and connects mouse interaction events."""
         fig = Figure(figsize=page_data.get("figsize", (7, 5)), dpi=100)
         canvas = FigureCanvas(fig)
         canvas.setFocusPolicy(Qt.FocusPolicy.ClickFocus | Qt.FocusPolicy.StrongFocus)
-        canvas.setFocus()
 
         # Connect events and store their IDs for later disconnection
         cids = [
@@ -1755,35 +1739,12 @@ class AnalysisPanel(QWidget):
                 with open(filepath, encoding="utf-8") as f:
                     loaded_settings = json.load(f)
 
-                analysis_name = loaded_settings.get("analysis_name")
-                self.analysisTypeCombo.setCurrentText(analysis_name)
-
-                # Apply the loaded settings to the UI widgets
-                self.on_analysis_type_changed(analysis_name)
-
-                all_args = {
-                    **loaded_settings.get("constructor_args", {}),
-                    **loaded_settings.get("view_args", {}),
-                }
-                for param_name, value in all_args.items():
-                    if param_name in self.current_settings_widgets:
-                        widget = self.current_settings_widgets[param_name]
-                        if isinstance(widget, QComboBox):
-                            index = widget.findData(str(value))
-                            if index != -1:
-                                widget.setCurrentIndex(index)
-                        elif isinstance(widget, QSpinBox | QDoubleSpinBox):
-                            widget.setValue(value)
-                        elif isinstance(widget, QCheckBox):
-                            widget.setChecked(value)
-                        elif isinstance(widget, QLineEdit):
-                            widget.setText(str(value))
+                self._apply_loaded_settings_to_ui(loaded_settings)
 
                 self.logArea.append(
                     f"Settings loaded from {filepath}. "
                     "Click 'Apply' or 'Run' to see results."
                 )
-                self._settings_edited()
 
             except Exception as e:
                 msg = f"Could not load or apply settings:\n{e}"

--- a/optiland_gui/services/analysis_plots.py
+++ b/optiland_gui/services/analysis_plots.py
@@ -1,0 +1,315 @@
+"""Plain plot data for the finite set of two-dimensional GUI analyses.
+
+The worker executes numerical ``view`` preparation. Only arrays, text and style
+values cross the process boundary; no Figure, Artist or optical object does.
+Unsupported artist families fail explicitly rather than silently dropping data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from matplotlib import colors
+from matplotlib.collections import LineCollection, PathCollection, QuadMesh
+from matplotlib.lines import Line2D
+from matplotlib.patches import PathPatch
+from matplotlib.path import Path
+
+if TYPE_CHECKING:
+    from matplotlib.artist import Artist
+    from matplotlib.axes import Axes
+    from matplotlib.colorizer import ColorizingArtist
+    from matplotlib.figure import Figure
+    from matplotlib.text import Text
+    from matplotlib.transforms import Transform
+
+
+def _array(value: Any) -> np.ndarray:
+    return np.array(np.ma.filled(value, np.nan), copy=True)
+
+
+def _style(artist: Artist) -> dict:
+    return {
+        "alpha": artist.get_alpha(),
+        "zorder": artist.get_zorder(),
+        "label": artist.get_label(),
+    }
+
+
+def _text(text: Text, transform: Transform) -> dict:
+    position = transform.inverted().transform(
+        text.get_transform().transform(text.get_position())
+    )
+    return {
+        "position": tuple(position),
+        "text": text.get_text(),
+        "fontsize": text.get_fontsize(),
+        "ha": text.get_ha(),
+        "va": text.get_va(),
+        "rotation": text.get_rotation(),
+    }
+
+
+def _normalization(artist: ColorizingArtist) -> dict:
+    norm = artist.norm
+    if type(norm) not in (colors.Normalize, colors.LogNorm):
+        raise ValueError(
+            f"Unsupported analysis color normalization: {type(norm).__name__}"
+        )
+    return {
+        "log": isinstance(norm, colors.LogNorm),
+        "vmin": norm.vmin,
+        "vmax": norm.vmax,
+        "cmap": artist.get_cmap().name,
+    }
+
+
+def _legend(ax: Axes) -> dict | None:
+    legend = ax.get_legend()
+    if legend is None:
+        return None
+    handles = []
+    for handle, label in zip(legend.legend_handles, legend.get_texts(), strict=True):
+        style = {"label": label.get_text()}
+        if isinstance(handle, Line2D):
+            style.update(
+                color=handle.get_color(),
+                linestyle=handle.get_linestyle(),
+                linewidth=handle.get_linewidth(),
+                marker=handle.get_marker(),
+                markersize=handle.get_markersize(),
+            )
+        elif isinstance(handle, PathCollection):
+            style.update(color=handle.get_facecolors()[0], marker="o", linestyle="None")
+        else:
+            raise ValueError(f"Unsupported analysis legend: {type(handle).__name__}")
+        handles.append(style)
+    anchor = legend.get_bbox_to_anchor().transformed(ax.transAxes.inverted())
+    return {"handles": handles, "location": legend._loc, "anchor": tuple(anchor.bounds)}
+
+
+def capture_analysis_plot(figure: Figure) -> dict:
+    """Extract the registered analyses' line, spot, pupil and image plot families."""
+    figure.canvas.draw()
+    result = {
+        "figsize": tuple(figure.get_size_inches()),
+        "axes": [],
+        "texts": [_text(t, figure.transFigure) for t in figure.texts],
+    }
+    for ax in figure.axes:
+        if ax.name != "rectilinear":
+            raise ValueError("Analysis pages currently support 2D projections only.")
+        axis = {
+            "position": tuple(ax.get_position().bounds),
+            "xlim": ax.get_xlim(),
+            "ylim": ax.get_ylim(),
+            "xscale": ax.get_xscale(),
+            "yscale": ax.get_yscale(),
+            "aspect": ax.get_aspect(),
+            "title": ax.get_title(),
+            "xlabel": ax.get_xlabel(),
+            "ylabel": ax.get_ylabel(),
+            "visible": ax.axison,
+            "grid": any(line.get_visible() for line in ax.get_xgridlines()),
+            "lines": [],
+            "patches": [],
+            "collections": [],
+            "images": [],
+            "texts": [_text(t, ax.transAxes) for t in ax.texts],
+            "legend": _legend(ax),
+            "colorbar": hasattr(ax, "_colorbar"),
+        }
+        for line in ax.lines:
+            if not line.get_visible():
+                continue
+            xy = ax.transData.inverted().transform(
+                line.get_transform().transform(line.get_xydata())
+            )
+            axis["lines"].append(
+                {
+                    "xy": xy.copy(),
+                    "color": line.get_color(),
+                    "linewidth": line.get_linewidth(),
+                    "linestyle": line.get_linestyle(),
+                    "marker": line.get_marker(),
+                    "markersize": line.get_markersize(),
+                    **_style(line),
+                }
+            )
+        for patch in ax.patches:
+            if not patch.get_visible():
+                continue
+            path = patch.get_path().transformed(patch.get_transform() - ax.transData)
+            axis["patches"].append(
+                {
+                    "vertices": path.vertices.copy(),
+                    "codes": None if path.codes is None else path.codes.copy(),
+                    "facecolor": patch.get_facecolor(),
+                    "edgecolor": patch.get_edgecolor(),
+                    "linewidth": patch.get_linewidth(),
+                    "linestyle": patch.get_linestyle(),
+                    **_style(patch),
+                }
+            )
+        for collection in ax.collections:
+            if not collection.get_visible():
+                continue
+            item = {
+                **_style(collection),
+                "facecolors": collection.get_facecolors().copy(),
+                "edgecolors": collection.get_edgecolors().copy(),
+                "linewidths": collection.get_linewidths().copy(),
+            }
+            if isinstance(collection, QuadMesh):
+                item.update(
+                    kind="mesh",
+                    coordinates=collection.get_coordinates().copy(),
+                    values=_array(collection.get_array()),
+                    **_normalization(collection),
+                )
+            elif isinstance(collection, PathCollection):
+                item.update(
+                    kind="scatter",
+                    offsets=_array(collection.get_offsets()),
+                    sizes=collection.get_sizes().copy(),
+                    paths=[
+                        (p.vertices.copy(), None if p.codes is None else p.codes.copy())
+                        for p in collection.get_paths()
+                    ],
+                )
+            elif isinstance(collection, LineCollection):
+                item.update(
+                    kind="segments",
+                    segments=[_array(s) for s in collection.get_segments()],
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported analysis artist: {type(collection).__name__}"
+                )
+            axis["collections"].append(item)
+        for im in ax.images:
+            axis["images"].append(
+                {
+                    "values": _array(im.get_array()),
+                    "extent": tuple(im.get_extent()),
+                    "origin": im.origin,
+                    "interpolation": im.get_interpolation(),
+                    **_normalization(im),
+                    **_style(im),
+                }
+            )
+        result["axes"].append(axis)
+    return result
+
+
+def _norm(item: dict) -> colors.Normalize:
+    cls = colors.LogNorm if item["log"] else colors.Normalize
+    return cls(vmin=item["vmin"], vmax=item["vmax"])
+
+
+def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> None:
+    """Install detached geometry on the GUI-owned figure without optical work."""
+    from optiland_gui.gui_plot_utils import apply_gui_matplotlib_styles
+
+    apply_gui_matplotlib_styles(theme)
+    figure.clear()
+    dark = "dark" in theme.lower()
+    foreground = "#dddddd" if dark else "#222222"
+    background = "#1e1e1e" if dark else "white"
+    figure.set_facecolor(background)
+    for data in prepared["axes"]:
+        ax = figure.add_axes(data["position"])
+        ax.set_facecolor(background)
+        for item in data["lines"]:
+            style = {k: v for k, v in item.items() if k != "xy"}
+            ax.plot(*item["xy"].T, **style)
+        for item in data["patches"]:
+            style = {k: v for k, v in item.items() if k not in ("vertices", "codes")}
+            ax.add_patch(PathPatch(Path(item["vertices"], item["codes"]), **style))
+        for item in data["collections"]:
+            style = {
+                k: item[k]
+                for k in (
+                    "alpha",
+                    "zorder",
+                    "label",
+                    "facecolors",
+                    "edgecolors",
+                    "linewidths",
+                )
+            }
+            if item["kind"] == "scatter":
+                collection = PathCollection(
+                    [Path(*p) for p in item["paths"]],
+                    sizes=item["sizes"],
+                    offsets=item["offsets"],
+                    offset_transform=ax.transData,
+                    **style,
+                )
+                # Scatter marker paths are in points; offsets are data coordinates.
+                from matplotlib.transforms import IdentityTransform
+
+                collection.set_transform(IdentityTransform())
+                ax.add_collection(collection)
+            elif item["kind"] == "segments":
+                ax.add_collection(LineCollection(item["segments"], **style))
+            else:
+                coords = item["coordinates"]
+                ax.pcolormesh(
+                    coords[..., 0],
+                    coords[..., 1],
+                    item["values"],
+                    cmap=item["cmap"],
+                    norm=_norm(item),
+                    shading="flat",
+                )
+        for item in data["images"]:
+            ax.imshow(
+                item["values"],
+                extent=item["extent"],
+                origin=item["origin"],
+                interpolation=item["interpolation"],
+                cmap=item["cmap"],
+                norm=_norm(item),
+            )
+        for item in data["texts"]:
+            style = {k: v for k, v in item.items() if k not in ("position", "text")}
+            ax.text(
+                *item["position"],
+                item["text"],
+                transform=ax.transAxes,
+                color=foreground,
+                **style,
+            )
+        ax.set(
+            xscale=data["xscale"],
+            yscale=data["yscale"],
+            xlim=data["xlim"],
+            ylim=data["ylim"],
+            aspect=data["aspect"],
+            title=data["title"],
+            xlabel=data["xlabel"],
+            ylabel=data["ylabel"],
+        )
+        ax.tick_params(colors=foreground)
+        ax.xaxis.label.set_color(foreground)
+        ax.yaxis.label.set_color(foreground)
+        ax.title.set_color(foreground)
+        if not data["visible"]:
+            ax.set_axis_off()
+        ax.grid(data["grid"])
+        if data["legend"]:
+            legend = data["legend"]
+            ax.legend(
+                handles=[Line2D([], [], **style) for style in legend["handles"]],
+                loc=legend["location"],
+                bbox_to_anchor=legend["anchor"],
+            )
+        if data["colorbar"]:
+            ax.yaxis.set_ticks_position("right")
+            ax.yaxis.set_label_position("right")
+            ax.set_xticks([])
+    for item in prepared["texts"]:
+        style = {k: v for k, v in item.items() if k not in ("position", "text")}
+        figure.text(*item["position"], item["text"], color=foreground, **style)

--- a/optiland_gui/services/analysis_plots.py
+++ b/optiland_gui/services/analysis_plots.py
@@ -18,9 +18,9 @@ from matplotlib.path import Path
 
 if TYPE_CHECKING:
     from matplotlib.artist import Artist
-    from matplotlib.axes import Axes
     from matplotlib.colorizer import ColorizingArtist
     from matplotlib.figure import Figure
+    from matplotlib.legend import Legend
     from matplotlib.text import Text
     from matplotlib.transforms import Transform
 
@@ -65,8 +65,7 @@ def _normalization(artist: ColorizingArtist) -> dict:
     }
 
 
-def _legend(ax: Axes) -> dict | None:
-    legend = ax.get_legend()
+def _legend(legend: Legend | None, transform: Transform) -> dict | None:
     if legend is None:
         return None
     handles = []
@@ -85,8 +84,14 @@ def _legend(ax: Axes) -> dict | None:
         else:
             raise ValueError(f"Unsupported analysis legend: {type(handle).__name__}")
         handles.append(style)
-    anchor = legend.get_bbox_to_anchor().transformed(ax.transAxes.inverted())
-    return {"handles": handles, "location": legend._loc, "anchor": tuple(anchor.bounds)}
+    anchor = legend.get_bbox_to_anchor().transformed(transform.inverted())
+    return {
+        "handles": handles,
+        "location": legend._loc,
+        "anchor": tuple(anchor.bounds),
+        "ncols": legend._ncols,
+        "title": legend.get_title().get_text(),
+    }
 
 
 def capture_analysis_plot(figure: Figure) -> dict:
@@ -96,6 +101,7 @@ def capture_analysis_plot(figure: Figure) -> dict:
         "figsize": tuple(figure.get_size_inches()),
         "axes": [],
         "texts": [_text(t, figure.transFigure) for t in figure.texts],
+        "legends": [_legend(legend, figure.transFigure) for legend in figure.legends],
     }
     for ax in figure.axes:
         if ax.name != "rectilinear":
@@ -117,7 +123,7 @@ def capture_analysis_plot(figure: Figure) -> dict:
             "collections": [],
             "images": [],
             "texts": [_text(t, ax.transAxes) for t in ax.texts],
-            "legend": _legend(ax),
+            "legend": _legend(ax.get_legend(), ax.transAxes),
             "colorbar": hasattr(ax, "_colorbar"),
         }
         for line in ax.lines:
@@ -182,6 +188,9 @@ def capture_analysis_plot(figure: Figure) -> dict:
                 item.update(
                     kind="segments",
                     segments=[_array(s) for s in collection.get_segments()],
+                    # get_linestyles() has already scaled dashes by linewidth;
+                    # constructors require the original patterns to avoid scaling twice.
+                    linestyles=collection._us_linestyles,
                 )
             else:
                 raise ValueError(
@@ -189,6 +198,8 @@ def capture_analysis_plot(figure: Figure) -> dict:
                 )
             axis["collections"].append(item)
         for im in ax.images:
+            if not im.get_visible():
+                continue
             axis["images"].append(
                 {
                     "values": _array(im.get_array()),
@@ -253,7 +264,11 @@ def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> N
                 collection.set_transform(IdentityTransform())
                 ax.add_collection(collection)
             elif item["kind"] == "segments":
-                ax.add_collection(LineCollection(item["segments"], **style))
+                ax.add_collection(
+                    LineCollection(
+                        item["segments"], linestyles=item["linestyles"], **style
+                    )
+                )
             else:
                 coords = item["coordinates"]
                 ax.pcolormesh(
@@ -263,6 +278,9 @@ def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> N
                     cmap=item["cmap"],
                     norm=_norm(item),
                     shading="flat",
+                    alpha=item["alpha"],
+                    zorder=item["zorder"],
+                    label=item["label"],
                 )
         for item in data["images"]:
             ax.imshow(
@@ -272,6 +290,9 @@ def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> N
                 interpolation=item["interpolation"],
                 cmap=item["cmap"],
                 norm=_norm(item),
+                alpha=item["alpha"],
+                zorder=item["zorder"],
+                label=item["label"],
             )
         for item in data["texts"]:
             style = {k: v for k, v in item.items() if k not in ("position", "text")}
@@ -305,6 +326,8 @@ def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> N
                 handles=[Line2D([], [], **style) for style in legend["handles"]],
                 loc=legend["location"],
                 bbox_to_anchor=legend["anchor"],
+                ncols=legend["ncols"],
+                title=legend["title"],
             )
         if data["colorbar"]:
             ax.yaxis.set_ticks_position("right")
@@ -313,3 +336,11 @@ def draw_analysis_plot(figure: Figure, prepared: dict, theme: str = "dark") -> N
     for item in prepared["texts"]:
         style = {k: v for k, v in item.items() if k not in ("position", "text")}
         figure.text(*item["position"], item["text"], color=foreground, **style)
+    for legend in prepared["legends"]:
+        figure.legend(
+            handles=[Line2D([], [], **style) for style in legend["handles"]],
+            loc=legend["location"],
+            bbox_to_anchor=legend["anchor"],
+            ncols=legend["ncols"],
+            title=legend["title"],
+        )

--- a/optiland_gui/services/analysis_runner.py
+++ b/optiland_gui/services/analysis_runner.py
@@ -258,14 +258,7 @@ class AnalysisRunner(QObject):
         del self._requests[target]
         self._last_result = result
         self.finished.emit(target, result)
-        if result.status == "failed" and any(
-            text in result.error
-            for text in (
-                "worker exited unexpectedly",
-                "Could not start the calculation worker",
-                "Invalid calculation-worker message size",
-            )
-        ):
+        if result.status == "failed" and result.infrastructure_error:
             self.stop()
         if self._batch_target == target:
             self._batch_target = None

--- a/optiland_gui/services/analysis_runner.py
+++ b/optiland_gui/services/analysis_runner.py
@@ -1,18 +1,33 @@
 """Analysis runner service for the Optiland GUI.
 
-Handles analysis class discovery via :mod:`optiland_gui.registry` and provides
-execution lifecycle stubs that forward to the :class:`AnalysisPanel`.
+Discovers registered classes and schedules explicit analyses through the shared
+calculation service. Neither construction nor plotting runs on the GUI thread.
 """
 
 from __future__ import annotations
 
+import copy
 import importlib
 import logging
+from collections import deque
+
+from PySide6.QtCore import QObject, QTimer, Signal, Slot
+
+from optiland_gui.services.analysis_worker import (
+    normalized_parameters,
+    validate_workload,
+)
+from optiland_gui.services.job_records import (
+    DocumentToken,
+    JobRequest,
+    JobResult,
+    OpticSnapshot,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class AnalysisRunner:
+class AnalysisRunner(QObject):
     """Manages analysis discovery and the execution lifecycle.
 
     Analysis classes are loaded lazily from
@@ -26,9 +41,27 @@ class AnalysisRunner:
             instance that owns this service.
     """
 
+    state_changed = Signal(str, str)
+    finished = Signal(str, object)
+    busy_changed = Signal(bool)
+    progress = Signal(str, str)
+
     def __init__(self, connector: object) -> None:
+        super().__init__(connector if isinstance(connector, QObject) else None)
         self._connector = connector
         self._registry_cache: list[tuple[str, str, type]] | None = None
+        self.jobs = connector.calculation_jobs
+        self._requests = {}
+        self._last_result = None
+        self._batch = deque()
+        self._batch_target = None
+        self._batch_snapshot = None
+        self._batch_token = None
+        self._document_id = connector.document_state.token.document_id
+        self.jobs.state_changed.connect(self._state_changed)
+        self.jobs.finished.connect(self._finished)
+        self.jobs.progress.connect(self._progress)
+        connector.document_state.changed.connect(self._document_changed)
 
     # ------------------------------------------------------------------
     # Registry
@@ -71,7 +104,7 @@ class AnalysisRunner:
         return self._registry_cache
 
     # ------------------------------------------------------------------
-    # Execution lifecycle stubs
+    # Explicit jobs use the shared executor and immutable prescription snapshots.
     # ------------------------------------------------------------------
 
     def run(
@@ -79,7 +112,13 @@ class AnalysisRunner:
         analysis_name: str,
         params: dict,
         optic: object,
-    ) -> None:
+        *,
+        target: str = "analysis",
+        view_args: dict | None = None,
+        theme: str = "dark",
+        snapshot: OpticSnapshot | None = None,
+        document_token: DocumentToken | None = None,
+    ) -> JobRequest:
         """Execute a named analysis with the given parameters.
 
         Args:
@@ -89,14 +128,171 @@ class AnalysisRunner:
                 analysis class constructor.
             optic: The :class:`~optiland.optic.Optic` instance to analyse.
         """
+        args = normalized_parameters(analysis_name, params)
+        validate_workload(
+            analysis_name,
+            args,
+            view_args or {},
+            optic.surfaces.num_surfaces,
+            optic.fields.num_fields,
+            optic.wavelengths.num_wavelengths,
+        )
+        snapshot = snapshot or OpticSnapshot.capture(optic)
+        # An explicit rerun supersedes this page's not-yet-dispatched batch entry.
+        self._batch = deque(e for e in self._batch if e["target"] != target)
+        request = self.jobs.submit(
+            target,
+            "optiland_gui.services.analysis_worker:prepare_analysis",
+            snapshot,
+            {
+                "name": analysis_name,
+                "constructor_args": args,
+                "view_args": view_args or {},
+                "theme": theme,
+            },
+            cancel_on_document_change=False,
+            document_token=document_token,
+        )
+        self._requests[target] = request
+        self.state_changed.emit(target, "queued")
+        self.busy_changed.emit(True)
+        return request
+
+    @property
+    def busy(self) -> bool:
+        return bool(self._requests or self._batch)
+
+    def run_batch(self, entries: list[dict], optic: object) -> None:
+        """Freeze existing configured pages once, then submit one entry at a time."""
+        if self.busy:
+            raise ValueError(
+                "Wait for analysis jobs to finish or stop them before Run All."
+            )
+        if not entries:
+            return
+        if len(entries) > 16:
+            raise ValueError("Run All supports at most 16 configured analysis pages.")
+        # Validate every entry before starting any work.
+        frozen = []
+        for entry in entries:
+            args = normalized_parameters(entry["name"], entry["constructor_args"])
+            validate_workload(
+                entry["name"],
+                args,
+                entry["view_args"],
+                optic.surfaces.num_surfaces,
+                optic.fields.num_fields,
+                optic.wavelengths.num_wavelengths,
+            )
+            frozen.append(copy.deepcopy({**entry, "constructor_args": args}))
+        self._batch_snapshot = OpticSnapshot.capture(optic)
+        self._batch_token = self._connector.document_state.token
+        self._batch = deque(frozen)
+        for entry in frozen:
+            self.state_changed.emit(entry["target"], "queued")
+        self.busy_changed.emit(True)
+        QTimer.singleShot(0, self._dispatch_batch)
+
+    @Slot()
+    def _dispatch_batch(self) -> None:
+        if self._batch_target is not None:
+            return
+        if not self._batch:
+            self._batch_snapshot = None
+            self._batch_token = None
+            self.busy_changed.emit(self.busy)
+            return
+        entry = self._batch.popleft()
+        target = entry["target"]
+        self._batch_target = target
+        try:
+            # Validation already used the captured prescription. Do not inspect
+            # a later edited optical model when dispatching the next batch entry.
+            request = self.jobs.submit(
+                target,
+                "optiland_gui.services.analysis_worker:prepare_analysis",
+                self._batch_snapshot,
+                {
+                    "name": entry["name"],
+                    "constructor_args": entry["constructor_args"],
+                    "view_args": entry["view_args"],
+                    "theme": entry["theme"],
+                },
+                cancel_on_document_change=False,
+                document_token=self._batch_token,
+            )
+            self._requests[target] = request
+        except RuntimeError as exc:
+            if "queue is full" in str(exc):
+                self._batch.appendleft(entry)
+                self._batch_target = None
+                QTimer.singleShot(100, self._dispatch_batch)
+            else:
+                request = JobRequest(0, self._batch_token, target, 0, "", None, {})
+                self.finished.emit(target, JobResult(request, "failed", error=str(exc)))
+                self._batch_target = None
+                self.stop()
+
+    def cancel(self, target: str) -> None:
+        """Revoke a page even if it is still waiting in the frozen batch."""
+        self._batch = deque(e for e in self._batch if e["target"] != target)
+        self.jobs.cancel_target(target)
+        self.state_changed.emit(target, "cancelled")
+        self.busy_changed.emit(self.busy)
+
+    @Slot(object, str)
+    def _state_changed(self, request: JobRequest, state: str) -> None:
+        if self._requests.get(request.target) is request:
+            self.state_changed.emit(request.target, state)
+
+    @Slot(object, dict)
+    def _progress(self, request: JobRequest, data: dict) -> None:
+        if self._requests.get(request.target) is request:
+            self.progress.emit(request.target, data["stage"])
+
+    @Slot(object)
+    def _finished(self, result: JobResult) -> None:
+        target = result.request.target
+        if self._requests.get(target) is not result.request:
+            return
+        del self._requests[target]
+        self._last_result = result
+        self.finished.emit(target, result)
+        if result.status == "failed" and any(
+            text in result.error
+            for text in (
+                "worker exited unexpectedly",
+                "Could not start the calculation worker",
+                "Invalid calculation-worker message size",
+            )
+        ):
+            self.stop()
+        if self._batch_target == target:
+            self._batch_target = None
+            QTimer.singleShot(0, self._dispatch_batch)
+        self.busy_changed.emit(self.busy)
+
+    @Slot(object)
+    def _document_changed(self, token: DocumentToken) -> None:
+        if token.document_id != self._document_id:
+            self._document_id = token.document_id
+            self.stop()
 
     def stop(self) -> None:
         """Request cancellation of an in-progress analysis run."""
+        pending, self._batch = self._batch, deque()
+        for entry in pending:
+            self.state_changed.emit(entry["target"], "cancelled")
+        for target in list(self._requests):
+            self.jobs.cancel_target(target)
+        self._batch_snapshot = None
+        self._batch_token = None
+        self.busy_changed.emit(self.busy)
 
     def get_result(self) -> object | None:
         """Return the result of the most recent analysis run.
 
         Returns:
-            ``None`` until background analysis execution is fully wired up.
+            The most recent detached result, or ``None`` before a job completes.
         """
-        return None
+        return self._last_result

--- a/optiland_gui/services/analysis_worker.py
+++ b/optiland_gui/services/analysis_worker.py
@@ -1,0 +1,231 @@
+"""Worker-only preparation of every analysis exposed in the GUI registry."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pickle
+import warnings
+from typing import TYPE_CHECKING
+
+from optiland_gui.registry import ANALYSIS_REGISTRY
+from optiland_gui.services.job_records import OpticSnapshot, check_cancelled
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from threading import Event
+
+MAX_RESULT_BYTES = 64 * 1024 * 1024
+MAX_WORKING_BYTES = 512 * 1024 * 1024
+
+
+def resolve_analysis(name: str) -> type:
+    """Resolve a known registry name, never a user-provided import path."""
+    path = next((p for _, n, p in ANALYSIS_REGISTRY if n == name), None)
+    if path is None:
+        raise ValueError(f"Unknown analysis: {name}")
+    module, cls = path.rsplit(".", 1)
+    return getattr(importlib.import_module(module), cls)
+
+
+def constructor_parameters(cls: type) -> dict[str, inspect.Parameter]:
+    """Resolve factory signatures without constructing an optical calculation."""
+    params = inspect.signature(cls.__init__).parameters
+    variadic = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    if all(p.kind in variadic for k, p in params.items() if k != "self"):
+        params = inspect.signature(cls.__new__).parameters
+    return {
+        k: p
+        for k, p in params.items()
+        if k not in ("self", "cls", "optic") and p.kind not in variadic
+    }
+
+
+def normalized_parameters(name: str, supplied: dict) -> dict:
+    """Preserve supported core defaults and required field/wavelength inputs."""
+    params = constructor_parameters(resolve_analysis(name))
+    unknown = set(supplied) - set(params)
+    if unknown:
+        raise ValueError(f"Unsupported {name} settings: {', '.join(sorted(unknown))}")
+    result = {
+        k: p.default
+        for k, p in params.items()
+        if p.default is not inspect.Parameter.empty
+    }
+    result.update(supplied)
+    for key, value in {"field": (0.0, 0.0), "wavelength": "primary"}.items():
+        if key in params and key not in result:
+            result[key] = value
+    return result
+
+
+def validate_workload(
+    name: str, params: dict, view: dict, surfaces: int, fields: int, wavelengths: int
+) -> int:
+    """Reject unsafe GUI allocations using the parameters' actual dimensions.
+
+    This is a conservative working-set estimate, not a promise of peak memory.
+    No sampling settings are silently reduced; larger jobs can be run explicitly
+    through the scripting API. The isolated worker remains cancellable.
+    """
+    for key in (
+        "num_rays",
+        "num_points",
+        "num_rays_for_fit",
+        "num_rings",
+        "num_fields",
+        "num_steps",
+        "num_terms",
+        "grid_size",
+        "image_size",
+    ):
+        value = params.get(key)
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, int) or value < 1
+        ):
+            raise ValueError(f"{key} must be a positive integer.")
+    if view.get("projection", "2d") != "2d":
+        raise ValueError("Analysis pages currently support 2D projections only.")
+    n = params.get("num_rays", params.get("num_points", 1))
+    rings = params.get("num_rings")
+    distribution = params.get("distribution", "grid")
+    if rings is not None:
+        rays = 1 + 3 * rings * (rings + 1)
+    elif name in ("OPD Fan", "Ray Fan", "Best-Fit Ray Fan"):
+        rays = n
+    elif "PSF" in name or name == "FFT MTF" or distribution in ("grid", "hexapolar"):
+        rays = 4 * n * n
+    else:
+        rays = n
+    num_fields = params.get("num_fields", fields)
+    steps = params.get("num_steps", 1)
+    if (
+        name in ("Spot Diagram", "Ray Fan", "Best-Fit Ray Fan", "OPD Fan")
+        and num_fields > 32
+    ):
+        raise ValueError("This analysis display supports at most 32 fields per page.")
+    if name == "Through-Focus Spot" and num_fields * steps > 64:
+        raise ValueError(
+            "Through-focus display is limited to 64 field/focus plots; "
+            "reduce num_steps or fields."
+        )
+    grid = params.get("grid_size") or 2 * n
+    image = params.get("image_size") or grid
+    ray_bytes = rays * max(2, surfaces) * 12 * 8
+    retained_bytes = rays * max(1, num_fields) * max(1, wavelengths) * steps * 6 * 8
+    fit_rays = params.get("num_rays_for_fit", 0)
+    ray_bytes += 4 * fit_rays * fit_rays * max(2, surfaces) * 12 * 8
+    retained_bytes += rays * params.get("num_terms", 0) * 8
+    plot_points = view.get("num_points", 256)
+    if (
+        isinstance(plot_points, bool)
+        or not isinstance(plot_points, int)
+        or plot_points < 1
+    ):
+        raise ValueError("Plot num_points must be a positive integer.")
+    if (
+        name == "MMDFT PSF"
+        and params.get("pixel_pitch") is not None
+        and params.get("image_size") is None
+    ):
+        raise ValueError(
+            "Set an explicit image_size when specifying MMDFT pixel_pitch; "
+            "automatic sizing is unbounded."
+        )
+    image_bytes = 0
+    if "PSF" in name or name == "FFT MTF":
+        image_bytes = (grid * grid + image * image) * 16 * 12
+    if "PSF" in name or name in ("OPD", "Zernike OPD"):
+        image_bytes += plot_points * plot_points * 8 * 8
+    estimate = ray_bytes + retained_bytes + image_bytes
+    if estimate > MAX_WORKING_BYTES:
+        raise ValueError(
+            f"{name} settings require an estimated {estimate / 2**20:.0f} MiB "
+            "working set (GUI limit 512 MiB). Reduce pupil sampling, image/grid "
+            "size, fields or focus steps; no settings have been changed."
+        )
+    return estimate
+
+
+def prepare_analysis(
+    snapshot: OpticSnapshot,
+    parameters: dict,
+    progress: Callable[..., None],
+    cancelled: Event,
+) -> dict:
+    """Prepare detached data and preserve numerical warnings for the result page."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = _prepare_analysis(snapshot, parameters, progress, cancelled)
+    result["warnings"] = list(dict.fromkeys(str(w.message) for w in recorded))
+    return result
+
+
+def _prepare_analysis(
+    snapshot: OpticSnapshot,
+    parameters: dict,
+    progress: Callable[..., None],
+    cancelled: Event,
+) -> dict:
+    """Calculate and prepare plots entirely inside the shared isolated process."""
+    import matplotlib.pyplot as plt
+
+    from optiland_gui.gui_plot_utils import apply_gui_matplotlib_styles
+    from optiland_gui.services.analysis_plots import capture_analysis_plot
+
+    name = parameters["name"]
+    args = normalized_parameters(name, parameters["constructor_args"])
+    view = dict(parameters["view_args"])
+    progress("Restoring analysis snapshot")
+    optic = snapshot.restore()
+    validate_workload(
+        name,
+        args,
+        view,
+        optic.surfaces.num_surfaces,
+        optic.fields.num_fields,
+        optic.wavelengths.num_wavelengths,
+    )
+    check_cancelled(cancelled)
+    progress(f"Calculating {name}")
+    calculation_args = dict(args)
+    if name == "MMDFT PSF" and calculation_args.get("wavelength") == "primary":
+        calculation_args["wavelength"] = optic.wavelengths.primary_wavelength.value
+    analysis = resolve_analysis(name)(optic=optic, **calculation_args)
+    check_cancelled(cancelled)
+    progress("Preparing analysis plot")
+    apply_gui_matplotlib_styles(parameters.get("theme", "dark"))
+    figure = plt.figure(figsize=(7, 5.5))
+    try:
+        view_parameters = inspect.signature(analysis.view).parameters
+        unknown = set(view) - set(view_parameters)
+        if unknown:
+            raise ValueError(f"Unsupported plot settings: {', '.join(sorted(unknown))}")
+        if "fig_to_plot_on" not in view_parameters:
+            raise ValueError(f"{name} does not support prepared embedded plots.")
+        if "show" in view_parameters:
+            view["show"] = False
+        analysis.view(fig_to_plot_on=figure, **view)
+        check_cancelled(cancelled)
+        if len(figure.axes) > 64:
+            raise ValueError("Prepared analysis exceeds the 64-axis page limit.")
+        summary = (
+            analysis.get_summary_text() if hasattr(analysis, "get_summary_text") else ""
+        )
+        prepared = capture_analysis_plot(figure)
+        result = {
+            "plot": prepared,
+            "summary": summary,
+            "constructor_args": args,
+            "view_args": parameters["view_args"],
+        }
+        size = len(pickle.dumps(result, protocol=5))
+        if size > MAX_RESULT_BYTES:
+            raise ValueError(
+                "Prepared analysis exceeds the 64 MiB page limit; reduce plot sampling."
+            )
+        result["size_bytes"] = size
+        return result
+    finally:
+        plt.close(figure)

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -223,7 +223,7 @@ class CalculationJobs(QObject):
             self._send(request.worker_message())
         except Exception as exc:
             self._active = None
-            self._terminal(request, "failed", error=str(exc))
+            self._terminal(request, "failed", error=str(exc), infrastructure_error=True)
             QTimer.singleShot(0, self._dispatch)
             return
         self.state_changed.emit(request, "running")
@@ -308,7 +308,13 @@ class CalculationJobs(QObject):
             QTimer.singleShot(0, self._dispatch)
 
     def _terminal(
-        self, request: JobRequest, status: str, data: Any = None, error: str = ""
+        self,
+        request: JobRequest,
+        status: str,
+        data: Any = None,
+        error: str = "",
+        *,
+        infrastructure_error: bool = False,
     ) -> None:
         self.state_changed.emit(request, status)
         self.finished.emit(
@@ -318,6 +324,7 @@ class CalculationJobs(QObject):
                 data,
                 error,
                 status != "cancelled" and self.is_current(request),
+                infrastructure_error,
             )
         )
 
@@ -360,6 +367,7 @@ class CalculationJobs(QObject):
                 request,
                 "cancelled" if self._cancelling else "failed",
                 error=self._stderr or "Calculation worker exited unexpectedly.",
+                infrastructure_error=not self._cancelling,
             )
         elif not self._closed and self._pending:
             # A failed launch must not loop forever, or leave queued controls busy.
@@ -369,6 +377,7 @@ class CalculationJobs(QObject):
                     request,
                     "failed",
                     error=self._stderr or "Could not start the calculation worker.",
+                    infrastructure_error=True,
                 )
         self._cancelling = False
         if self._closed:

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -110,6 +110,7 @@ class CalculationJobs(QObject):
         *,
         replace: bool = True,
         cancel_on_document_change: bool = True,
+        document_token: DocumentToken | None = None,
         context: Any = None,
     ) -> JobRequest:
         """Queue detached inputs; replace previews while keeping explicit FIFO jobs."""
@@ -125,7 +126,7 @@ class CalculationJobs(QObject):
         generation = self._generations.setdefault(target, 0)
         request = JobRequest(
             self._serial,
-            self.document.token,
+            document_token if document_token is not None else self.document.token,
             target,
             generation,
             handler,

--- a/optiland_gui/services/job_records.py
+++ b/optiland_gui/services/job_records.py
@@ -188,6 +188,7 @@ class JobResult:
     data: Any = None
     error: str = ""
     current: bool = False
+    infrastructure_error: bool = False
 
 
 class CalculationCancelled(Exception):

--- a/tests/gui/analysis_job_fakes.py
+++ b/tests/gui/analysis_job_fakes.py
@@ -46,11 +46,23 @@ class ManualJobs(QObject):
         if request:
             self.finished.emit(JobResult(request, "cancelled"))
 
-    def complete(self, target, data=None, status="succeeded", error=""):
+    def complete(
+        self,
+        target,
+        data=None,
+        status="succeeded",
+        error="",
+        infrastructure_error=False,
+    ):
         request = self.requests.pop(target)
         self.finished.emit(
             JobResult(
-                request, status, data, error, request.document == self.document.token
+                request,
+                status,
+                data,
+                error,
+                request.document == self.document.token,
+                infrastructure_error,
             )
         )
 
@@ -71,7 +83,7 @@ def connector_for(optic):
 
 def result_data():
     return {
-        "plot": {"figsize": (7, 5), "axes": [], "texts": []},
+        "plot": {"figsize": (7, 5), "axes": [], "texts": [], "legends": []},
         "size_bytes": 100,
         "summary": "Completed data",
     }

--- a/tests/gui/analysis_job_fakes.py
+++ b/tests/gui/analysis_job_fakes.py
@@ -1,0 +1,77 @@
+"""Controllable shared executor for analysis page lifecycle tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from PySide6.QtCore import QObject, Signal
+
+from optiland_gui.services.analysis_runner import AnalysisRunner
+from optiland_gui.services.calculation_jobs import DocumentState
+from optiland_gui.services.job_records import JobRequest, JobResult
+
+
+class ManualJobs(QObject):
+    state_changed = Signal(object, str)
+    finished = Signal(object)
+    progress = Signal(object, dict)
+
+    def __init__(self, document):
+        super().__init__()
+        self.document = document
+        self.submissions = []
+        self.requests = {}
+        self.cancelled = []
+
+    def submit(self, target, handler, snapshot, parameters, **options):
+        self.cancel_target(target)
+        request = JobRequest(
+            len(self.submissions) + 1,
+            options.get("document_token") or self.document.token,
+            target,
+            0,
+            handler,
+            snapshot,
+            parameters,
+            options.get("cancel_on_document_change", True),
+        )
+        self.submissions.append(request)
+        self.requests[target] = request
+        return request
+
+    def cancel_target(self, target):
+        self.cancelled.append(target)
+        request = self.requests.pop(target, None)
+        if request:
+            self.finished.emit(JobResult(request, "cancelled"))
+
+    def complete(self, target, data=None, status="succeeded", error=""):
+        request = self.requests.pop(target)
+        self.finished.emit(
+            JobResult(
+                request, status, data, error, request.document == self.document.token
+            )
+        )
+
+
+def connector_for(optic):
+    state = DocumentState()
+    connector = SimpleNamespace(
+        document_state=state,
+        calculation_jobs=ManualJobs(state),
+        get_optic=lambda: optic,
+        toast_manager=Mock(),
+        get_field_options=lambda: [("All", "all")],
+        get_wavelength_options=lambda: [("Primary", "primary")],
+    )
+    connector._analysis_runner = AnalysisRunner(connector)
+    return connector
+
+
+def result_data():
+    return {
+        "plot": {"figsize": (7, 5), "axes": [], "texts": []},
+        "size_bytes": 100,
+        "summary": "Completed data",
+    }

--- a/tests/gui/calculation_worker_fixture.py
+++ b/tests/gui/calculation_worker_fixture.py
@@ -28,7 +28,13 @@ while header := sys.stdin.buffer.read(4):
     parameters = message["parameters"]
     send({"event": "progress", "job_id": job_id, "stage": "fixture"})
     if parameters.get("crash"):
+        if parameters.get("stderr"):
+            print(parameters["stderr"], file=sys.stderr, flush=True)
         os._exit(7)
+    if parameters.get("malformed"):
+        sys.stdout.buffer.write(struct.pack("!I", 2**32 - 1))
+        sys.stdout.buffer.flush()
+        time.sleep(30)
     time.sleep(parameters.get("delay", 0.01))
     send(
         {

--- a/tests/gui/test_analysis_jobs_process.py
+++ b/tests/gui/test_analysis_jobs_process.py
@@ -1,0 +1,97 @@
+"""Actual isolated numerical work while Qt keeps processing interactions."""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from PySide6.QtCore import QTimer
+
+from optiland_gui.analysis_panel import AnalysisPanel
+from optiland_gui.services.analysis_runner import AnalysisRunner
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+
+
+def wait_for(qapp, condition, timeout=45):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if condition():
+            return
+        time.sleep(0.002)
+    raise AssertionError("Analysis job did not reach its expected state")
+
+
+def test_real_huygens_stop_and_fft_result_keep_qt_alive(
+    qapp, minimal_optic, record_property
+):
+    document = DocumentState()
+    jobs = CalculationJobs(document, cancel_grace_ms=300)
+    connector = SimpleNamespace(
+        document_state=document,
+        calculation_jobs=jobs,
+        get_optic=lambda: minimal_optic,
+        toast_manager=Mock(),
+        get_field_options=lambda: [("All", "all")],
+        get_wavelength_options=lambda: [("Primary", "primary")],
+    )
+    connector._analysis_runner = AnalysisRunner(connector)
+    panel = AnalysisPanel(connector)
+    panel.resize(1000, 750)
+    panel.show()
+    beats = []
+    timer = QTimer()
+    timer.setInterval(10)
+    timer.timeout.connect(lambda: beats.append(time.monotonic()))
+    timer.start()
+    terminal = []
+    stages = []
+    jobs.finished.connect(terminal.append)
+    jobs.progress.connect(lambda request, data: stages.append(data["stage"]))
+    try:
+        page = panel._execute_analysis(
+            None, "Huygens PSF", {"num_rays": 128, "image_size": 512}, {}
+        )
+        panel.switch_plot_page(0)
+        assert page is not None
+        wait_for(qapp, lambda: "Calculating Huygens PSF" in stages)
+        before_stop = time.monotonic()
+        panel.btnStop.click()
+        assert time.monotonic() - before_stop < 0.1
+        wait_for(qapp, lambda: terminal, timeout=5)
+        assert terminal[0].status == "cancelled"
+        record_property("cancel_seconds", time.monotonic() - before_stop)
+        assert time.monotonic() - before_stop < 3
+        assert page["state"] == "cancelled"
+        fft = panel._execute_analysis(
+            None, "FFT PSF", {"num_rays": 32, "grid_size": 64}, {}
+        )
+        panel.switch_plot_page(1)
+        wait_for(qapp, lambda: fft.get("prepared"))
+        assert terminal[-1].status == "succeeded"
+        assert len(terminal) == 2
+        assert len(beats) > 20
+        assert max(b - a for a, b in zip(beats, beats[1:], strict=False)) < 0.75
+        record_property(
+            "max_heartbeat_gap_ms",
+            1000 * max(b - a for a, b in zip(beats, beats[1:], strict=False)),
+        )
+        record_property("heartbeat_ticks", len(beats))
+        # Theme and page operations operate on retained arrays and remain usable.
+        panel.update_theme("light")
+        panel.update_theme("dark")
+        panel._clone_analysis_page(1)
+        assert len(terminal) == 2
+        capture = os.environ.get("OPTILAND_GUI005_CAPTURE")
+        if capture:
+            qapp.processEvents()
+            assert panel.grab().save(capture)
+    finally:
+        timer.stop()
+        panel.close()
+        jobs.shutdown()
+        wait_for(qapp, lambda: jobs._process is None, timeout=5)
+        panel.deleteLater()
+        qapp.processEvents()

--- a/tests/gui/test_analysis_panel.py
+++ b/tests/gui/test_analysis_panel.py
@@ -1,154 +1,149 @@
-"""Tests for the AnalysisPanel (analysis_panel.py) bug fixes."""
+"""Analysis page identity, cancellation, stale results and presentation isolation."""
 
 from __future__ import annotations
 
-import inspect
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-
-@pytest.fixture()
-def mock_connector(minimal_optic, qapp):
-    conn = MagicMock()
-    conn._optic = minimal_optic
-    conn.toast_manager = MagicMock()
-    conn.get_analysis_registry.return_value = []
-    return conn
+from optiland_gui.analysis_panel import AnalysisPanel
+from tests.gui.analysis_job_fakes import connector_for, result_data
 
 
 @pytest.fixture()
-def panel(mock_connector, qapp):
-    from optiland_gui.analysis_panel import AnalysisPanel
-
-    return AnalysisPanel(mock_connector)
-
-
-class TestMtfStringLiteralFix:
-    """Verify the string-literal bug in the MTF max_freq condition is fixed."""
-
-    def test_mtf_condition_uses_constants_not_strings(self, panel):
-        """The MTF check must reference class constants, not quoted literals."""
-        src = inspect.getsource(panel._run_and_package_analysis)
-        # The fixed code should not contain the buggy string literals
-        assert '"self.GEOMETRIC_MTF"' not in src
-        assert '"self.FFT_MTF"' not in src
+def panel(minimal_optic, qapp):
+    connector = connector_for(minimal_optic)
+    panel = AnalysisPanel(connector)
+    yield panel
+    panel.close()
+    panel.deleteLater()
+    qapp.processEvents()
 
 
-class TestFieldWavelengthDefaults:
-    """Verify field/wavelength defaults are injected for wavefront/PSF analyses."""
-
-    def test_defaults_injected_for_opd(self, panel):
-        """_run_and_package_analysis injects field/wavelength for OPD."""
-        import inspect
-
-        from optiland.wavefront import OPD
-
-        # Build a fake analysis class with the same signature as OPD but
-        # that records the args passed to it instead of computing anything.
-        sig = inspect.signature(OPD.__init__)
-
-        captured_kwargs = {}
-
-        class _FakeOPD:
-            def __init__(self, optic, field, wavelength, **rest):
-                captured_kwargs["field"] = field
-                captured_kwargs["wavelength"] = wavelength
-
-            def view(self, **kwargs):
-                pass
-
-        # Preserve the original signature so introspection works
-        _FakeOPD.__init__.__wrapped__ = OPD.__init__
-
-        with patch.object(
-            _FakeOPD,
-            "__init__",
-            side_effect=lambda s, **kw: captured_kwargs.update(kw)
-            or None.__class__.__init__(s),
-        ):
-            pass  # don't use this approach
-
-        # Simpler: directly call the source-level method and check injected keys
-        # by verifying the injection code exists in the source.
-        src = inspect.getsource(panel._run_and_package_analysis)
-        assert "_required_defaults" in src
-        assert '"field"' in src
-        assert '"wavelength"' in src
-        assert "_key not in filtered_args" in src or "not in filtered_args" in src
-
-    def test_opd_signature_has_field_and_wavelength(self):
-        """OPD.__init__ must declare field and wavelength for injection to work."""
-        import inspect
-
-        from optiland.wavefront import OPD
-
-        params = inspect.signature(OPD.__init__).parameters
-        assert "field" in params
-        assert "wavelength" in params
-
-    def test_fft_psf_signature_has_field_and_wavelength(self):
-        """FFTPSF must declare field and wavelength (via __new__ for factory types)."""
-        import inspect
-
-        from optiland.psf import FFTPSF
-
-        # Factory-dispatch classes expose their real signature on __new__
-        init_params = inspect.signature(FFTPSF.__init__).parameters
-        new_params = inspect.signature(FFTPSF.__new__).parameters
-        all_params = set(init_params) | set(new_params)
-        assert "field" in all_params
-        assert "wavelength" in all_params
-
-    def test_zernike_opd_signature_has_field_and_wavelength(self):
-        """ZernikeOPD must declare field and wavelength for injection to work."""
-        import inspect
-
-        try:
-            from optiland.wavefront import ZernikeOPD
-        except ImportError:
-            pytest.skip("ZernikeOPD not available")
-
-        params = inspect.signature(ZernikeOPD.__init__).parameters
-        assert "field" in params
-        assert "wavelength" in params
+def run_page(panel, name="Ray Fan"):
+    page = panel._execute_analysis(
+        panel._analysis_class_map[name], name, {"num_points": 16}, {}
+    )
+    assert page is not None
+    panel.switch_plot_page(len(panel.analysis_results_pages) - 1)
+    return page
 
 
-class TestAnalysisErrorsUseToast:
-    """Verify analysis errors emit toasts instead of modal QMessageBoxes."""
+def test_pending_page_immediate_and_late_result_does_not_steal_focus(panel):
+    first = run_page(panel)
+    second = run_page(panel)
+    assert panel.current_plot_page_index == 1
+    panel.connector.calculation_jobs.complete(first["page_id"], result_data())
+    assert panel.current_plot_page_index == 1
+    assert first["prepared"]
+    assert second["prepared"] is None
 
-    def test_analysis_error_calls_toast_not_msgbox(self, panel, mock_connector):
-        """When an analysis raises, the toast manager should be called."""
-        from optiland.analysis import SpotDiagram
 
-        # Provide a valid optic so validation passes
-        mock_connector.get_optic.return_value = mock_connector._optic
+def test_retains_result_during_rerun_cancel_and_error(panel):
+    page = run_page(panel)
+    jobs = panel.connector.calculation_jobs
+    jobs.complete(page["page_id"], result_data())
+    prepared = page["prepared"]
+    panel._execute_analysis(None, page["name"], {"num_points": 32}, {}, page=page)
+    assert page["prepared"] is prepared
+    panel.stop_analysis_slot()
+    assert page["state"] == "cancelled"
+    assert page["prepared"] is prepared
+    panel._execute_analysis(None, page["name"], {"num_points": 64}, {}, page=page)
+    jobs.complete(page["page_id"], status="failed", error="Bad optical system")
+    assert page["prepared"] is prepared
+    panel.connector.toast_manager.notify.assert_called()
 
-        # Patch SpotDiagram to raise on instantiation
-        with patch.object(
-            SpotDiagram, "__init__", side_effect=RuntimeError("test error")
-        ):
-            with patch("optiland_gui.analysis_panel.QMessageBox") as mock_msgbox:
-                panel._execute_analysis(SpotDiagram, "Spot Diagram")
-                # Toast must have been notified
-                mock_connector.toast_manager.notify.assert_called()
-                # QMessageBox.critical must NOT have been called
-                mock_msgbox.critical.assert_not_called()
 
-    def test_validation_uses_toast_for_empty_system(self, qapp):
-        """System with no surfaces should trigger a toast, not a dialog."""
-        from optiland.optic import Optic
-        from optiland_gui.analysis_panel import AnalysisPanel
+def test_outdated_result_labeled_and_theme_never_recalculates(panel):
+    page = run_page(panel)
+    panel.connector.document_state.change()
+    panel.connector.calculation_jobs.complete(page["page_id"], result_data())
+    assert "Out of date" in panel.dataInfoLabel.text()
+    with patch.object(panel.runner, "run", side_effect=AssertionError("recalculation")):
+        panel.update_theme("light")
+        panel.update_theme("dark")
+        panel.switch_plot_page(0)
+    assert "Out of date" in panel.dataInfoLabel.text()
 
-        empty_optic = Optic()
-        conn = MagicMock()
-        conn._optic = empty_optic
-        conn.toast_manager = MagicMock()
-        conn.get_analysis_registry.return_value = []
 
-        p = AnalysisPanel(conn)
-        with patch("optiland_gui.analysis_panel.QMessageBox") as mock_msgbox:
-            result = p._validate_system_for_analysis(empty_optic)
-            assert result is False
-            conn.toast_manager.notify.assert_called()
-            mock_msgbox.warning.assert_not_called()
+def test_clone_shares_completed_data_and_has_independent_identity(panel):
+    page = run_page(panel)
+    panel.connector.calculation_jobs.complete(page["page_id"], result_data())
+    panel._clone_analysis_page(0)
+    cloned = panel.analysis_results_pages[1]
+    assert cloned["page_id"] != page["page_id"]
+    assert cloned["prepared"] is page["prepared"]
+    cloned["constructor_args_used"]["num_points"] = 32
+    assert page["constructor_args_used"]["num_points"] == 16
+
+
+def test_remove_active_page_revokes_target_before_completion(panel):
+    page = run_page(panel)
+    panel._remove_analysis_page(0)
+    assert page["page_id"] in panel.connector.calculation_jobs.cancelled
+    assert panel.analysis_results_pages == []
+    assert not panel.btnRunAll.isEnabled()
+
+
+def test_result_retention_is_bounded_without_dropping_previous_data(panel):
+    page = run_page(panel)
+    jobs = panel.connector.calculation_jobs
+    jobs.complete(page["page_id"], result_data())
+    retained = page["prepared"]
+    panel._execute_analysis(None, page["name"], {"num_points": 32}, {}, page=page)
+    oversized = result_data()
+    oversized["size_bytes"] = panel._result_budget + 1
+    jobs.complete(page["page_id"], oversized)
+    assert page["state"] == "failed"
+    assert page["prepared"] is retained
+
+
+def test_empty_system_uses_toast(panel):
+    from optiland.optic import Optic
+
+    assert not panel._validate_system_for_analysis(Optic())
+    panel.connector.toast_manager.notify.assert_called()
+
+
+def test_optional_fft_settings_remain_auto_on_reopen(panel):
+    page = panel._execute_analysis(None, "FFT PSF", {"num_rays": 32}, {})
+    panel.switch_plot_page(0)
+    grid = panel.current_settings_widgets["grid_size"]
+    assert grid.specialValueText() == "Auto"
+    assert panel._get_value_from_spinbox(grid) is None
+    panel._apply_settings_and_rerun_analysis_slot()
+    assert page["constructor_args_used"]["grid_size"] is None
+
+
+def test_dirty_settings_survive_completion_and_theme_change(panel):
+    page = run_page(panel)
+    widget = panel.current_settings_widgets["num_points"]
+    widget.setValue(48)
+    assert page["settings_dirty"]
+    panel.connector.calculation_jobs.complete(page["page_id"], result_data())
+    assert widget.value() == 48
+    assert "Settings changed" in panel.dataInfoLabel.text()
+    panel.update_theme("light")
+    assert widget.value() == 48
+
+
+def test_intentional_stop_does_not_show_worker_termination_error(panel):
+    page = run_page(panel)
+    panel.connector.calculation_jobs.complete(
+        page["page_id"],
+        status="cancelled",
+        error="Calculation worker exited unexpectedly.",
+    )
+    assert page["error"] == ""
+    panel.connector.toast_manager.notify.assert_not_called()
+
+
+def test_backend_change_labels_retained_result_outdated(panel):
+    from optiland_gui.services.job_records import BackendConfig
+
+    page = run_page(panel)
+    panel.connector.calculation_jobs.complete(page["page_id"], result_data())
+    with patch.object(BackendConfig, "capture", return_value=BackendConfig("torch")):
+        panel._update_page_status(page)
+        assert "Out of date" in panel.dataInfoLabel.text()

--- a/tests/gui/test_analysis_panel.py
+++ b/tests/gui/test_analysis_panel.py
@@ -147,3 +147,94 @@ def test_backend_change_labels_retained_result_outdated(panel):
     with patch.object(BackendConfig, "capture", return_value=BackendConfig("torch")):
         panel._update_page_status(page)
         assert "Out of date" in panel.dataInfoLabel.text()
+
+
+def test_settings_draft_survives_switch_and_closing_another_page(panel):
+    first, second = run_page(panel), run_page(panel)
+    jobs = panel.connector.calculation_jobs
+    jobs.complete(first["page_id"], result_data())
+    jobs.complete(second["page_id"], result_data())
+    panel.switch_plot_page(0)
+    panel.current_settings_widgets["num_points"].setValue(48)
+    panel.switch_plot_page(1)
+    panel.switch_plot_page(0)
+    assert panel.current_settings_widgets["num_points"].value() == 48
+    panel.current_settings_widgets["num_points"].setValue(64)
+    panel._remove_analysis_page(1)
+    assert panel.current_settings_widgets["num_points"].value() == 64
+    panel.analysisTypeCombo.setCurrentText("Spot Diagram")
+    panel.analysisTypeCombo.setCurrentText("Ray Fan")
+    assert panel.current_settings_widgets["num_points"].value() == 64
+    assert first["settings_dirty"]
+    assert first["constructor_args_used"]["num_points"] == 16
+    assert first["result_settings"]["constructor_args"]["num_points"] == 16
+    assert len(jobs.submissions) == 2
+
+
+def test_clone_copies_pending_draft_without_recalculating_or_sharing_edits(panel):
+    page = run_page(panel)
+    jobs = panel.connector.calculation_jobs
+    jobs.complete(page["page_id"], result_data())
+    panel.current_settings_widgets["num_points"].setValue(48)
+    panel._clone_analysis_page(0)
+    clone = panel.analysis_results_pages[1]
+    assert panel.current_settings_widgets["num_points"].value() == 48
+    assert clone["prepared"] is page["prepared"]
+    assert clone["draft_settings"] is not page["draft_settings"]
+    assert clone["settings_dirty"]
+    panel.current_settings_widgets["num_points"].setValue(64)
+    panel.switch_plot_page(0)
+    assert panel.current_settings_widgets["num_points"].value() == 48
+    panel.switch_plot_page(1)
+    assert panel.current_settings_widgets["num_points"].value() == 64
+    assert len(jobs.submissions) == 1
+
+
+def test_apply_submits_restored_draft_but_completion_keeps_later_edits(panel):
+    first, second = run_page(panel), run_page(panel)
+    jobs = panel.connector.calculation_jobs
+    jobs.complete(first["page_id"], result_data())
+    jobs.complete(second["page_id"], result_data())
+    panel.switch_plot_page(0)
+    panel.current_settings_widgets["num_points"].setValue(48)
+    panel.switch_plot_page(1)
+    panel.switch_plot_page(0)
+    panel._apply_settings_and_rerun_analysis_slot()
+    assert jobs.submissions[-1].parameters["constructor_args"]["num_points"] == 48
+    assert first["constructor_args_used"]["num_points"] == 48
+    assert first["draft_settings"] is None
+    assert not first["settings_dirty"]
+    panel.current_settings_widgets["num_points"].setValue(64)
+    jobs.complete(first["page_id"], result_data())
+    panel.switch_plot_page(1)
+    panel.switch_plot_page(0)
+    assert panel.current_settings_widgets["num_points"].value() == 64
+    assert first["settings_dirty"]
+    assert first["result_settings"]["constructor_args"]["num_points"] == 48
+    assert len(jobs.submissions) == 3
+
+
+def test_incomplete_text_and_control_drafts_survive_navigation(panel):
+    page = panel._execute_analysis(None, "FFT PSF", {"num_rays": 32}, {})
+    run_page(panel)
+    panel.switch_plot_page(0)
+    field = panel.current_settings_widgets["field"]
+    field.setText("0,")
+    field.textEdited.emit("0,")
+    panel.current_settings_widgets["remove_tilt"].setChecked(True)
+    panel.current_settings_widgets["strategy"].setCurrentText("centroid")
+    panel.current_settings_widgets["grid_size"].setValue(0)
+    panel.switch_plot_page(1)
+    panel.switch_plot_page(0)
+    assert panel.current_settings_widgets["field"].text() == "0,"
+    assert panel.current_settings_widgets["remove_tilt"].isChecked()
+    assert panel.current_settings_widgets["strategy"].currentText() == "centroid"
+    assert (
+        panel._get_value_from_spinbox(panel.current_settings_widgets["grid_size"])
+        is None
+    )
+    assert page["settings_dirty"]
+    panel._apply_settings_and_rerun_analysis_slot()
+    assert panel.current_settings_widgets["field"].text() == "0,"
+    assert page["settings_dirty"]
+    assert len(panel.connector.calculation_jobs.submissions) == 2

--- a/tests/gui/test_analysis_panel.py
+++ b/tests/gui/test_analysis_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +38,21 @@ def test_pending_page_immediate_and_late_result_does_not_steal_focus(panel):
     assert panel.current_plot_page_index == 1
     assert first["prepared"]
     assert second["prepared"] is None
+
+
+def test_completion_preserves_keyboard_focus_in_settings(panel, qapp):
+    page = run_page(panel)
+    panel.show()
+    panel.settings_area_widget.show()
+    panel.activateWindow()
+    qapp.processEvents()
+    setting = panel.current_settings_widgets["num_points"]
+    setting.setFocus()
+    qapp.processEvents()
+    assert setting.hasFocus()
+    panel.connector.calculation_jobs.complete(page["page_id"], result_data())
+    qapp.processEvents()
+    assert setting.hasFocus()
 
 
 def test_retains_result_during_rerun_cancel_and_error(panel):
@@ -238,3 +254,82 @@ def test_incomplete_text_and_control_drafts_survive_navigation(panel):
     assert panel.current_settings_widgets["field"].text() == "0,"
     assert page["settings_dirty"]
     assert len(panel.connector.calculation_jobs.submissions) == 2
+
+
+def test_numeric_wavelength_survives_page_restoration(panel):
+    panel.connector.get_wavelength_options = lambda: [
+        ("all", "'all'"),
+        ("primary", "'primary'"),
+        ("0.4500 µm", "[0.45]"),
+    ]
+    page = panel._execute_analysis(
+        None, "FFT PSF", {"wavelength": 0.45, "num_rays": 32}, {}
+    )
+    panel.switch_plot_page(0)
+    assert panel._collect_current_settings()[0]["wavelength"] == 0.45
+    panel._apply_settings_and_rerun_analysis_slot()
+    assert page["constructor_args_used"]["wavelength"] == 0.45
+
+
+def test_selected_field_survives_json_settings_round_trip(panel):
+    panel.connector.get_field_options = lambda: [
+        ("all", "'all'"),
+        ("Field 2", "[(0.0, 0.5)]"),
+    ]
+    page = run_page(panel)
+    panel.current_settings_widgets["fields"].setCurrentIndex(1)
+    args, view = panel._collect_current_settings()
+    saved = json.loads(
+        json.dumps(
+            {"analysis_name": "Ray Fan", "constructor_args": args, "view_args": view}
+        )
+    )
+    panel.current_settings_widgets["fields"].setCurrentIndex(0)
+    panel._apply_loaded_settings_to_ui(saved)
+    assert panel._collect_current_settings()[0]["fields"] == [(0.0, 0.5)]
+    panel._apply_settings_and_rerun_analysis_slot()
+    assert page["constructor_args_used"]["fields"] == [(0.0, 0.5)]
+
+
+def test_loaded_json_settings_restore_coordinates_choices_and_pending_draft(
+    panel, tmp_path, monkeypatch
+):
+    from PySide6.QtWidgets import QFileDialog
+
+    page = panel._execute_analysis(None, "FFT PSF", {"num_rays": 32}, {})
+    panel.switch_plot_page(0)
+    path = tmp_path / "settings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "analysis_name": "FFT PSF",
+                "constructor_args": {
+                    "field": [0.2, 0.3],
+                    "strategy": "centroid",
+                    "grid_size": None,
+                    "remove_tilt": True,
+                    "num_rays": 48,
+                },
+                "view_args": {},
+            }
+        )
+    )
+    monkeypatch.setattr(QFileDialog, "getOpenFileName", lambda *a, **k: (str(path), ""))
+    panel._load_analysis_settings_slot()
+    assert panel._validate_all_inputs() == (True, "")
+    args, _ = panel._collect_current_settings()
+    assert args["field"] == (0.2, 0.3)
+    assert args["strategy"] == "centroid" and args["remove_tilt"]
+    assert args["num_rays"] == 48
+    assert "grid_size" not in args
+    assert page["settings_dirty"]
+    panel.switch_plot_page(0)
+    assert panel.current_settings_widgets["field"].text() == "0.2, 0.3"
+    assert len(panel.connector.calculation_jobs.submissions) == 1
+
+
+def test_loading_unknown_analysis_keeps_current_settings(panel):
+    run_page(panel)
+    with pytest.raises(ValueError, match="supported analysis"):
+        panel._apply_loaded_settings_to_ui({"analysis_name": "Unknown analysis"})
+    assert panel.current_settings_widgets["num_points"].value() == 16

--- a/tests/gui/test_analysis_plots.py
+++ b/tests/gui/test_analysis_plots.py
@@ -1,0 +1,149 @@
+"""Prepared analysis plots retain explanatory keys and optical plot styling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.colors import BoundaryNorm
+from matplotlib.figure import Figure
+from matplotlib.patches import Circle
+
+from optiland_gui.services.analysis_plots import (
+    capture_analysis_plot,
+    draw_analysis_plot,
+)
+
+
+def figure_with_canvas():
+    figure = Figure(figsize=(7, 5))
+    FigureCanvasAgg(figure)
+    return figure
+
+
+@pytest.mark.parametrize("theme", ["dark", "light"])
+def test_figure_and_axes_legends_preserve_labels_columns_and_anchor(theme):
+    original = figure_with_canvas()
+    ax = original.subplots()
+    ax.plot([0, 1], [0, 1], label="Short wavelength", color="blue")
+    ax.scatter([0, 1], [1, 0], label="Long wavelength", color="orange")
+    ax.legend(ncols=2, title="Axis key", loc="upper left")
+    original.legend(
+        ncols=2, title="Wavelengths", loc="lower center", bbox_to_anchor=(0.5, 0.02)
+    )
+    prepared = capture_analysis_plot(original)
+    restored = figure_with_canvas()
+    draw_analysis_plot(restored, prepared, theme)
+    restored.canvas.draw()
+    assert len(restored.legends) == 1
+    for actual, expected in (
+        (restored.legends[0], original.legends[0]),
+        (restored.axes[0].get_legend(), ax.get_legend()),
+    ):
+        assert [t.get_text() for t in actual.get_texts()] == [
+            t.get_text() for t in expected.get_texts()
+        ]
+        assert actual._ncols == 2
+        assert actual.get_title().get_text() == expected.get_title().get_text()
+        np.testing.assert_allclose(
+            actual.get_bbox_to_anchor().bounds, expected.get_bbox_to_anchor().bounds
+        )
+
+
+def test_dashed_collections_image_opacity_and_patch_paths_survive_transfer():
+    original = figure_with_canvas()
+    ax = original.subplots()
+    segments = [[[0, 0], [1, 1]], [[1, 1], [2, 0]]]
+    lines = LineCollection(
+        segments,
+        linewidths=[2, 3],
+        linestyles=["--", ":"],
+        colors=["blue", "orange"],
+        alpha=0.7,
+    )
+    ax.add_collection(lines)
+    ax.add_patch(Circle((0.5, 0.5), 0.2, fill=False, linestyle="--"))
+    image = ax.imshow([[0, 1], [2, 3]], alpha=0.4, zorder=5, label="Intensity")
+    hidden = ax.imshow([[0, 1], [2, 3]])
+    hidden.set_visible(False)
+    prepared = capture_analysis_plot(original)
+    restored = figure_with_canvas()
+    draw_analysis_plot(restored, prepared)
+    actual = restored.axes[0]
+    assert len(actual.images) == 1
+    assert actual.images[0].get_alpha() == image.get_alpha()
+    assert actual.images[0].get_zorder() == image.get_zorder()
+    assert actual.images[0].get_label() == image.get_label()
+    for actual_style, expected in zip(
+        actual.collections[0].get_linestyles(), lines.get_linestyles(), strict=True
+    ):
+        assert actual_style[0] == expected[0]
+        np.testing.assert_allclose(actual_style[1], expected[1])
+    np.testing.assert_allclose(actual.collections[0].get_segments(), segments)
+    assert actual.collections[0].get_alpha() == 0.7
+    expected_path = (
+        ax.patches[0]
+        .get_path()
+        .transformed(ax.patches[0].get_transform() - ax.transData)
+    )
+    np.testing.assert_allclose(
+        actual.patches[0].get_path().vertices, expected_path.vertices
+    )
+
+
+def test_quadmesh_retains_normalization_and_transparency():
+    original = figure_with_canvas()
+    ax = original.subplots()
+    mesh = ax.pcolormesh([[1, 2], [3, 4]], alpha=0.6, zorder=4, cmap="viridis")
+    prepared = capture_analysis_plot(original)
+    restored = figure_with_canvas()
+    draw_analysis_plot(restored, prepared)
+    actual = restored.axes[0].collections[0]
+    assert actual.get_alpha() == mesh.get_alpha()
+    assert actual.get_zorder() == mesh.get_zorder()
+    np.testing.assert_allclose(actual.get_array(), mesh.get_array())
+    assert actual.norm.vmin == mesh.norm.vmin and actual.norm.vmax == mesh.norm.vmax
+
+
+def test_annotations_survive_and_hidden_artists_remain_hidden():
+    original = figure_with_canvas()
+    ax = original.subplots()
+    ax.plot([0, 1], [0, 1], visible=False)
+    patch = Circle((0, 0), 1, visible=False)
+    ax.add_patch(patch)
+    ax.scatter([0], [0], visible=False)
+    ax.text(0.2, 0.7, "Reference focus", transform=ax.transAxes)
+    ax.set_axis_off()
+    restored = figure_with_canvas()
+    draw_analysis_plot(restored, capture_analysis_plot(original))
+    actual = restored.axes[0]
+    assert not actual.lines and not actual.collections and not actual.patches
+    assert not actual.axison
+    assert actual.texts[0].get_text() == "Reference focus"
+    np.testing.assert_allclose(actual.texts[0].get_position(), (0.2, 0.7))
+
+
+def test_unsupported_legend_is_reported():
+    original = figure_with_canvas()
+    ax = original.subplots()
+    ax.add_patch(Circle((0, 0), 1, label="Unsupported filled legend"))
+    ax.legend()
+    with pytest.raises(ValueError, match="Unsupported analysis legend"):
+        capture_analysis_plot(original)
+
+
+@pytest.mark.parametrize("unsupported", ["projection", "collection", "normalization"])
+def test_unsupported_plot_payload_fails_instead_of_silently_dropping_content(
+    unsupported,
+):
+    original = figure_with_canvas()
+    ax = original.add_subplot(
+        projection="polar" if unsupported == "projection" else None
+    )
+    if unsupported == "collection":
+        ax.add_collection(PolyCollection([[(0, 0), (1, 0), (0, 1)]]))
+    elif unsupported == "normalization":
+        ax.imshow([[1, 2], [3, 4]], norm=BoundaryNorm([0, 2, 4], 2))
+    with pytest.raises(ValueError, match="2D projections|Unsupported analysis"):
+        capture_analysis_plot(original)

--- a/tests/gui/test_analysis_runner.py
+++ b/tests/gui/test_analysis_runner.py
@@ -126,7 +126,61 @@ def test_unrecoverable_worker_exit_stops_remaining_batch(connector, qapp):
     runner, jobs = connector._analysis_runner, connector.calculation_jobs
     runner.run_batch(entries(), connector.get_optic())
     qapp.processEvents()
-    jobs.complete("a", status="failed", error="Calculation worker exited unexpectedly.")
+    jobs.complete(
+        "a", status="failed", error="Native library aborted", infrastructure_error=True
+    )
     qapp.processEvents()
     assert [r.target for r in jobs.submissions] == ["a"]
     assert not runner.busy
+
+
+def test_numerical_failure_with_transport_words_does_not_stop_batch(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    jobs.complete("a", status="failed", error="Calculation worker exited unexpectedly.")
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a", "b"]
+    runner.stop()
+
+
+def test_batch_waiting_for_queue_can_be_stopped_without_later_submission(
+    connector, qapp, monkeypatch
+):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    submit = jobs.submit
+    monkeypatch.setattr(
+        jobs,
+        "submit",
+        lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("Calculation queue is full")
+        ),
+    )
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    assert runner.busy and not jobs.submissions
+    runner.stop()
+    monkeypatch.setattr(jobs, "submit", submit)
+    runner._dispatch_batch()
+    assert not runner.busy and not jobs.submissions
+
+
+def test_batch_closed_service_reports_first_failure_and_cancels_rest(
+    connector, qapp, monkeypatch
+):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    finished, states = [], []
+    runner.finished.connect(lambda target, result: finished.append((target, result)))
+    runner.state_changed.connect(lambda target, state: states.append((target, state)))
+    monkeypatch.setattr(
+        jobs,
+        "submit",
+        lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("Calculation service is closed.")
+        ),
+    )
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    assert finished[0][0] == "a" and finished[0][1].status == "failed"
+    assert ("b", "cancelled") in states and ("c", "cancelled") in states
+    assert not runner.busy and runner._batch_snapshot is None

--- a/tests/gui/test_analysis_runner.py
+++ b/tests/gui/test_analysis_runner.py
@@ -1,43 +1,132 @@
-"""Tests for AnalysisRunner."""
+"""Shared-job ownership and finite snapshot batch behavior."""
 
 from __future__ import annotations
 
-import importlib
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
-from optiland_gui.services.analysis_runner import AnalysisRunner
+from tests.gui.analysis_job_fakes import connector_for
 
 
 @pytest.fixture()
-def runner():
-    conn = MagicMock()
-    conn._optic = None
-    return AnalysisRunner(conn)
+def connector(minimal_optic, qapp):
+    return connector_for(minimal_optic)
 
 
-class TestAnalysisRunner:
-    def test_registry_contains_spot_diagram(self, runner):
-        registry = runner.get_analysis_registry()
-        names = [name for _, name, _ in registry]
-        assert any("spot" in name.lower() for name in names)
+def entries():
+    return [
+        {
+            "target": target,
+            "name": "Ray Fan",
+            "constructor_args": {"num_points": 16},
+            "view_args": {},
+            "theme": "dark",
+        }
+        for target in ("a", "b", "c")
+    ]
 
-    def test_all_class_paths_importable(self, runner):
-        from optiland_gui.registry import ANALYSIS_REGISTRY
 
-        for _category, name, class_path in ANALYSIS_REGISTRY:
-            module_path, class_name = class_path.rsplit(".", 1)
-            try:
-                module = importlib.import_module(module_path)
-                cls = getattr(module, class_name)
-                assert cls is not None
-            except (ImportError, AttributeError) as exc:
-                pytest.fail(f"Could not import '{name}' at '{class_path}': {exc}")
+def test_run_only_captures_inputs_without_constructing_analysis(connector):
+    runner = connector._analysis_runner
+    with patch(
+        "optiland.analysis.SpotDiagram.__init__",
+        side_effect=AssertionError("GUI calculation"),
+    ):
+        request = runner.run("Spot Diagram", {}, connector.get_optic(), target="page")
+    assert request.snapshot is not None
+    assert request.handler.endswith(":prepare_analysis")
+    assert not request.cancel_on_document_change
+    assert runner.busy
+    runner.stop()
+    assert not runner.busy
 
-    def test_run_does_not_raise(self, runner, minimal_optic):
-        # run() is a stub — must not raise regardless of inputs
-        runner.run("Spot Diagram", {}, minimal_optic)
 
-    def test_stop_does_not_raise(self, runner):
-        runner.stop()
+def test_run_all_freezes_order_settings_and_document_once(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    configuration = entries()
+    token = connector.document_state.token
+    runner.run_batch(configuration, connector.get_optic())
+    configuration[1]["constructor_args"]["num_points"] = 500
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a"]
+    snapshot = jobs.submissions[0].snapshot
+    connector.document_state.change()
+    jobs.complete("a")
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a", "b"]
+    assert jobs.submissions[1].document == token
+    assert jobs.submissions[1].snapshot is snapshot
+    assert jobs.submissions[1].parameters["constructor_args"]["num_points"] == 16
+    jobs.complete("b", status="failed", error="Numerical page error")
+    qapp.processEvents()
+    assert jobs.submissions[-1].target == "c"
+    jobs.complete("c")
+    qapp.processEvents()
+    assert not runner.busy
+    assert runner._batch_snapshot is None
+
+
+def test_stop_drops_entire_unsent_batch(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    runner.stop()
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a"]
+    assert not runner.busy
+
+
+def test_replacement_stops_batch_but_optical_edit_does_not(connector, qapp):
+    runner = connector._analysis_runner
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    connector.document_state.change()
+    assert runner.busy
+    connector.document_state.replace()
+    qapp.processEvents()
+    assert not runner.busy
+
+
+def test_removed_queued_page_cannot_run(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    runner.run_batch(entries(), connector.get_optic())
+    runner.cancel("b")
+    qapp.processEvents()
+    jobs.complete("a")
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a", "c"]
+    runner.stop()
+
+
+def test_registry_and_workload_validation_before_snapshot(connector):
+    runner = connector._analysis_runner
+    assert len(runner.get_analysis_registry()) == 22
+    with patch(
+        "optiland_gui.services.analysis_runner.OpticSnapshot.capture"
+    ) as capture:
+        with pytest.raises(ValueError, match="512 MiB"):
+            runner.run("FFT PSF", {"num_rays": 10000}, connector.get_optic())
+        capture.assert_not_called()
+
+
+def test_explicit_rerun_supersedes_unsent_batch_entry(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    runner.run("Ray Fan", {"num_points": 32}, connector.get_optic(), target="b")
+    jobs.complete("a")
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a", "b", "c"]
+    assert jobs.submissions[1].parameters["constructor_args"]["num_points"] == 32
+    runner.stop()
+
+
+def test_unrecoverable_worker_exit_stops_remaining_batch(connector, qapp):
+    runner, jobs = connector._analysis_runner, connector.calculation_jobs
+    runner.run_batch(entries(), connector.get_optic())
+    qapp.processEvents()
+    jobs.complete("a", status="failed", error="Calculation worker exited unexpectedly.")
+    qapp.processEvents()
+    assert [r.target for r in jobs.submissions] == ["a"]
+    assert not runner.busy

--- a/tests/gui/test_analysis_worker.py
+++ b/tests/gui/test_analysis_worker.py
@@ -70,6 +70,14 @@ def test_every_registry_family_prepares_owned_numeric_plots(
     )
     assert_plain(result)
     assert result["plot"]["axes"]
+    if name in (
+        "Spot Diagram",
+        "Ray Fan",
+        "Best-Fit Ray Fan",
+        "Pupil Aberration",
+        "Through-Focus Spot",
+    ):
+        assert result["plot"]["legends"], "The wavelength legend must survive transfer"
     assert pickle.dumps(minimal_optic.to_dict(), protocol=5) == original
     # Present the result twice, including a theme change, without an analysis object.
     before = pickle.dumps(result, protocol=5)
@@ -79,6 +87,7 @@ def test_every_registry_family_prepares_owned_numeric_plots(
         draw_analysis_plot(figure, result["plot"], theme)
         figure.canvas.draw()
         assert len(figure.axes) == len(result["plot"]["axes"])
+        assert len(figure.legends) == len(result["plot"]["legends"])
         for actual, expected in zip(figure.axes, result["plot"]["axes"], strict=True):
             np.testing.assert_allclose(actual.get_xlim(), expected["xlim"])
             np.testing.assert_allclose(actual.get_ylim(), expected["ylim"])
@@ -130,6 +139,68 @@ def test_dimension_aware_workload_rejected_before_allocating():
         )
     with pytest.raises(ValueError, match="512 MiB"):
         validate_workload("OPD", {"num_rays": 12}, {"num_points": 100000}, 10, 1, 1)
+
+
+@pytest.mark.parametrize(
+    ("name", "params", "view", "fields", "message"),
+    [
+        ("Ray Fan", {}, {"projection": "3d"}, 1, "2D projections"),
+        ("Spot Diagram", {}, {}, 33, "32 fields"),
+        ("OPD", {}, {"num_points": 0}, 1, "positive integer"),
+    ],
+)
+def test_invalid_display_dimensions_fail_before_calculation(
+    name, params, view, fields, message
+):
+    with pytest.raises(ValueError, match=message):
+        validate_workload(name, params, view, 4, fields, 1)
+
+
+def test_unknown_registry_entry_is_rejected():
+    with pytest.raises(ValueError, match="Unknown analysis"):
+        normalized_parameters("Unregistered analysis", {})
+
+
+@pytest.mark.parametrize("failure", ["unknown_view", "no_embedding", "axes", "size"])
+def test_worker_presentation_limits_report_errors_and_release_figure(
+    minimal_optic, monkeypatch, failure
+):
+    import matplotlib.pyplot as plt
+
+    from optiland_gui.services import analysis_worker
+
+    class TestAnalysis:
+        def __init__(self, optic):
+            pass
+
+        def view(self, fig_to_plot_on, show=False):
+            for _ in range(65 if failure == "axes" else 1):
+                fig_to_plot_on.add_axes((0.1, 0.1, 0.8, 0.8))
+
+    expected = {
+        "unknown_view": "Unsupported plot settings",
+        "no_embedding": "prepared embedded plots",
+        "axes": "64-axis page limit",
+        "size": "64 MiB page limit",
+    }
+    if failure == "no_embedding":
+        monkeypatch.setattr(TestAnalysis, "view", lambda self: None)
+    if failure == "size":
+        monkeypatch.setattr(analysis_worker, "MAX_RESULT_BYTES", 1)
+    monkeypatch.setattr(analysis_worker, "resolve_analysis", lambda name: TestAnalysis)
+    before = plt.get_fignums()
+    with pytest.raises(ValueError, match=expected[failure]):
+        prepare_analysis(
+            OpticSnapshot.capture(minimal_optic),
+            {
+                "name": "Ray Fan",
+                "constructor_args": {},
+                "view_args": {"unsupported": True} if failure == "unknown_view" else {},
+            },
+            lambda *a, **k: None,
+            threading.Event(),
+        )
+    assert plt.get_fignums() == before
 
 
 def test_worker_cancels_before_calculation(minimal_optic):

--- a/tests/gui/test_analysis_worker.py
+++ b/tests/gui/test_analysis_worker.py
@@ -1,0 +1,162 @@
+"""Real registry coverage for detached numerical and prepared-plot results."""
+
+from __future__ import annotations
+
+import pickle
+import threading
+
+import numpy as np
+import pytest
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+from optiland_gui.registry import ANALYSIS_REGISTRY
+from optiland_gui.services.analysis_plots import draw_analysis_plot
+from optiland_gui.services.analysis_worker import (
+    normalized_parameters,
+    prepare_analysis,
+    validate_workload,
+)
+from optiland_gui.services.job_records import CalculationCancelled, OpticSnapshot
+
+
+def small_parameters(name):
+    defaults = normalized_parameters(name, {})
+    overrides = {
+        "num_points": 16,
+        "num_fields": 3,
+        "num_rings": 3,
+        "num_steps": 3,
+        "num_rays": 32,
+        "grid_size": 64,
+        "image_size": 64,
+        "num_terms": 9,
+    }
+    return {k: v for k, v in overrides.items() if k in defaults}
+
+
+def assert_plain(value):
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert isinstance(key, str)
+            assert_plain(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            assert_plain(item)
+    else:
+        assert value is None or isinstance(
+            value, (str, bool, int, float, np.ndarray, np.number)
+        )
+
+
+@pytest.mark.parametrize("name", [name for _, name, _ in ANALYSIS_REGISTRY])
+@pytest.mark.parametrize("use_defaults", [False, True], ids=["small", "defaults"])
+def test_every_registry_family_prepares_owned_numeric_plots(
+    name, use_defaults, minimal_optic
+):
+    minimal_optic.fields.add(y=1.0)
+    minimal_optic.updater.update()
+    original = pickle.dumps(minimal_optic.to_dict(), protocol=5)
+    result = prepare_analysis(
+        OpticSnapshot.capture(minimal_optic),
+        {
+            "name": name,
+            "constructor_args": {} if use_defaults else small_parameters(name),
+            "view_args": {},
+            "theme": "dark",
+        },
+        lambda *a, **k: None,
+        threading.Event(),
+    )
+    assert_plain(result)
+    assert result["plot"]["axes"]
+    assert pickle.dumps(minimal_optic.to_dict(), protocol=5) == original
+    # Present the result twice, including a theme change, without an analysis object.
+    before = pickle.dumps(result, protocol=5)
+    for theme in ("dark", "light"):
+        figure = Figure(figsize=result["plot"]["figsize"])
+        FigureCanvasAgg(figure)
+        draw_analysis_plot(figure, result["plot"], theme)
+        figure.canvas.draw()
+        assert len(figure.axes) == len(result["plot"]["axes"])
+        for actual, expected in zip(figure.axes, result["plot"]["axes"], strict=True):
+            np.testing.assert_allclose(actual.get_xlim(), expected["xlim"])
+            np.testing.assert_allclose(actual.get_ylim(), expected["ylim"])
+            for line, data in zip(actual.lines, expected["lines"], strict=True):
+                np.testing.assert_allclose(
+                    line.get_xydata(), data["xy"], equal_nan=True
+                )
+            for image, data in zip(actual.images, expected["images"], strict=True):
+                np.testing.assert_allclose(
+                    image.get_array(), data["values"], equal_nan=True
+                )
+            if expected["legend"]:
+                assert [t.get_text() for t in actual.get_legend().get_texts()] == [
+                    item["label"] for item in expected["legend"]["handles"]
+                ]
+    assert pickle.dumps(result, protocol=5) == before
+
+
+def test_fft_factory_defaults_and_no_parameter_loss():
+    params = normalized_parameters("FFT PSF", {"num_rays": 64})
+    assert params["field"] == (0.0, 0.0)
+    assert params["wavelength"] == "primary"
+    assert params["num_rays"] == 64
+    with pytest.raises(ValueError, match="Unsupported"):
+        normalized_parameters("FFT PSF", {"mistyped": 1})
+
+
+def test_dimension_aware_workload_rejected_before_allocating():
+    with pytest.raises(ValueError, match="512 MiB"):
+        validate_workload("FFT PSF", {"num_rays": 10000}, {}, 10, 1, 1)
+    with pytest.raises(ValueError, match="positive integer"):
+        validate_workload("Ray Fan", {"num_points": -1}, {}, 10, 1, 1)
+    with pytest.raises(ValueError, match="64 field/focus"):
+        validate_workload(
+            "Through-Focus Spot", {"num_rings": 3, "num_steps": 40}, {}, 10, 2, 1
+        )
+    with pytest.raises(ValueError, match="512 MiB"):
+        validate_workload(
+            "Encircled Energy",
+            {"num_rays": 100000, "distribution": "grid"},
+            {},
+            10,
+            1,
+            1,
+        )
+    with pytest.raises(ValueError, match="explicit image_size"):
+        validate_workload(
+            "MMDFT PSF", {"num_rays": 32, "pixel_pitch": 1e-12}, {}, 10, 1, 1
+        )
+    with pytest.raises(ValueError, match="512 MiB"):
+        validate_workload("OPD", {"num_rays": 12}, {"num_points": 100000}, 10, 1, 1)
+
+
+def test_worker_cancels_before_calculation(minimal_optic):
+    cancelled = threading.Event()
+    cancelled.set()
+    with pytest.raises(CalculationCancelled):
+        prepare_analysis(
+            OpticSnapshot.capture(minimal_optic),
+            {"name": "FFT PSF", "constructor_args": {}, "view_args": {}},
+            lambda *a, **k: None,
+            cancelled,
+        )
+
+
+@pytest.mark.parametrize("name", ["FFT PSF", "Huygens PSF"])
+def test_polarized_factory_backend_payloads(set_test_backend, name, minimal_optic):
+    from optiland.rays import PolarizationState
+
+    minimal_optic.polarization = PolarizationState(is_polarized=False)
+    parameters = {"num_rays": 16}
+    parameters["grid_size" if name == "FFT PSF" else "image_size"] = 32
+    result = prepare_analysis(
+        OpticSnapshot.capture(minimal_optic),
+        {"name": name, "constructor_args": parameters, "view_args": {}},
+        lambda *a, **k: None,
+        threading.Event(),
+    )
+    assert_plain(result)
+    assert result["plot"]["axes"][0]["images"]
+    assert "Vectorial" in result["plot"]["axes"][0]["title"]

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -232,6 +232,7 @@ def test_replacement_kills_stubborn_active_and_runs_latest(qapp, jobs):
     assert receiver.results[1].request == second
     assert receiver.results[1].data == "latest"
     assert not receiver.results[0].current
+    assert not receiver.results[0].infrastructure_error
 
 
 def test_document_replacement_rejects_old_completion(qapp, jobs):
@@ -266,14 +267,19 @@ def test_hidden_target_never_dispatches(qapp, jobs):
     assert not receiver.progress
 
 
-def test_crash_has_terminal_error_and_service_recovers(qapp, jobs):
+@pytest.mark.parametrize("stderr", ["", "Native library aborted"])
+def test_crash_has_terminal_error_and_service_recovers(qapp, jobs, stderr):
     state, service, receiver = jobs
-    service.submit("2d", "unused", None, {"crash": True})
+    service.submit("2d", "unused", None, {"crash": True, "stderr": stderr})
     wait_for(qapp, lambda: receiver.results)
     assert receiver.results[0].status == "failed"
+    assert receiver.results[0].infrastructure_error
+    if stderr:
+        assert stderr in receiver.results[0].error
     service.submit("2d", "unused", None, {})
     wait_for(qapp, lambda: len(receiver.results) == 2)
     assert receiver.results[1].status == "succeeded"
+    assert not receiver.results[1].infrastructure_error
 
 
 def test_shutdown_revokes_and_reaps_without_blocking(qapp, jobs):
@@ -297,6 +303,7 @@ def test_failed_start_finishes_queued_request(qapp):
     service.submit("2d", "unused", None, {})
     wait_for(qapp, lambda: receiver.results)
     assert receiver.results[0].status == "failed"
+    assert receiver.results[0].infrastructure_error
     assert not service.running
     service.shutdown()
 
@@ -322,9 +329,40 @@ def test_actual_worker_reports_handler_failure_and_closes(qapp):
         wait_for(qapp, lambda: receiver.results)
         assert receiver.results[0].status == "failed"
         assert "does_not_exist" in receiver.results[0].error
+        assert not receiver.results[0].infrastructure_error
     finally:
         service.shutdown()
         wait_for(qapp, lambda: service._process is None)
+
+
+def test_malformed_worker_transport_is_infrastructure_failure(qapp, jobs):
+    _, service, receiver = jobs
+    service.submit("bad-transport", "unused", None, {"malformed": True})
+    wait_for(qapp, lambda: receiver.results)
+    assert receiver.results[0].status == "failed"
+    assert receiver.results[0].infrastructure_error
+    assert "Invalid calculation-worker message size" in receiver.results[0].error
+
+
+def test_local_request_encoding_failure_is_infrastructure_error(
+    qapp, jobs, monkeypatch
+):
+    _, service, receiver = jobs
+    service.submit("warmup", "unused", None, {})
+    wait_for(qapp, lambda: receiver.results)
+    original = service._send
+
+    def failing_send(message):
+        if message["command"] == "run":
+            raise ValueError("Request exceeds transport limit")
+        original(message)
+
+    monkeypatch.setattr(service, "_send", failing_send)
+    service.submit("oversized", "unused", None, {})
+    wait_for(qapp, lambda: len(receiver.results) == 2)
+    result = receiver.results[-1]
+    assert result.status == "failed" and result.infrastructure_error
+    assert "transport limit" in result.error
 
 
 def test_detached_explicit_job_survives_document_edit_as_stale(qapp, jobs):

--- a/tests/gui/test_calculation_jobs.py
+++ b/tests/gui/test_calculation_jobs.py
@@ -354,3 +354,30 @@ def test_current_must_be_rechecked_at_commit(qapp, jobs):
     assert receiver.results[0].current
     state.change()
     assert not service.is_current(request)
+
+
+def test_sequential_batch_preserves_its_captured_document_token(qapp, jobs):
+    state, service, receiver = jobs
+    captured = state.token
+    service.submit(
+        "batch-first",
+        "unused",
+        None,
+        {},
+        document_token=captured,
+        cancel_on_document_change=False,
+    )
+    wait_for(qapp, lambda: receiver.results)
+    state.change()
+    second = service.submit(
+        "batch-second",
+        "unused",
+        None,
+        {},
+        document_token=captured,
+        cancel_on_document_change=False,
+    )
+    wait_for(qapp, lambda: len(receiver.results) == 2)
+    assert second.document == captured
+    assert receiver.results[-1].status == "succeeded"
+    assert not receiver.results[-1].current


### PR DESCRIPTION
Fixes #835.

Running an analysis currently constructs the numerical analysis and prepares its plot in the GUI event handler, blocking interaction and cancellation. This moves those steps into the shared isolated calculation worker and returns owned plot data for display on the GUI thread.

Run creates a pending result page immediately. Run All freezes the configured pages, settings and one design revision, then processes the pages sequentially. Stop cancels active work and clears the remaining batch. Completed plots remain available during reruns, failures and cancellation, and results from older design revisions are clearly marked. Page navigation, cloning, theme changes and settings edits do not trigger numerical work or lose pending input.

The implementation covers all 22 registered 2D analysis families, bounds job/page resources, preserves wavelength legends and plot styling, and distinguishes numerical failures from worker or transport failures. It also preserves selected wavelengths and fields when settings are restored from JSON. It builds on the calculation service already on master and can be merged independently of the other GUI branches.

Validation:

- 131 focused runner, page, plot, numerical-worker and process tests passed; 10 additional resource and unsupported-payload tests passed. After the last field restoration correction, all 20 page tests passed again.
- Default and reduced settings exercised all 22 registered families; polarized FFT/Huygens tests passed with NumPy and Torch.
- Two native Windows acceptance tests passed. Cancelling a synthetic Huygens calculation completed in 0.305 seconds; the largest observed GUI heartbeat gap was 46.9 ms. Editing focus survived result completion.
- Ruff, formatting and whitespace checks passed. All fixtures are synthetic.
- Existing repository coverage configuration excludes GUI code. Supplemental GUI coverage measured 588/619 changed executable statements (94.99%), including all statements in the new worker and prepared-plot adapter. Coverage configuration is unchanged.
