### PR TITLE
Coalesce GUI document changes and refresh affected editors

### DIFF
--- a/optiland_gui/layout_presenter.py
+++ b/optiland_gui/layout_presenter.py
@@ -10,7 +10,7 @@ from optiland.visualization.themes import get_active_theme
 from optiland_gui import gui_plot_utils
 
 
-def present_2d(viewer, data, context, restyle=False):
+def present_2d(viewer, data, context, restyle=False, *, reset=False):
     """Reconstruct the 2D canvas and retain surface identities for highlighting."""
     gui_plot_utils.apply_gui_matplotlib_styles(viewer.current_theme)
     theme = get_active_theme().parameters
@@ -19,8 +19,15 @@ def present_2d(viewer, data, context, restyle=False):
         same_document = (
             getattr(viewer, "_scene_document_id", None) == context["document_id"]
         )
-        preserve = same_document and (
-            restyle or viewer._preserve_next or viewer._user_initiated_view_change
+        preserve = (
+            same_document
+            and not reset
+            and (
+                restyle
+                or viewer.preserve_zoom
+                or viewer._preserve_next
+                or viewer._user_initiated_view_change
+            )
         )
         xlim, ylim = viewer.ax.get_xlim(), viewer.ax.get_ylim()
         if hasattr(viewer, "_finish_default_pan"):

--- a/optiland_gui/lens_editor.py
+++ b/optiland_gui/lens_editor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QEvent, QSize, Qt, QTimer, Signal, Slot
+from PySide6.QtCore import QEvent, QItemSelectionModel, QSize, Qt, QTimer, Signal, Slot
 from PySide6.QtGui import QBrush, QColor, QIcon, QPainter, QPen
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -114,6 +114,19 @@ class SurfacePropertiesWidget(QWidget):
             params_to_set[name] = widget.text()
         self.connector.set_surface_geometry_params(self.row, params_to_set)
 
+    def refresh_values(self):
+        """Refresh derived values without discarding a focused parameter draft."""
+        params = self.connector.get_surface_geometry_params(self.row)
+        for name, widget in self.input_widgets.items():
+            if widget.hasFocus() or name not in params:
+                continue
+            value = params[name]
+            if isinstance(value, (list, tuple)) or hasattr(value, "tolist"):
+                values = value.tolist() if hasattr(value, "tolist") else value
+                widget.setText(str(values))
+            else:
+                widget.setText(f"{value:.6f}")
+
 
 class SurfaceTypeWidget(QWidget):
     """A custom widget for the 'Type' column, allowing text edit and dropdown."""
@@ -196,6 +209,15 @@ class SurfaceTypeWidget(QWidget):
             self._var_badge.setVisible(True)
         else:
             self._var_badge.setVisible(False)
+
+    def refresh_type_info(self):
+        """Update the stop/type label while retaining the existing controls."""
+        info = self.connector.get_surface_type_info(self.row)
+        if not self.type_edit.hasFocus():
+            self.type_edit.setText(info["display_text"])
+        self.props_button.setVisible(
+            bool(self.connector.get_surface_geometry_params(self.row))
+        )
 
     def type_selected(self, new_type):
         self.type_edit.setText(new_type.title())
@@ -286,8 +308,7 @@ class LensEditor(QWidget):
         self.tableWidget.itemChanged.connect(self.on_item_changed_handler)
         self.tableWidget.customContextMenuRequested.connect(self.show_context_menu)
         self.tableWidget.itemSelectionChanged.connect(self.update_headers_on_selection)
-        self.connector.opticLoaded.connect(self.full_refresh_from_optic)
-        self.connector.opticChanged.connect(self.full_refresh_from_optic)
+        self.connector.document_state.committed.connect(self._on_document_change)
         self.connector.optimizationVariablesChanged.connect(
             self.full_refresh_from_optic
         )
@@ -364,6 +385,92 @@ class LensEditor(QWidget):
         self.load_data()
         self.update_headers_on_selection()
 
+    def _on_document_change(self, change):
+        """Keep local data updates from replacing active editors or selection."""
+        if change.categories == {"presentation"}:
+            self.tableWidget.viewport().update()
+            return
+        if change.structural:
+            self._refresh_structure()
+            return
+        table = self.tableWidget
+        current = table.currentIndex()
+        editing = table.state() == QAbstractItemView.State.EditingState
+        rows = change.surface_indices or range(self.connector.get_surface_count())
+        columns = change.columns or range(table.columnCount())
+        previous = table.blockSignals(True)
+        try:
+            for surface_index in rows:
+                row = self.map_surface_index_to_ui_row(surface_index)
+                if self.connector.COL_TYPE in columns:
+                    widget = table.cellWidget(row, self.connector.COL_TYPE)
+                    if isinstance(widget, SurfaceTypeWidget):
+                        widget.refresh_type_info()
+                if surface_index == self.open_prop_source_row:
+                    widget = table.cellWidget(row + 1, 0)
+                    if isinstance(widget, SurfacePropertiesWidget):
+                        widget.refresh_values()
+                for column in columns:
+                    if editing and current.row() == row and current.column() == column:
+                        continue
+                    item = table.item(row, column)
+                    if item is not None:
+                        value = self.connector.get_surface_data(surface_index, column)
+                        text = str(value) if value is not None else ""
+                        if item.text() != text:
+                            item.setText(text)
+        finally:
+            table.blockSignals(previous)
+        self.update_headers_on_selection()
+
+    def _refresh_structure(self):
+        """Restore structural UI state by surface identity, never shifted row IDs."""
+        table = self.tableWidget
+        old_surfaces = self._displayed_surfaces
+        selected_ids = {
+            id(old_surfaces[index])
+            for row in table.selectionModel().selectedRows()
+            if 0
+            <= (index := self.map_ui_row_to_surface_index(row.row()))
+            < len(old_surfaces)
+        }
+        current_index = self.map_ui_row_to_surface_index(table.currentRow())
+        current_id = (
+            id(old_surfaces[current_index])
+            if 0 <= current_index < len(old_surfaces)
+            else None
+        )
+        current_column = table.currentColumn()
+        property_id = (
+            id(old_surfaces[self.open_prop_source_row])
+            if 0 <= self.open_prop_source_row < len(old_surfaces)
+            else None
+        )
+        horizontal = table.horizontalScrollBar().value()
+        vertical = table.verticalScrollBar().value()
+        new_surfaces = tuple(self.connector.get_optic().surfaces)
+        self.open_prop_source_row = next(
+            (
+                index
+                for index, surface in enumerate(new_surfaces)
+                if id(surface) == property_id
+            ),
+            -1,
+        )
+        self.full_refresh_from_optic()
+        table.clearSelection()
+        for index, surface in enumerate(new_surfaces):
+            row = self.map_surface_index_to_ui_row(index)
+            if id(surface) in selected_ids:
+                table.selectionModel().select(
+                    table.model().index(row, 0),
+                    QItemSelectionModel.Select | QItemSelectionModel.Rows,
+                )
+            if id(surface) == current_id:
+                table.setCurrentCell(row, current_column, QItemSelectionModel.NoUpdate)
+        table.horizontalScrollBar().setValue(horizontal)
+        table.verticalScrollBar().setValue(vertical)
+
     def _process_table_cell(self, row, col_idx, header):
         """Creates and configures the appropriate widget or item for a
         single table cell."""
@@ -438,6 +545,7 @@ class LensEditor(QWidget):
 
     @Slot()
     def load_data(self):
+        self._displayed_surfaces = tuple(self.connector.get_optic().surfaces)
         self.tableWidget.blockSignals(True)
         self.tableWidget.setRowCount(0)
         num_surfaces = self.connector.get_surface_count()
@@ -537,9 +645,6 @@ class LensEditor(QWidget):
             if ui_row == -1:
                 return
             surface_index_to_remove = self.map_ui_row_to_surface_index(ui_row)
-
-        if self.open_prop_source_row == surface_index_to_remove:
-            self.open_prop_source_row = -1  # Close properties if its owner is removed
 
         self.connector.remove_surface(surface_index_to_remove)
 

--- a/optiland_gui/lens_editor.py
+++ b/optiland_gui/lens_editor.py
@@ -308,10 +308,10 @@ class LensEditor(QWidget):
         self.tableWidget.itemChanged.connect(self.on_item_changed_handler)
         self.tableWidget.customContextMenuRequested.connect(self.show_context_menu)
         self.tableWidget.itemSelectionChanged.connect(self.update_headers_on_selection)
-        self.connector.document_state.committed.connect(self._on_document_change)
         self.connector.optimizationVariablesChanged.connect(
             self.full_refresh_from_optic
         )
+        self.connector.document_state.committed.connect(self._on_document_change)
 
     def setup_table(self):
         self.tableWidget.blockSignals(True)
@@ -546,8 +546,8 @@ class LensEditor(QWidget):
 
     @Slot()
     def load_data(self):
-        self._displayed_surfaces = tuple(self.connector.get_optic().surfaces)
         self.tableWidget.blockSignals(True)
+        self._displayed_surfaces = tuple(self.connector.get_optic().surfaces)
         self.tableWidget.setRowCount(0)
         num_surfaces = self.connector.get_surface_count()
         self.tableWidget.setRowCount(num_surfaces)

--- a/optiland_gui/lens_editor.py
+++ b/optiland_gui/lens_editor.py
@@ -387,8 +387,9 @@ class LensEditor(QWidget):
 
     def _on_document_change(self, change):
         """Keep local data updates from replacing active editors or selection."""
-        if change.categories == {"presentation"}:
-            self.tableWidget.viewport().update()
+        if change.categories <= {"polarization", "presentation"}:
+            if "presentation" in change.categories:
+                self.tableWidget.viewport().update()
             return
         if change.structural:
             self._refresh_structure()

--- a/optiland_gui/optiland_connector.py
+++ b/optiland_gui/optiland_connector.py
@@ -10,6 +10,8 @@ Author: Manuel Fragata Mendes, 2025
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 from PySide6.QtCore import QObject, Signal
 
 from optiland.optic import Optic
@@ -80,8 +82,9 @@ class OptilandConnector(QObject):
 
         # Invalidate before any panel handles the same synchronous notification.
         self.document_state = DocumentState(self)
-        self.opticLoaded.connect(self.document_state.replace)
-        self.opticChanged.connect(self.document_state.change)
+        self._publishing_change = False
+        self.opticLoaded.connect(self._on_optic_loaded)
+        self.opticChanged.connect(self._on_optic_changed)
         self.calculation_jobs = CalculationJobs(self.document_state, self)
 
         self._optic = Optic("Default System")
@@ -103,13 +106,42 @@ class OptilandConnector(QObject):
         self._undo_redo_manager.redoStackAvailabilityChanged.connect(
             self.redoStackAvailabilityChanged
         )
-        self.opticLoaded.emit()
-        self.opticChanged.emit()
+        with self.change_transaction(replacement=True):
+            self.opticLoaded.emit()
+            self.opticChanged.emit()
         self._undo_redo_manager.clear_stacks()
 
     # ------------------------------------------------------------------
     # Shared state utilities (stay on connector; used by services)
     # ------------------------------------------------------------------
+
+    def _on_optic_loaded(self):
+        if not self._publishing_change:
+            self.document_state.replace()
+
+    def _on_optic_changed(self):
+        if not self._publishing_change:
+            self.document_state.change()
+
+    def notify_change(self, category="optical", *, surface_indices=(), columns=()):
+        """Publish classified internal changes and preserve the public signal."""
+        self.document_state.record(
+            category, surface_indices=surface_indices, columns=columns
+        )
+        self._publishing_change = True
+        try:
+            if category == "replacement":
+                self.opticLoaded.emit()
+            else:
+                self.opticChanged.emit()
+        finally:
+            self._publishing_change = False
+
+    @contextmanager
+    def change_transaction(self, *, replacement=False):
+        """Coalesce notifications for an atomic edit or prepared replacement."""
+        with self.document_state.transaction(replacement=replacement):
+            yield
 
     def set_modified(self, modified: bool) -> None:
         """Set the modified flag and emit ``modifiedStateChanged`` if changed.

--- a/optiland_gui/optiland_connector.py
+++ b/optiland_gui/optiland_connector.py
@@ -116,17 +116,21 @@ class OptilandConnector(QObject):
     # ------------------------------------------------------------------
 
     def _on_optic_loaded(self):
-        if not self._publishing_change:
-            self._document_optic = self._optic
-            self.document_state.replace()
+        if self._publishing_change:
+            self._publishing_change = False
+            return
+        self._document_optic = self._optic
+        self.document_state.replace()
 
     def _on_optic_changed(self):
-        if not self._publishing_change:
-            if getattr(self, "_document_optic", None) is not self._optic:
-                self._document_optic = self._optic
-                self.document_state.replace()
-            else:
-                self.document_state.change()
+        if self._publishing_change:
+            self._publishing_change = False
+            return
+        if getattr(self, "_document_optic", None) is not self._optic:
+            self._document_optic = self._optic
+            self.document_state.replace()
+        else:
+            self.document_state.change()
 
     def notify_change(self, category="optical", *, surface_indices=(), columns=()):
         """Publish classified internal changes and preserve the public signal."""
@@ -141,15 +145,19 @@ class OptilandConnector(QObject):
         self.document_state.record(
             category, surface_indices=surface_indices, columns=columns
         )
-        self._publishing_change = True
-        try:
-            if category == "replacement":
-                self.opticLoaded.emit()
-                self.opticChanged.emit()
-            else:
-                self.opticChanged.emit()
-        finally:
-            self._publishing_change = False
+        signals = (
+            (self.opticLoaded, self.opticChanged)
+            if category == "replacement"
+            else (self.opticChanged,)
+        )
+        for signal in signals:
+            # The first-connected bridge consumes this flag before public
+            # listeners run. A listener's reentrant external emit is a new edit.
+            self._publishing_change = True
+            try:
+                signal.emit()
+            finally:
+                self._publishing_change = False
 
     @contextmanager
     def change_transaction(self, *, replacement=False):

--- a/optiland_gui/optiland_connector.py
+++ b/optiland_gui/optiland_connector.py
@@ -117,14 +117,27 @@ class OptilandConnector(QObject):
 
     def _on_optic_loaded(self):
         if not self._publishing_change:
+            self._document_optic = self._optic
             self.document_state.replace()
 
     def _on_optic_changed(self):
         if not self._publishing_change:
-            self.document_state.change()
+            if getattr(self, "_document_optic", None) is not self._optic:
+                self._document_optic = self._optic
+                self.document_state.replace()
+            else:
+                self.document_state.change()
 
     def notify_change(self, category="optical", *, surface_indices=(), columns=()):
         """Publish classified internal changes and preserve the public signal."""
+        if self._document_optic is not self._optic:
+            category = "replacement"
+        self._document_optic = self._optic
+        if category == "optical" and (self._optic.pickups or self._optic.solves):
+            # Generic pickups and solves can modify other rows or system inputs.
+            # Retain a conservative global scope until their dependency graph
+            # can prove a smaller affected set.
+            surface_indices, columns = (), ()
         self.document_state.record(
             category, surface_indices=surface_indices, columns=columns
         )
@@ -132,6 +145,7 @@ class OptilandConnector(QObject):
         try:
             if category == "replacement":
                 self.opticLoaded.emit()
+                self.opticChanged.emit()
             else:
                 self.opticChanged.emit()
         finally:
@@ -291,7 +305,7 @@ class OptilandConnector(QObject):
         """
         self._optic = Optic.from_dict(state_data)
         self._initialize_optic_structure(self._optic, is_specific_new_system=False)
-        self.opticLoaded.emit()
+        self.notify_change("replacement")
 
     # ------------------------------------------------------------------
     # Undo / Redo

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -7,11 +7,17 @@ import struct
 import sys
 import uuid
 from collections import deque
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QTimer, Signal, Slot
 
 from optiland_gui.services.calculation_worker import MAX_MESSAGE_BYTES, encode_message
+from optiland_gui.services.document_changes import (
+    CHANGE_CATEGORIES,
+    OPTICAL_CATEGORIES,
+    DocumentChange,
+)
 from optiland_gui.services.job_records import (
     BackendConfig,
     DocumentToken,
@@ -27,20 +33,109 @@ class DocumentState(QObject):
     """Conservative revision boundary, connected before any panel subscriptions."""
 
     changed = Signal(object)
+    committed = Signal(object)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         self.token = DocumentToken(uuid.uuid4().hex, 0)
+        self._transaction_depth = 0
+        self._replacement_transaction = False
+        self._invalidated = False
+        self._categories = set()
+        self._surface_indices = set()
+        self._columns = set()
+        self._transaction_failed = False
 
     @Slot()
     def change(self) -> None:
-        self.token = DocumentToken(self.token.document_id, self.token.revision + 1)
-        self.changed.emit(self.token)
+        self.record("optical")
 
     @Slot()
     def replace(self) -> None:
-        self.token = DocumentToken(uuid.uuid4().hex, 0)
-        self.changed.emit(self.token)
+        self.record("replacement")
+
+    def record(self, category="optical", *, surface_indices=(), columns=()):
+        """Invalidate immediately, then publish a classified committed change.
+
+        Optical invalidation is never delayed until a repaint/coalescing timer.
+        Metadata and presentation leave worker result permissions unchanged.
+        """
+        if category not in CHANGE_CATEGORIES:
+            raise ValueError(f"Unknown document change category: {category}")
+        replacement = category == "replacement" or self._replacement_transaction
+        if category in OPTICAL_CATEGORIES and not self._invalidated:
+            self.token = (
+                DocumentToken(uuid.uuid4().hex, 0)
+                if replacement
+                else DocumentToken(self.token.document_id, self.token.revision + 1)
+            )
+            self._invalidated = bool(self._transaction_depth)
+            self.changed.emit(self.token)
+        elif (
+            category == "replacement"
+            and self._invalidated
+            and not self._replacement_transaction
+        ):
+            raise ValueError(
+                "Declare replacement=True before a replacement transaction."
+            )
+        self._categories.add(category)
+        self._surface_indices.update(surface_indices)
+        self._columns.update(columns)
+        if not self._transaction_depth:
+            self._publish()
+
+    @contextmanager
+    def transaction(self, *, replacement=False):
+        """Group successful notifications; callers own atomic mutation/rollback.
+
+        A failed transaction publishes no successful change. Its already revoked
+        worker permissions stay revoked. Callers must restore mutated state or
+        publish a prepared replacement atomically before leaving this boundary.
+        """
+        if (
+            self._transaction_depth
+            and replacement
+            and not self._replacement_transaction
+        ):
+            raise ValueError("A replacement must be declared on the outer transaction.")
+        outer = not self._transaction_depth
+        if outer:
+            self._replacement_transaction = replacement
+            self._transaction_failed = False
+        self._transaction_depth += 1
+        try:
+            yield
+        except Exception:
+            self._transaction_failed = True
+            if outer:
+                self._reset_pending()
+            raise
+        finally:
+            self._transaction_depth -= 1
+            if outer:
+                self._replacement_transaction = False
+                self._invalidated = False
+                if self._transaction_failed:
+                    self._reset_pending()
+                else:
+                    self._publish()
+
+    def _publish(self):
+        if self._categories:
+            change = DocumentChange(
+                self.token,
+                frozenset(self._categories),
+                frozenset(self._surface_indices),
+                frozenset(self._columns),
+            )
+            self._reset_pending()
+            self.committed.emit(change)
+
+    def _reset_pending(self):
+        self._categories.clear()
+        self._surface_indices.clear()
+        self._columns.clear()
 
 
 class CalculationJobs(QObject):

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -103,7 +103,7 @@ class DocumentState(QObject):
         surface_indices, columns = tuple(surface_indices), tuple(columns)
         self._surface_indices.update(surface_indices)
         self._columns.update(columns)
-        if category != "presentation":
+        if category not in {"presentation", "polarization"}:
             self._all_surfaces |= not surface_indices
             self._all_columns |= not columns
         if not self._transaction_depth:

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -30,7 +30,14 @@ if TYPE_CHECKING:
 
 
 class DocumentState(QObject):
-    """Conservative revision boundary, connected before any panel subscriptions."""
+    """Separate calculation validity from whole-document ownership.
+
+    ``token`` changes for optical inputs; ``edit_token`` changes for every
+    persisted edit, including metadata. Whole-document consumers must capture
+    ``edit_token`` alongside their detached snapshot and compare it immediately
+    before replacing the document or declaring a saved snapshot clean. Optical
+    job currency alone cannot authorize overwriting intervening comment edits.
+    """
 
     changed = Signal(object)
     committed = Signal(object)
@@ -38,9 +45,11 @@ class DocumentState(QObject):
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         self.token = DocumentToken(uuid.uuid4().hex, 0)
+        self.edit_token = self.token
         self._transaction_depth = 0
         self._replacement_transaction = False
         self._invalidated = False
+        self._edit_invalidated = False
         self._categories = set()
         self._surface_indices = set()
         self._columns = set()
@@ -63,22 +72,31 @@ class DocumentState(QObject):
         if category not in CHANGE_CATEGORIES:
             raise ValueError(f"Unknown document change category: {category}")
         replacement = category == "replacement" or self._replacement_transaction
-        if category in OPTICAL_CATEGORIES and not self._invalidated:
-            self.token = (
-                DocumentToken(uuid.uuid4().hex, 0)
-                if replacement
-                else DocumentToken(self.token.document_id, self.token.revision + 1)
-            )
-            self._invalidated = bool(self._transaction_depth)
-            self.changed.emit(self.token)
-        elif (
+        if (
             category == "replacement"
-            and self._invalidated
+            and self._edit_invalidated
             and not self._replacement_transaction
         ):
             raise ValueError(
                 "Declare replacement=True before a replacement transaction."
             )
+        if category != "presentation" and not self._edit_invalidated:
+            self.edit_token = (
+                DocumentToken(uuid.uuid4().hex, 0)
+                if replacement
+                else DocumentToken(
+                    self.edit_token.document_id, self.edit_token.revision + 1
+                )
+            )
+            self._edit_invalidated = bool(self._transaction_depth)
+        if category in OPTICAL_CATEGORIES and not self._invalidated:
+            self.token = (
+                DocumentToken(self.edit_token.document_id, 0)
+                if replacement
+                else DocumentToken(self.token.document_id, self.token.revision + 1)
+            )
+            self._invalidated = bool(self._transaction_depth)
+            self.changed.emit(self.token)
         self._categories.add(category)
         self._surface_indices.update(surface_indices)
         self._columns.update(columns)
@@ -116,6 +134,7 @@ class DocumentState(QObject):
             if outer:
                 self._replacement_transaction = False
                 self._invalidated = False
+                self._edit_invalidated = False
                 if self._transaction_failed:
                     self._reset_pending()
                 else:
@@ -125,6 +144,7 @@ class DocumentState(QObject):
         if self._categories:
             change = DocumentChange(
                 self.token,
+                self.edit_token,
                 frozenset(self._categories),
                 frozenset(self._surface_indices),
                 frozenset(self._columns),

--- a/optiland_gui/services/calculation_jobs.py
+++ b/optiland_gui/services/calculation_jobs.py
@@ -53,6 +53,8 @@ class DocumentState(QObject):
         self._categories = set()
         self._surface_indices = set()
         self._columns = set()
+        self._all_surfaces = False
+        self._all_columns = False
         self._transaction_failed = False
 
     @Slot()
@@ -98,8 +100,12 @@ class DocumentState(QObject):
             self._invalidated = bool(self._transaction_depth)
             self.changed.emit(self.token)
         self._categories.add(category)
+        surface_indices, columns = tuple(surface_indices), tuple(columns)
         self._surface_indices.update(surface_indices)
         self._columns.update(columns)
+        if category != "presentation":
+            self._all_surfaces |= not surface_indices
+            self._all_columns |= not columns
         if not self._transaction_depth:
             self._publish()
 
@@ -146,8 +152,8 @@ class DocumentState(QObject):
                 self.token,
                 self.edit_token,
                 frozenset(self._categories),
-                frozenset(self._surface_indices),
-                frozenset(self._columns),
+                frozenset() if self._all_surfaces else frozenset(self._surface_indices),
+                frozenset() if self._all_columns else frozenset(self._columns),
             )
             self._reset_pending()
             self.committed.emit(change)
@@ -156,6 +162,8 @@ class DocumentState(QObject):
         self._categories.clear()
         self._surface_indices.clear()
         self._columns.clear()
+        self._all_surfaces = False
+        self._all_columns = False
 
 
 class CalculationJobs(QObject):

--- a/optiland_gui/services/document_changes.py
+++ b/optiland_gui/services/document_changes.py
@@ -1,0 +1,32 @@
+"""Classified, GUI-local document notifications independent of job activity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .job_records import DocumentToken
+
+CHANGE_CATEGORIES = frozenset(
+    {"optical", "structure", "replacement", "metadata", "presentation"}
+)
+OPTICAL_CATEGORIES = frozenset({"optical", "structure", "replacement"})
+
+
+@dataclass(frozen=True)
+class DocumentChange:
+    """One committed edit, possibly assembled from a nested transaction."""
+
+    token: DocumentToken
+    categories: frozenset[str]
+    surface_indices: frozenset[int] = frozenset()
+    columns: frozenset[int] = frozenset()
+
+    @property
+    def affects_optics(self) -> bool:
+        return bool(self.categories & OPTICAL_CATEGORIES)
+
+    @property
+    def structural(self) -> bool:
+        return bool(self.categories & {"structure", "replacement"})

--- a/optiland_gui/services/document_changes.py
+++ b/optiland_gui/services/document_changes.py
@@ -9,9 +9,9 @@ if TYPE_CHECKING:
     from .job_records import DocumentToken
 
 CHANGE_CATEGORIES = frozenset(
-    {"optical", "structure", "replacement", "metadata", "presentation"}
+    {"optical", "structure", "replacement", "metadata", "presentation", "polarization"}
 )
-OPTICAL_CATEGORIES = frozenset({"optical", "structure", "replacement"})
+OPTICAL_CATEGORIES = frozenset({"optical", "structure", "replacement", "polarization"})
 
 
 @dataclass(frozen=True)

--- a/optiland_gui/services/document_changes.py
+++ b/optiland_gui/services/document_changes.py
@@ -19,6 +19,7 @@ class DocumentChange:
     """One committed edit, possibly assembled from a nested transaction."""
 
     token: DocumentToken
+    edit_token: DocumentToken
     categories: frozenset[str]
     surface_indices: frozenset[int] = frozenset()
     columns: frozenset[int] = frozenset()

--- a/optiland_gui/services/file_service.py
+++ b/optiland_gui/services/file_service.py
@@ -139,8 +139,7 @@ class FileService:
         )
         self._current_filepath = None
         self._connector.set_modified(False)
-        self._connector.opticLoaded.emit()
-        self._connector.opticChanged.emit()
+        self._connector.notify_change("replacement")
 
     def load(self, filepath: str) -> None:
         """Load an optical system from *filepath*.
@@ -169,7 +168,7 @@ class FileService:
                 self._connector._optic, is_specific_new_system=False
             )
             self._connector.set_modified(False)
-            self._connector.opticLoaded.emit()
+            self._connector.notify_change("replacement")
             self._toast(f"Opened \u2014 {os.path.basename(filepath)}", "info")
         except Exception as e:
             self._toast(f"Load failed: {e}", "error", sub=filepath)
@@ -211,8 +210,7 @@ class FileService:
             self._current_filepath = None
             self._connector._initialize_optic_structure(self._connector._optic)
             self._connector.set_modified(True)
-            self._connector.opticLoaded.emit()
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("replacement")
         except Exception as e:
             self._toast(f"Failed to load system from sample object: {e}", "error")
             self.new_system()
@@ -234,8 +232,7 @@ class FileService:
                 self._connector._optic, is_specific_new_system=False
             )
             self._connector.set_modified(True)
-            self._connector.opticLoaded.emit()
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("replacement")
         except Exception as e:
             self._toast(f"Failed to import Zemax file from {filepath}: {e}", "error")
 
@@ -256,8 +253,7 @@ class FileService:
                 self._connector._optic, is_specific_new_system=False
             )
             self._connector.set_modified(True)
-            self._connector.opticLoaded.emit()
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("replacement")
         except Exception as e:
             self._toast(f"Failed to import CODE V file from {filepath}: {e}", "error")
 

--- a/optiland_gui/services/surface_service.py
+++ b/optiland_gui/services/surface_service.py
@@ -444,7 +444,9 @@ class SurfaceService:
         """
         if not (0 <= row < self.get_surface_count()):
             return
-        if col_idx == self._connector.COL_COMMENT:
+        if col_idx == self._connector.COL_COMMENT and not (
+            self._connector._optic.pickups or self._connector._optic.solves
+        ):
             surface = self._connector._optic.surfaces[row]
             if surface.comment == value_str:
                 return
@@ -601,6 +603,8 @@ class SurfaceService:
         if not (0 < row < self.get_surface_count() - 1):
             logger.warning("SurfaceService: Stop must be an intermediate surface.")
             return
+        if self._connector._optic.surfaces.stop_index == row:
+            return
 
         old_state = self._connector._capture_optic_state()
         try:
@@ -608,7 +612,8 @@ class SurfaceService:
             self._connector._optic.updater.update()
             self._connector._undo_redo_manager.add_state(old_state)
             self._connector.set_modified(True)
-            self._connector.notify_change("optical", surface_indices=(row,))
+            # The old stop label and system aperture information also change.
+            self._connector.notify_change("optical")
         except Exception as exc:
             logger.warning("SurfaceService: Error setting stop surface: %s", exc)
             self._connector._restore_optic_state(old_state)

--- a/optiland_gui/services/surface_service.py
+++ b/optiland_gui/services/surface_service.py
@@ -444,6 +444,18 @@ class SurfaceService:
         """
         if not (0 <= row < self.get_surface_count()):
             return
+        if col_idx == self._connector.COL_COMMENT:
+            surface = self._connector._optic.surfaces[row]
+            if surface.comment == value_str:
+                return
+            old_state = self._connector._optic.to_dict()
+            self._set_comment_data(surface, value_str)
+            self._connector._undo_redo_manager.add_state(old_state)
+            self._connector.set_modified(True)
+            self._connector.notify_change(
+                "metadata", surface_indices=(row,), columns=(col_idx,)
+            )
+            return
         old_state = self._connector._capture_optic_state()
         try:
             c = self._connector
@@ -462,7 +474,7 @@ class SurfaceService:
             c._optic.updater.update()
             c._undo_redo_manager.add_state(old_state)
             c.set_modified(True)
-            c.opticChanged.emit()
+            c.notify_change("optical", surface_indices=(row,), columns=(col_idx,))
         except Exception as exc:
             logger.warning(
                 "SurfaceService: Error setting data at (%d, %d) to '%s': %s",
@@ -526,7 +538,7 @@ class SurfaceService:
             self._connector._optic.updater.update()
             self._connector._undo_redo_manager.add_state(old_state)
             self._connector.set_modified(True)
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("structure", surface_indices=(row,))
 
         except Exception as exc:
             logger.warning("SurfaceService: Error setting surface type: %s", exc)
@@ -556,7 +568,7 @@ class SurfaceService:
         self._connector._optic.updater.update()
         self._connector._undo_redo_manager.add_state(old_state)
         self._connector.set_modified(True)
-        self._connector.opticChanged.emit()
+        self._connector.notify_change("structure", surface_indices=(insert_idx,))
 
     def remove_surface(self, lde_row_index: int) -> None:
         """Remove a surface by its LDE row index.
@@ -576,7 +588,7 @@ class SurfaceService:
             self._connector._optic.updater.update()
             self._connector._undo_redo_manager.add_state(old_state)
             self._connector.set_modified(True)
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("structure", surface_indices=(lde_row_index,))
         except Exception:
             self._connector._restore_optic_state(old_state)
 
@@ -596,7 +608,7 @@ class SurfaceService:
             self._connector._optic.updater.update()
             self._connector._undo_redo_manager.add_state(old_state)
             self._connector.set_modified(True)
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("optical", surface_indices=(row,))
         except Exception as exc:
             logger.warning("SurfaceService: Error setting stop surface: %s", exc)
             self._connector._restore_optic_state(old_state)
@@ -799,7 +811,7 @@ class SurfaceService:
             self._connector._optic.updater.update()
             self._connector._undo_redo_manager.add_state(old_state)
             self._connector.set_modified(True)
-            self._connector.opticChanged.emit()
+            self._connector.notify_change("optical", surface_indices=(row,))
 
         except Exception as exc:
             logger.warning("SurfaceService: Error setting geometry params: %s", exc)

--- a/optiland_gui/services/system_service.py
+++ b/optiland_gui/services/system_service.py
@@ -121,12 +121,15 @@ class SystemService:
                 raise ValueError(
                     "All polarization fields are required when mode is 'polarized'."
                 )
-            phase_x = math.radians(phase_x_deg)
-            phase_y = math.radians(phase_y_deg)
-            if not all(math.isfinite(value) for value in (Ex, Ey, phase_x, phase_y)):
+            if not all(
+                math.isfinite(value) for value in (Ex, Ey, phase_x_deg, phase_y_deg)
+            ):
                 raise ValueError("Polarization values must be finite.")
             if Ex == 0 and Ey == 0:
                 raise ValueError("Polarized light requires a nonzero field amplitude.")
+            # Reduce GUI degree inputs before casting to the backend precision.
+            phase_x = math.radians(phase_x_deg % 360)
+            phase_y = math.radians(phase_y_deg % 360)
             state = PolarizationState(
                 is_polarized=True,
                 Ex=Ex,
@@ -147,26 +150,34 @@ class SystemService:
         self._connector.notify_change("polarization")
 
     @staticmethod
-    def _same_polarization(first, second):
+    def _same_polarization(first, second) -> bool:
         if isinstance(first, str) or isinstance(second, str):
             return (
                 isinstance(first, str) and isinstance(second, str) and first == second
             )
+        if not isinstance(first, PolarizationState) or not isinstance(
+            second, PolarizationState
+        ):
+            return False
         if first.is_polarized != second.is_polarized:
             return False
         if not first.is_polarized:
             return True
         values = []
+        tolerance = 1e-12
         for state in (first, second):
-            values.append(
-                [
-                    float(be.to_numpy(state.Ex)),
-                    float(be.to_numpy(state.Ey)),
-                    float(be.to_numpy(state.phase_x)) % math.tau,
-                    float(be.to_numpy(state.phase_y)) % math.tau,
-                ]
+            components = [
+                np.asarray(be.to_numpy(value))
+                for value in (state.Ex, state.Ey, state.phase_x, state.phase_y)
+            ]
+            tolerance = max(
+                tolerance, *(4 * np.finfo(value.dtype).eps for value in components)
             )
-        return bool(np.allclose(values[0], values[1], rtol=0, atol=1e-12))
+            values.append([float(value) for value in components])
+        difference = np.subtract(values[0], values[1])
+        # A float32 full turn can lie just to either side of the 0/2π boundary.
+        difference[2:] = [math.remainder(value, math.tau) for value in difference[2:]]
+        return bool(np.all(np.abs(difference) <= tolerance))
 
     def get_field_types(self) -> list[tuple[str, str]]:
         """Return all four supported field types.

--- a/optiland_gui/services/system_service.py
+++ b/optiland_gui/services/system_service.py
@@ -142,7 +142,9 @@ class SystemService:
         optic.updater.set_polarization(state)
         self._connector._undo_redo_manager.add_state(old_state)
         self._connector.set_modified(True)
-        self._connector.notify_change("optical")
+        # This setter changes no surface property or derived geometry. Traces
+        # are invalidated, while the lens table can retain all existing cells.
+        self._connector.notify_change("polarization")
 
     @staticmethod
     def _same_polarization(first, second):

--- a/optiland_gui/services/system_service.py
+++ b/optiland_gui/services/system_service.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 import optiland.aperture  # noqa: F401 — ensures all subclasses are registered
+import optiland.backend as be
 from optiland.aperture import BaseSystemAperture
 from optiland.rays import PolarizationState
 
@@ -110,10 +113,9 @@ class SystemService:
         if optic is None:
             return
         if mode == "ignore":
-            optic.updater.set_polarization("ignore")
+            state = "ignore"
         elif mode == "unpolarized":
             state = PolarizationState(is_polarized=False)
-            optic.updater.set_polarization(state)
         elif mode == "polarized":
             if None in (Ex, Ey, phase_x_deg, phase_y_deg):
                 raise ValueError(
@@ -121,6 +123,10 @@ class SystemService:
                 )
             phase_x = math.radians(phase_x_deg)
             phase_y = math.radians(phase_y_deg)
+            if not all(math.isfinite(value) for value in (Ex, Ey, phase_x, phase_y)):
+                raise ValueError("Polarization values must be finite.")
+            if Ex == 0 and Ey == 0:
+                raise ValueError("Polarized light requires a nonzero field amplitude.")
             state = PolarizationState(
                 is_polarized=True,
                 Ex=Ex,
@@ -128,10 +134,37 @@ class SystemService:
                 phase_x=phase_x,
                 phase_y=phase_y,
             )
-            optic.updater.set_polarization(state)
         else:
             raise ValueError(f"Unknown polarization mode: {mode}")
-        self._connector.opticChanged.emit()
+        if self._same_polarization(optic.polarization, state):
+            return
+        old_state = optic.to_dict()
+        optic.updater.set_polarization(state)
+        self._connector._undo_redo_manager.add_state(old_state)
+        self._connector.set_modified(True)
+        self._connector.notify_change("optical")
+
+    @staticmethod
+    def _same_polarization(first, second):
+        if isinstance(first, str) or isinstance(second, str):
+            return (
+                isinstance(first, str) and isinstance(second, str) and first == second
+            )
+        if first.is_polarized != second.is_polarized:
+            return False
+        if not first.is_polarized:
+            return True
+        values = []
+        for state in (first, second):
+            values.append(
+                [
+                    float(be.to_numpy(state.Ex)),
+                    float(be.to_numpy(state.Ey)),
+                    float(be.to_numpy(state.phase_x)) % math.tau,
+                    float(be.to_numpy(state.phase_y)) % math.tau,
+                ]
+            )
+        return bool(np.allclose(values[0], values[1], rtol=0, atol=1e-12))
 
     def get_field_types(self) -> list[tuple[str, str]]:
         """Return all four supported field types.

--- a/optiland_gui/system_properties_panel.py
+++ b/optiland_gui/system_properties_panel.py
@@ -181,6 +181,10 @@ class PropertyEditorBase(QWidget):
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         self.init_ui()
 
+    def _notify_optical_edit(self):
+        self.connector.set_modified(True)
+        self.connector.notify_change("optical")
+
     def init_ui(self):
         """
         Initializes the user interface of the editor.
@@ -246,9 +250,15 @@ class ApertureEditor(PropertyEditorBase):
         if optic:
             ap_type = self.cmbApertureType.currentText()
             ap_value = self.spnApertureValue.value()
+            if (
+                optic.aperture
+                and optic.aperture.ap_type == ap_type
+                and optic.aperture.value == ap_value
+            ):
+                return
             try:
                 optic.set_aperture(ap_type, ap_value)
-                self.connector.opticChanged.emit()
+                self._notify_optical_edit()
                 print(f"Aperture updated: {ap_type}, {ap_value}")
             except ValueError as e:
                 print(f"Aperture Error: {e}")
@@ -338,11 +348,13 @@ class FieldsEditor(PropertyEditorBase):
         optic = self.connector.get_optic()
         if optic:
             new_type = self.cmbFieldType.currentData()
-            if new_type is None:
+            if new_type is None or new_type == _FIELD_TYPE_MAP.get(
+                type(optic.fields.field_definition)
+            ):
                 return
             try:
                 optic.fields.set_type(new_type)
-                self.connector.opticChanged.emit()
+                self._notify_optical_edit()
                 print(f"Field type changed to: {new_type}")
             except ValueError as e:
                 print(f"Field Type Error: {e}")
@@ -363,8 +375,7 @@ class FieldsEditor(PropertyEditorBase):
             )
 
             optic.fields.add(y=y_val)
-            self.load_data()
-            self.connector.opticChanged.emit()
+            self._notify_optical_edit()
             print("Field added.")
 
     @Slot()
@@ -374,33 +385,21 @@ class FieldsEditor(PropertyEditorBase):
         current_row = self.tableFields.currentRow()
         if optic and current_row != -1 and optic.fields.num_fields > current_row:
             del optic.fields.fields[current_row]
-            self.load_data()
-            self.connector.opticChanged.emit()
+            self._notify_optical_edit()
             print(f"Field at row {current_row} removed.")
 
-    def _update_field_from_row(self, row_index):
-        """Reads data from a table row and updates the corresponding field object.
-        Returns True if a change was made."""
+    def _field_values_from_row(self, row_index):
+        """Validate one draft row without mutating the live prescription."""
         try:
-            x = float(self.tableFields.item(row_index, 0).text())
-            y = float(self.tableFields.item(row_index, 1).text())
-            vx = float(self.tableFields.item(row_index, 2).text())
-            vy = float(self.tableFields.item(row_index, 3).text())
-
-            field_obj = self.connector.get_optic().fields.fields[row_index]
-            if (
-                field_obj.x != x
-                or field_obj.y != y
-                or field_obj.vx != vx
-                or field_obj.vy != vy
-            ):
-                field_obj.x, field_obj.y, field_obj.vx, field_obj.vy = x, y, vx, vy
-                return True
-        except (ValueError, AttributeError) as e:
-            print(f"Invalid data in fields table row {row_index + 1}: {e}")
-            # Re-raise the exception to be handled by the caller
-            raise ValueError(f"Invalid data in row {row_index + 1}") from e
-        return False
+            values = tuple(
+                float(self.tableFields.item(row_index, column).text())
+                for column in range(4)
+            )
+            if not all(math.isfinite(value) for value in values):
+                raise ValueError("Field values must be finite")
+            return values
+        except (ValueError, AttributeError) as exc:
+            raise ValueError(f"Invalid data in row {row_index + 1}") from exc
 
     @Slot()
     def apply_table_field_changes(self):
@@ -413,18 +412,24 @@ class FieldsEditor(PropertyEditorBase):
             self.load_data()  # Mismatch, so reload to be safe
             return
 
-        any_changed = False
         try:
-            for i in range(self.tableFields.rowCount()):
-                if self._update_field_from_row(i):
-                    any_changed = True
+            rows = [
+                self._field_values_from_row(i)
+                for i in range(self.tableFields.rowCount())
+            ]
         except ValueError:
-            self.load_data()  # Reload table on error to show original valid data
+            self.load_data()
             return
+        fields = optic.fields.fields
+        if all(
+            (field.x, field.y, field.vx, field.vy) == values
+            for field, values in zip(fields, rows, strict=True)
+        ):
+            return
+        for field, values in zip(fields, rows, strict=True):
+            field.x, field.y, field.vx, field.vy = values
+        self._notify_optical_edit()
 
-        if any_changed:
-            self.connector.opticChanged.emit()
-            print("Field table changes applied.")
 
 
 class WavelengthsEditor(PropertyEditorBase):
@@ -509,8 +514,7 @@ class WavelengthsEditor(PropertyEditorBase):
         if optic:
             is_new_primary = optic.wavelengths.num_wavelengths == 0
             optic.wavelengths.add(0.6328, is_primary=is_new_primary, unit="um")
-            self.load_data()
-            self.connector.opticChanged.emit()
+            self._notify_optical_edit()
             print("Wavelength added.")
 
     @Slot()
@@ -533,8 +537,7 @@ class WavelengthsEditor(PropertyEditorBase):
             if was_primary and optic.wavelengths.num_wavelengths > 0:
                 optic.wavelengths.wavelengths[0].is_primary = True
 
-            self.load_data()
-            self.connector.opticChanged.emit()
+            self._notify_optical_edit()
             print(f"Wavelength at row {current_row} removed.")
 
     @Slot()
@@ -547,10 +550,11 @@ class WavelengthsEditor(PropertyEditorBase):
             and current_row != -1
             and optic.wavelengths.num_wavelengths > current_row
         ):
+            if optic.wavelengths.primary_index == current_row:
+                return
             for i, wl_obj in enumerate(optic.wavelengths.wavelengths):
                 wl_obj.is_primary = i == current_row
-            self.load_data()
-            self.connector.opticChanged.emit()
+            self._notify_optical_edit()
             print(f"Wavelength at row {current_row} set as primary.")
 
     @Slot()
@@ -560,28 +564,31 @@ class WavelengthsEditor(PropertyEditorBase):
         if self.is_loading or not optic or not optic.wavelengths:
             return
 
-        changed = False
-        if self.tableWavelengths.rowCount() == optic.wavelengths.num_wavelengths:
-            for i in range(self.tableWavelengths.rowCount()):
-                try:
-                    new_val_um_str = self.tableWavelengths.item(i, 0).text()
-                    new_val_um = float(new_val_um_str)
-
-                    wl_obj = optic.wavelengths.wavelengths[i]
-                    if wl_obj.value != new_val_um:
-                        wl_obj._value = new_val_um
-                        wl_obj._unit = "um"
-                        wl_obj._value_in_um = new_val_um
-                        changed = True
-                except (ValueError, AttributeError):
-                    print(f"Invalid numeric data in Wavelengths table row {i + 1}.")
-                    self.load_data()
-                    return
-            if changed:
-                self.connector.opticChanged.emit()
-                print("Wavelength table changes applied.")
-        else:
+        if self.tableWavelengths.rowCount() != optic.wavelengths.num_wavelengths:
             self.load_data()
+            return
+        try:
+            values = [
+                float(self.tableWavelengths.item(i, 0).text())
+                for i in range(self.tableWavelengths.rowCount())
+            ]
+            if not all(math.isfinite(value) and value > 0 for value in values):
+                raise ValueError("Wavelengths must be finite and positive")
+        except (ValueError, AttributeError):
+            self.load_data()
+            return
+        wavelengths = optic.wavelengths.wavelengths
+        if all(
+            wavelength.value == value
+            for wavelength, value in zip(wavelengths, values, strict=True)
+        ):
+            return
+        for wavelength, value in zip(wavelengths, values, strict=True):
+            wavelength._value = value
+            wavelength._unit = "um"
+            wavelength._value_in_um = value
+        self._notify_optical_edit()
+
 
 
 class PolarizationEditor(PropertyEditorBase):

--- a/optiland_gui/system_properties_panel.py
+++ b/optiland_gui/system_properties_panel.py
@@ -86,6 +86,10 @@ class SystemPropertiesPanel(QWidget):
         self.connector.document_state.committed.connect(self._on_document_change)
 
     def _on_document_change(self, change):
+        if "polarization" in change.categories:
+            self.polarizationEditor.load_data()
+        if change.categories <= {"polarization", "presentation"}:
+            return
         if change.structural or (change.affects_optics and not change.surface_indices):
             self.load_properties()
 
@@ -431,7 +435,6 @@ class FieldsEditor(PropertyEditorBase):
         self._notify_optical_edit()
 
 
-
 class WavelengthsEditor(PropertyEditorBase):
     """A widget for editing the wavelengths of the optical system."""
 
@@ -588,7 +591,6 @@ class WavelengthsEditor(PropertyEditorBase):
             wavelength._unit = "um"
             wavelength._value_in_um = value
         self._notify_optical_edit()
-
 
 
 class PolarizationEditor(PropertyEditorBase):

--- a/optiland_gui/system_properties_panel.py
+++ b/optiland_gui/system_properties_panel.py
@@ -83,8 +83,11 @@ class SystemPropertiesPanel(QWidget):
             self.navTree.setCurrentItem(self.navTree.topLevelItem(0))
             self.stackedWidget.setCurrentIndex(0)
 
-        self.connector.opticLoaded.connect(self.load_properties)
-        self.connector.opticChanged.connect(self.load_properties)
+        self.connector.document_state.committed.connect(self._on_document_change)
+
+    def _on_document_change(self, change):
+        if change.structural or (change.affects_optics and not change.surface_indices):
+            self.load_properties()
 
     def _init_ui(self):
         """Initializes the main layout, navigation tree,
@@ -177,8 +180,6 @@ class PropertyEditorBase(QWidget):
         self.is_loading = False
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         self.init_ui()
-        self.connector.opticLoaded.connect(self.load_data)
-        self.connector.opticChanged.connect(self.load_data)
 
     def init_ui(self):
         """

--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -304,7 +304,6 @@ class ViewerPanel(QWidget):
 
     def _set_preserve_zoom(self, checked):
         self.viewer2D.preserve_zoom = checked
-        self.viewer2D._preserve_next = checked
 
     @Slot()
     def update_viewers(self):
@@ -469,7 +468,9 @@ class MatplotlibViewer(QWidget):
         self._user_initiated_view_change = False
         self._preserve_next = False
         if self.layout_job.data is not None:
-            self._present_layout(self.layout_job.data, self.layout_job.context)
+            self._present_layout(
+                self.layout_job.data, self.layout_job.context, reset=True
+            )
         else:
             self.layout_job.request()
 
@@ -587,12 +588,12 @@ class MatplotlibViewer(QWidget):
             "distribution": self.dist_combo.currentText(),
         }
 
-    def _present_layout(self, data, context, restyle=False):
-        present_2d(self, data, context, restyle)
+    def _present_layout(self, data, context, restyle=False, *, reset=False):
+        present_2d(self, data, context, restyle, reset=reset)
 
     def plot_optic(self, preserve_zoom=False):
         """Request the latest visible layout; calculation belongs to its worker."""
-        self._preserve_next = self.preserve_zoom or bool(preserve_zoom)
+        self._preserve_next = bool(preserve_zoom)
         self.layout_job.request()
 
 

--- a/optiland_gui/viewer_panel.py
+++ b/optiland_gui/viewer_panel.py
@@ -159,7 +159,7 @@ class SagViewer(QWidget):
         self.layout_job = LayoutJobView(
             self, "sag", plot_layout, self._layout_parameters, self._present_layout
         )
-        self.connector.opticChanged.connect(self.update_surface_range)
+        self.connector.document_state.committed.connect(self._on_document_change)
         self.update_surface_range()
         self.layout_job.redraw()
         self.update_theme()
@@ -208,6 +208,10 @@ class SagViewer(QWidget):
         """Updates the range of the surface selector spinbox."""
         count = self.connector.get_surface_count()
         self.surface_selector.setRange(0, max(0, count - 1))
+
+    def _on_document_change(self, change):
+        if change.structural:
+            self.update_surface_range()
 
     def update_theme(self, theme="dark"):
         self.current_theme = theme
@@ -274,8 +278,9 @@ class ViewerPanel(QWidget):
 
         main_layout.addWidget(self.tabWidget)
 
-        self.connector.opticLoaded.connect(self.update_viewers)
-        self.connector.opticChanged.connect(self.update_viewers)
+        # Each LayoutJobView owns immediate optical invalidation and coalesced
+        # visible requests. Public Loaded/Changed signals must not request a
+        # synchronous duplicate while a classified transaction is still open.
 
     def _create_2d_viewer_tab(self):
         """Creates the container widget for the 2D viewer, including its toolbar."""
@@ -289,12 +294,17 @@ class ViewerPanel(QWidget):
         self.preserve_zoom_checkbox.setToolTip(
             "Lock the current zoom and pan level when the system updates."
         )
+        self.preserve_zoom_checkbox.toggled.connect(self._set_preserve_zoom)
         toolbar_layout.addWidget(self.preserve_zoom_checkbox)
         toolbar_layout.addStretch()
 
         layout.addLayout(toolbar_layout)
         layout.addWidget(self.viewer2D)
         return container
+
+    def _set_preserve_zoom(self, checked):
+        self.viewer2D.preserve_zoom = checked
+        self.viewer2D._preserve_next = checked
 
     @Slot()
     def update_viewers(self):
@@ -442,6 +452,7 @@ class MatplotlibViewer(QWidget):
         self._is_panning = False
 
         self._preserve_next = False
+        self.preserve_zoom = False
         self.layout_job = LayoutJobView(
             self, "2d", self.layout, self._layout_parameters, self._present_layout
         )
@@ -581,7 +592,7 @@ class MatplotlibViewer(QWidget):
 
     def plot_optic(self, preserve_zoom=False):
         """Request the latest visible layout; calculation belongs to its worker."""
-        self._preserve_next = bool(preserve_zoom)
+        self._preserve_next = self.preserve_zoom or bool(preserve_zoom)
         self.layout_job.request()
 
 

--- a/tests/gui/test_document_changes.py
+++ b/tests/gui/test_document_changes.py
@@ -86,6 +86,19 @@ def test_canonical_connector_notification_preserves_public_signal_once(qapp):
     assert len(invalidations) == 2
 
 
+def test_external_replacement_is_detected_even_with_only_changed_signal(qapp):
+    from optiland.optic import Optic
+
+    connector = OptilandConnector()
+    original = connector.document_state.token
+    commits = []
+    connector.document_state.committed.connect(commits.append)
+    connector._optic = Optic()
+    connector.opticChanged.emit()
+    assert connector.document_state.token.document_id != original.document_id
+    assert commits[0].structural
+
+
 def test_comment_edit_skips_optical_update_and_noop(qapp, monkeypatch):
     connector = OptilandConnector()
     optic = connector.get_optic()

--- a/tests/gui/test_document_changes.py
+++ b/tests/gui/test_document_changes.py
@@ -1,0 +1,119 @@
+"""Immediate optical invalidation and coherent committed change notifications."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from optiland_gui.optiland_connector import OptilandConnector
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+from optiland_gui.services.job_records import JobRequest
+
+
+def test_nested_transaction_invalidates_once_before_commit(qapp):
+    state = DocumentState()
+    invalidations, commits = [], []
+    state.changed.connect(invalidations.append)
+    state.committed.connect(commits.append)
+    initial = state.token
+    with state.transaction():
+        state.record("optical", surface_indices=(2,), columns=(3,))
+        assert state.token.revision == initial.revision + 1
+        assert len(invalidations) == 1 and not commits
+        with state.transaction():
+            state.record("structure", surface_indices=(4,))
+        state.record("metadata", surface_indices=(2,), columns=(1,))
+    assert len(invalidations) == 1 and len(commits) == 1
+    assert commits[0].categories == {"optical", "structure", "metadata"}
+    assert commits[0].surface_indices == {2, 4}
+    assert commits[0].columns == {1, 3}
+
+
+def test_replacement_and_changed_pair_is_one_epoch(qapp):
+    state = DocumentState()
+    events, commits = [], []
+    state.changed.connect(events.append)
+    state.committed.connect(commits.append)
+    previous = state.token
+    with state.transaction(replacement=True):
+        state.replace()
+        state.change()
+    assert len(events) == len(commits) == 1
+    assert state.token.document_id != previous.document_id
+    assert state.token.revision == 0
+
+
+def test_metadata_does_not_revoke_calculations(qapp):
+    state = DocumentState()
+    jobs = CalculationJobs(state)
+    request = JobRequest(1, state.token, "layout", 0, "unused", None, {})
+    commits = []
+    state.committed.connect(commits.append)
+    state.record("metadata", surface_indices=(1,), columns=(1,))
+    assert jobs.is_current(request)
+    assert not commits[0].affects_optics
+    with state.transaction():
+        state.change()
+        assert not jobs.is_current(request)  # Before any timer/event-loop turn.
+
+
+def test_failed_nested_transaction_never_publishes_success(qapp):
+    state = DocumentState()
+    commits = []
+    state.committed.connect(commits.append)
+    with state.transaction():
+        state.change()
+        with pytest.raises(ValueError), state.transaction():
+            state.record("metadata")
+            raise ValueError("Prepared mutation rejected")
+    assert not commits
+    state.record("metadata")
+    assert len(commits) == 1 and commits[0].categories == {"metadata"}
+
+
+def test_canonical_connector_notification_preserves_public_signal_once(qapp):
+    connector = OptilandConnector()
+    invalidations, commits, legacy = [], [], []
+    connector.document_state.changed.connect(invalidations.append)
+    connector.document_state.committed.connect(commits.append)
+    connector.opticChanged.connect(lambda: legacy.append(True))
+    connector.notify_change("metadata", surface_indices=(0,), columns=(1,))
+    assert not invalidations and len(commits) == len(legacy) == 1
+    connector.notify_change("optical")
+    assert len(invalidations) == 1 and len(commits) == len(legacy) == 2
+    connector.opticChanged.emit()  # Supported external signal remains conservative.
+    assert len(invalidations) == 2
+
+
+def test_comment_edit_skips_optical_update_and_noop(qapp, monkeypatch):
+    connector = OptilandConnector()
+    optic = connector.get_optic()
+    original_token = connector.document_state.token
+    update = MagicMock(side_effect=AssertionError("A comment recalculated optics"))
+    monkeypatch.setattr(optic.updater, "update", update)
+    connector.set_surface_data(1, connector.COL_COMMENT, "Renamed surface")
+    assert optic.surfaces[1].comment == "Renamed surface"
+    assert connector.document_state.token == original_token
+    assert connector.is_modified()
+    count = len(connector._undo_redo_manager._undo_stack)
+    connector.set_surface_data(1, connector.COL_COMMENT, "Renamed surface")
+    assert len(connector._undo_redo_manager._undo_stack) == count
+    update.assert_not_called()
+
+
+def test_polarization_noop_compares_normalized_values(qapp, monkeypatch):
+    connector = OptilandConnector()
+    service = connector._system_service
+    service.set_polarization_state("unpolarized")
+    initial = connector.document_state.token
+    service.set_polarization_state("unpolarized")
+    assert connector.document_state.token == initial
+    service.set_polarization_state("polarized", 1, 0, 0, 90)
+    initial = connector.document_state.token
+    service.set_polarization_state("polarized", 2, 0, 360, 450)
+    assert connector.document_state.token == initial
+    service.set_polarization_state("polarized", 1, 1, 0, 90)
+    assert connector.document_state.token.revision == initial.revision + 1
+    with pytest.raises(ValueError, match="nonzero"):
+        service.set_polarization_state("polarized", 0, 0, 0, 0)

--- a/tests/gui/test_document_changes.py
+++ b/tests/gui/test_document_changes.py
@@ -27,7 +27,19 @@ def test_nested_transaction_invalidates_once_before_commit(qapp):
     assert len(invalidations) == 1 and len(commits) == 1
     assert commits[0].categories == {"optical", "structure", "metadata"}
     assert commits[0].surface_indices == {2, 4}
-    assert commits[0].columns == {1, 3}
+    assert not commits[0].columns  # The structural change affects all columns.
+
+
+def test_global_change_is_not_narrowed_by_another_local_edit(qapp):
+    state = DocumentState()
+    commits = []
+    state.committed.connect(commits.append)
+    with state.transaction():
+        state.record("optical")
+        state.record("metadata", surface_indices=(1,), columns=(1,))
+    assert not commits[0].surface_indices and not commits[0].columns
+    state.record("metadata", surface_indices=(2,), columns=(1,))
+    assert commits[1].surface_indices == {2} and commits[1].columns == {1}
 
 
 def test_replacement_and_changed_pair_is_one_epoch(qapp):

--- a/tests/gui/test_document_changes.py
+++ b/tests/gui/test_document_changes.py
@@ -142,3 +142,50 @@ def test_polarization_noop_compares_normalized_values(qapp, monkeypatch):
     assert connector.document_state.token.revision == initial.revision + 1
     with pytest.raises(ValueError, match="nonzero"):
         service.set_polarization_state("polarized", 0, 0, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "category, signal_name",
+    [("metadata", "opticChanged"), ("replacement", "opticLoaded")],
+)
+def test_external_change_during_public_notification_still_revokes_results(
+    qapp, category, signal_name
+):
+    connector = OptilandConnector()
+    initial = connector.document_state.token
+    request = JobRequest(1, initial, "layout", 0, "unused", None, {})
+    adjusted = []
+
+    def adjust_once():
+        if not adjusted:
+            adjusted.append(connector.document_state.token)
+            connector.get_optic().surfaces[1].geometry.radius = 75.0
+            connector.opticChanged.emit()
+
+    getattr(connector, signal_name).connect(adjust_once)
+    connector.notify_change(category, surface_indices=(1,), columns=(1,))
+    assert adjusted
+    assert connector.document_state.token.revision == adjusted[0].revision + 1
+    assert not connector.calculation_jobs.is_current(request)
+
+
+def test_invalid_transaction_declarations_leave_no_success_notifications(qapp):
+    state = DocumentState()
+    commits = []
+    state.committed.connect(commits.append)
+    initial = state.token, state.edit_token
+    with pytest.raises(ValueError, match="Unknown"):
+        state.record("unsupported")
+    assert (state.token, state.edit_token) == initial
+    with (
+        pytest.raises(ValueError, match="outer"),
+        state.transaction(),
+        state.transaction(replacement=True),
+    ):
+        pass
+    with pytest.raises(ValueError, match="Declare"), state.transaction():
+        state.record("metadata")
+        state.replace()
+    assert not commits
+    state.change()
+    assert len(commits) == 1

--- a/tests/gui/test_document_edit_ownership.py
+++ b/tests/gui/test_document_edit_ownership.py
@@ -1,0 +1,70 @@
+"""Whole-document candidates cannot overwrite newer metadata-only edits."""
+
+from __future__ import annotations
+
+import pytest
+
+from optiland_gui.services.calculation_jobs import CalculationJobs, DocumentState
+from optiland_gui.services.job_records import JobRequest
+
+
+def test_metadata_preserves_preview_but_revokes_whole_candidate_before_commit(qapp):
+    state = DocumentState()
+    jobs = CalculationJobs(state)
+    request = JobRequest(1, state.token, "optimization", 0, "unused", None, {})
+    candidate_edit_token = state.edit_token
+    commits = []
+    state.committed.connect(commits.append)
+    with state.transaction():
+        state.record("metadata")
+        assert jobs.is_current(request)
+        assert state.edit_token != candidate_edit_token
+        assert not commits
+        state.record("metadata")
+        assert state.edit_token.revision == candidate_edit_token.revision + 1
+    assert commits[0].edit_token == state.edit_token
+
+
+def test_presentation_is_not_a_persisted_edit(qapp):
+    state = DocumentState()
+    before = state.token, state.edit_token
+    state.record("presentation")
+    assert (state.token, state.edit_token) == before
+
+
+def test_mixed_nested_transaction_has_one_edit_revision(qapp):
+    state = DocumentState()
+    initial = state.edit_token
+    observed = []
+    state.changed.connect(lambda _: observed.append(state.edit_token))
+    with state.transaction():
+        state.record("metadata")
+        with state.transaction():
+            state.change()
+        state.record("metadata")
+    assert state.edit_token.revision == initial.revision + 1
+    assert observed == [state.edit_token]
+
+
+def test_replacement_uses_one_shared_epoch_and_revokes_both_guards(qapp):
+    state = DocumentState()
+    previous = state.edit_token
+    with state.transaction(replacement=True):
+        state.record("metadata")
+        state.replace()
+        state.change()
+    assert state.token == state.edit_token
+    assert state.token.document_id != previous.document_id
+    assert state.token.revision == 0
+
+
+def test_failed_transaction_does_not_restore_candidate_permission(qapp):
+    state = DocumentState()
+    previous = state.edit_token
+    with pytest.raises(ValueError), state.transaction():
+        state.record("metadata")
+        raise ValueError("Mutation must be rolled back by its owner")
+    assert state.edit_token != previous
+    failed = state.edit_token
+    state.record("metadata")
+    assert state.edit_token.revision == failed.revision + 1

--- a/tests/gui/test_document_layout_refresh.py
+++ b/tests/gui/test_document_layout_refresh.py
@@ -1,0 +1,72 @@
+"""Canonical document edits reach only the latest visible layout request."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from optiland_gui.optiland_connector import OptilandConnector
+from tests.gui.test_calculation_jobs import wait_for
+
+
+def test_metadata_noop_transactions_hidden_views_and_theme_have_bounded_work(
+    qapp, minimal_optic, monkeypatch
+):
+    import optiland_gui.viewer_panel as module
+
+    monkeypatch.setattr(module, "VTK_AVAILABLE", False)
+    connector = OptilandConnector()
+    connector.load_optic_from_object(minimal_optic)
+    connector.set_polarization_state("unpolarized")
+    panel = module.ViewerPanel(connector)
+    jobs = connector.calculation_jobs
+    two_d = panel.viewer2D.layout_job
+    sag = panel.sagViewer.layout_job
+    panel.resize(700, 600)
+    panel.show()
+    try:
+        wait_for(qapp, lambda: two_d._completed_key is not None, timeout=30)
+        serial, token = jobs._serial, connector.document_state.token
+        connector.set_surface_data(1, connector.COL_COMMENT, "Useful new label")
+        connector.set_polarization_state("unpolarized")
+        panel.update_theme("light")
+        qapp.processEvents()
+        assert connector.document_state.token == token
+        assert jobs._serial == serial
+        assert sag.data is None
+
+        panel.preserve_zoom_checkbox.setChecked(True)
+        panel.viewer2D.ax.set_xlim(0, 40)
+        panel.viewer2D.ax.set_ylim(-3, 3)
+        with connector.change_transaction():
+            connector.notify_change("optical")
+            connector.notify_change("optical")
+            connector.notify_change("metadata")
+            assert connector.document_state.token.revision == token.revision + 1
+            assert jobs._serial == serial  # Request waits for the event-loop turn.
+            assert two_d._completed_key is None
+        wait_for(qapp, lambda: two_d._completed_key is not None, timeout=30)
+        assert jobs._serial == serial + 1
+        np.testing.assert_allclose(panel.viewer2D.ax.get_xlim(), (0, 40))
+        np.testing.assert_allclose(panel.viewer2D.ax.get_ylim(), (-3, 3))
+        assert sag.data is None
+
+        panel.hide()
+        serial = jobs._serial
+        connector.notify_change("optical")
+        connector.notify_change("optical")
+        qapp.processEvents()
+        assert jobs._serial == serial
+        panel.show()
+        wait_for(qapp, lambda: two_d._completed_key is not None, timeout=30)
+        assert jobs._serial == serial + 1
+        panel.tabWidget.setCurrentWidget(panel.sagViewer)
+        wait_for(qapp, lambda: sag._completed_key is not None, timeout=30)
+        serial = jobs._serial
+        panel.tabWidget.setCurrentIndex(0)
+        qapp.processEvents()
+        assert jobs._serial == serial
+    finally:
+        panel.hide()
+        jobs.shutdown()
+        wait_for(qapp, lambda: jobs._process is None)
+        panel.deleteLater()

--- a/tests/gui/test_document_producers.py
+++ b/tests/gui/test_document_producers.py
@@ -1,0 +1,95 @@
+"""Public import and property actions publish one classified document change."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from PySide6.QtTest import QTest
+
+from optiland_gui.lens_editor import LensEditor
+from optiland_gui.optiland_connector import OptilandConnector
+from optiland_gui.services import file_service
+from optiland_gui.system_properties_panel import SystemPropertiesPanel
+
+
+@pytest.mark.parametrize("kind", ["json", "zemax", "codev", "restore"])
+def test_successful_public_load_publishes_single_replacement(
+    qapp, minimal_optic, tmp_path, monkeypatch, kind
+):
+    connector = OptilandConnector()
+    before = connector.document_state.token
+    commits, invalidations, loaded, changed = [], [], [], []
+    connector.document_state.committed.connect(commits.append)
+    connector.document_state.changed.connect(invalidations.append)
+    connector.opticLoaded.connect(lambda: loaded.append(True))
+    connector.opticChanged.connect(lambda: changed.append(True))
+    if kind == "json":
+        path = tmp_path / "sample.json"
+        path.write_text(json.dumps(minimal_optic.to_dict()), encoding="utf-8")
+        connector._file_service.load(str(path))
+    elif kind == "restore":
+        connector._restore_optic_state(minimal_optic.to_dict())
+    else:
+        # Parsing belongs to the file-format tests; exercise the real successful
+        # publication adapter with a prepared optical model here.
+        monkeypatch.setattr(
+            file_service, f"load_{kind}_file", lambda path: minimal_optic
+        )
+        getattr(connector._file_service, f"import_{kind}")("sample.input")
+    assert connector.get_optic().name == minimal_optic.name
+    assert connector.document_state.token.document_id != before.document_id
+    assert len(commits) == len(invalidations) == len(loaded) == len(changed) == 1
+    assert commits[0].categories == {"replacement"}
+
+
+def test_system_property_actions_commit_once_and_refresh_their_tables(qapp):
+    connector = OptilandConnector()
+    panel = SystemPropertiesPanel(connector)
+    commits = []
+    connector.document_state.committed.connect(commits.append)
+    fields = panel.fieldsEditor
+    waves = panel.wavelengthsEditor
+    try:
+        fields.add_field()
+        assert fields.tableFields.rowCount() == 2
+        fields.tableFields.setCurrentCell(1, 0)
+        fields.remove_field()
+        assert fields.tableFields.rowCount() == 1
+        waves.add_wavelength()
+        assert waves.tableWavelengths.rowCount() == 2
+        waves.tableWavelengths.setCurrentCell(1, 0)
+        waves.set_primary_wavelength()
+        assert waves.tableWavelengths.item(1, 2).text() == "Yes"
+        waves.tableWavelengths.setCurrentCell(1, 0)
+        waves.remove_wavelength()
+        assert waves.tableWavelengths.rowCount() == 1
+        assert connector.get_optic().wavelengths.primary_index == 0
+        assert len(commits) == 5
+        assert all(change.affects_optics for change in commits)
+    finally:
+        panel.deleteLater()
+
+
+def test_expanded_parameter_refresh_retains_focused_draft(qapp, minimal_optic):
+    connector = OptilandConnector()
+    connector.load_optic_from_object(minimal_optic)
+    connector.set_surface_type(1, "biconic")
+    editor = LensEditor(connector)
+    editor.resize(1000, 500)
+    editor.show()
+    editor.toggle_properties_widget(1)
+    try:
+        properties = editor.tableWidget.cellWidget(2, 0)
+        focused = properties.input_widgets["Radius X"]
+        focused.setFocus()
+        QTest.qWait(10)
+        focused.setText("Uncommitted radius draft")
+        connector.set_surface_geometry_params(1, {"Conic X": "-0.25"})
+        assert focused.hasFocus()
+        assert focused.text() == "Uncommitted radius draft"
+        assert float(properties.input_widgets["Conic X"].text()) == -0.25
+        assert editor.tableWidget.cellWidget(2, 0) is properties
+    finally:
+        editor.close()
+        editor.deleteLater()

--- a/tests/gui/test_document_refresh.py
+++ b/tests/gui/test_document_refresh.py
@@ -23,6 +23,50 @@ def make_editor(minimal_optic):
     return connector, editor
 
 
+def test_polarization_invalidates_rays_without_reading_any_lens_cells(
+    qapp, minimal_optic, monkeypatch
+):
+    connector, editor = make_editor(minimal_optic)
+    props = SystemPropertiesPanel(connector)
+    changes = []
+    connector.document_state.committed.connect(changes.append)
+    original = connector.document_state.token
+    try:
+        with monkeypatch.context() as scope:
+            scope.setattr(
+                connector,
+                "get_surface_data",
+                MagicMock(
+                    side_effect=AssertionError("Polarization queried a lens cell")
+                ),
+            )
+            connector.set_polarization_state("unpolarized")
+        assert len(changes) == 1
+        assert changes[0].categories == {"polarization"}
+        assert changes[0].affects_optics
+        assert connector.document_state.token.revision == original.revision + 1
+        assert props.polarizationEditor.cmbMode.currentText() == "Unpolarized"
+        queried = MagicMock(wraps=connector.get_surface_data)
+        monkeypatch.setattr(connector, "get_surface_data", queried)
+        with connector.change_transaction():
+            connector.set_polarization_state("ignore")
+            connector.set_surface_data(1, connector.COL_COMMENT, "Changed comment")
+        assert (
+            editor.tableWidget.item(1, connector.COL_COMMENT).text()
+            == "Changed comment"
+        )
+        assert props.polarizationEditor.cmbMode.currentText() == "Ignore"
+        assert len(queried.call_args_list) <= 2
+        assert all(
+            call.args == (1, connector.COL_COMMENT) for call in queried.call_args_list
+        )
+    finally:
+        props.close()
+        props.deleteLater()
+        editor.close()
+        editor.deleteLater()
+
+
 def test_local_update_keeps_type_widget_selection_and_scroll(
     qapp, minimal_optic, monkeypatch
 ):
@@ -167,9 +211,10 @@ def test_stop_change_updates_both_type_labels_and_same_stop_is_noop(
         connector.set_stop_surface(1)
         for row, widget in zip((1, 2), original, strict=True):
             assert table.cellWidget(row, 0) is widget
-            assert widget.type_edit.text() == connector.get_surface_type_info(row)[
-                "display_text"
-            ]
+            assert (
+                widget.type_edit.text()
+                == connector.get_surface_type_info(row)["display_text"]
+            )
         token = connector.document_state.token
         connector.set_stop_surface(1)
         assert connector.document_state.token == token

--- a/tests/gui/test_document_refresh.py
+++ b/tests/gui/test_document_refresh.py
@@ -164,14 +164,14 @@ def test_stop_change_updates_both_type_labels_and_same_stop_is_noop(
     try:
         table = editor.tableWidget
         original = [table.cellWidget(row, 0) for row in (1, 2)]
-        connector.set_stop_surface(2)
+        connector.set_stop_surface(1)
         for row, widget in zip((1, 2), original, strict=True):
             assert table.cellWidget(row, 0) is widget
             assert widget.type_edit.text() == connector.get_surface_type_info(row)[
                 "display_text"
             ]
         token = connector.document_state.token
-        connector.set_stop_surface(2)
+        connector.set_stop_surface(1)
         assert connector.document_state.token == token
     finally:
         editor.close()

--- a/tests/gui/test_document_refresh.py
+++ b/tests/gui/test_document_refresh.py
@@ -1,0 +1,178 @@
+"""Canonical notifications preserve editor state and avoid duplicate rebuilds."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QLineEdit
+
+from optiland_gui.lens_editor import LensEditor
+from optiland_gui.optiland_connector import OptilandConnector
+from optiland_gui.system_properties_panel import SystemPropertiesPanel
+
+
+def make_editor(minimal_optic):
+    connector = OptilandConnector()
+    connector.load_optic_from_object(minimal_optic)
+    editor = LensEditor(connector)
+    editor.resize(900, 500)
+    editor.show()
+    QTest.qWait(10)
+    return connector, editor
+
+
+def test_local_update_keeps_type_widget_selection_and_scroll(
+    qapp, minimal_optic, monkeypatch
+):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        table = editor.tableWidget
+        table.setCurrentCell(1, connector.COL_RADIUS)
+        original_widget = table.cellWidget(1, connector.COL_TYPE)
+        rebuild = MagicMock(
+            side_effect=AssertionError("Local cell edit rebuilt the table")
+        )
+        monkeypatch.setattr(editor, "full_refresh_from_optic", rebuild)
+        connector.set_surface_data(1, connector.COL_RADIUS, "75")
+        assert table.cellWidget(1, connector.COL_TYPE) is original_widget
+        assert table.currentRow() == 1
+        assert table.selectionModel().selectedRows()[0].row() == 1
+        assert float(table.item(1, connector.COL_RADIUS).text()) == 75
+        rebuild.assert_not_called()
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_structural_update_preserves_selected_surface_and_expanded_owner(
+    qapp, minimal_optic
+):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        surfaces = tuple(connector.get_optic().surfaces)
+        editor.toggle_properties_widget(1)
+        editor.tableWidget.setCurrentCell(3, connector.COL_RADIUS)
+        connector.add_surface(index=1)
+        assert connector.get_optic().surfaces[2] is surfaces[1]
+        assert connector.get_optic().surfaces[3] is surfaces[2]
+        assert editor.open_prop_source_row == 2
+        assert editor.tableWidget.currentRow() == 4
+        assert editor.tableWidget.selectionModel().selectedRows()[0].row() == 4
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_replacement_rebuilds_once_despite_public_loaded_and_changed(
+    qapp, minimal_optic, monkeypatch
+):
+    connector, editor = make_editor(minimal_optic)
+    rebuild = MagicMock(wraps=editor.full_refresh_from_optic)
+    monkeypatch.setattr(editor, "full_refresh_from_optic", rebuild)
+    invalidations, committed = [], []
+    connector.document_state.changed.connect(invalidations.append)
+    connector.document_state.committed.connect(committed.append)
+    try:
+        connector.new_system()
+        assert rebuild.call_count == 1
+        assert len(invalidations) == len(committed) == 1
+        assert committed[0].categories == {"replacement"}
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_metadata_refresh_preserves_active_cell_draft(qapp, minimal_optic):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        table = editor.tableWidget
+        table.setCurrentCell(1, connector.COL_COMMENT)
+        table.editItem(table.item(1, connector.COL_COMMENT))
+        QTest.qWait(10)
+        cell_editor = QApplication.focusWidget()
+        assert isinstance(cell_editor, QLineEdit)
+        cell_editor.setText("Uncommitted user draft")
+        connector.get_optic().surfaces[1].comment = "External label"
+        connector.notify_change(
+            "metadata", surface_indices=(1,), columns=(connector.COL_COMMENT,)
+        )
+        assert QApplication.focusWidget() is cell_editor
+        assert cell_editor.text() == "Uncommitted user draft"
+        QTest.keyClick(cell_editor, Qt.Key_Return)
+        QTest.qWait(10)
+        assert connector.get_optic().surfaces[1].comment == "Uncommitted user draft"
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_properties_have_one_refresh_owner_and_ignore_surface_labels(qapp, monkeypatch):
+    connector = OptilandConnector()
+    panel = SystemPropertiesPanel(connector)
+    refresh = MagicMock(wraps=panel.load_properties)
+    monkeypatch.setattr(panel, "load_properties", refresh)
+    connector.notify_change("metadata", surface_indices=(1,), columns=(1,))
+    assert not refresh.called
+    connector.notify_change("replacement")
+    assert refresh.call_count == 1
+    panel.close()
+
+
+def test_pickup_changes_refresh_derived_rows_without_rebuilding(
+    qapp, minimal_optic, monkeypatch
+):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        optic = connector.get_optic()
+        optic.pickups.add(1, "radius", 2, scale=-1)
+        rebuild = MagicMock(
+            side_effect=AssertionError("Pickup data update rebuilt widgets")
+        )
+        monkeypatch.setattr(editor, "full_refresh_from_optic", rebuild)
+        connector.set_surface_data(1, connector.COL_RADIUS, "65")
+        assert float(editor.tableWidget.item(2, connector.COL_RADIUS).text()) == -65
+        rebuild.assert_not_called()
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_removing_expanded_surface_retains_the_selected_surviving_surface(
+    qapp, minimal_optic
+):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        surviving = connector.get_optic().surfaces[2]
+        editor.toggle_properties_widget(1)
+        editor.tableWidget.setCurrentCell(3, connector.COL_RADIUS)
+        editor.remove_surface_handler(1)
+        assert editor.open_prop_source_row == -1
+        assert connector.get_optic().surfaces[1] is surviving
+        assert editor.tableWidget.currentRow() == 1
+        assert editor.tableWidget.selectionModel().selectedRows()[0].row() == 1
+    finally:
+        editor.close()
+        editor.deleteLater()
+
+
+def test_stop_change_updates_both_type_labels_and_same_stop_is_noop(
+    qapp, minimal_optic
+):
+    connector, editor = make_editor(minimal_optic)
+    try:
+        table = editor.tableWidget
+        original = [table.cellWidget(row, 0) for row in (1, 2)]
+        connector.set_stop_surface(2)
+        for row, widget in zip((1, 2), original, strict=True):
+            assert table.cellWidget(row, 0) is widget
+            assert widget.type_edit.text() == connector.get_surface_type_info(row)[
+                "display_text"
+            ]
+        token = connector.document_state.token
+        connector.set_stop_surface(2)
+        assert connector.document_state.token == token
+    finally:
+        editor.close()
+        editor.deleteLater()

--- a/tests/gui/test_document_view_preferences.py
+++ b/tests/gui/test_document_view_preferences.py
@@ -1,0 +1,89 @@
+"""Presentation-time zoom preferences coexist with explicit navigation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from optiland_gui.optiland_connector import OptilandConnector
+
+
+@pytest.fixture()
+def scene(qapp, monkeypatch):
+    import optiland_gui.viewer_panel as module
+
+    monkeypatch.setattr(module, "VTK_AVAILABLE", False)
+    connector = OptilandConnector()
+    panel = module.ViewerPanel(connector)
+    viewer = panel.viewer2D
+    data = {
+        "name": "Synthetic layout",
+        "primitives": [
+            {
+                "kind": "line",
+                "role": "surface",
+                "surfaces": (),
+                "xy": np.array([[0.0, -1.0], [10.0, 1.0]]),
+                "linewidth": 1.0,
+                "linestyle": "-",
+                "label": "surface",
+            }
+        ],
+        "annotations": [],
+        "boundaries": {},
+        "references": {},
+    }
+    context = {
+        "document_id": connector.document_state.token.document_id,
+        "surface_identities": tuple(connector.get_optic().surfaces),
+    }
+    viewer._present_layout(data, context)
+    viewer.layout_job.data, viewer.layout_job.context = data, context
+    yield panel, viewer, data, context
+    panel.close()
+    panel.deleteLater()
+    connector.calculation_jobs.shutdown()
+
+
+def set_automatic_limits(viewer):
+    viewer._is_plotting = True
+    viewer.ax.set_xlim(20, 30)
+    viewer.ax.set_ylim(-4, 4)
+    viewer._is_plotting = False
+    viewer._user_initiated_view_change = False
+
+
+def test_checkbox_is_read_when_pending_result_is_presented(scene):
+    panel, viewer, data, context = scene
+    set_automatic_limits(viewer)
+    panel.preserve_zoom_checkbox.setChecked(True)
+    viewer.plot_optic()  # Explicit default must not clear the persistent preference.
+    viewer._present_layout(data, context)
+    np.testing.assert_allclose(viewer.ax.get_xlim(), (20, 30))
+    panel.preserve_zoom_checkbox.setChecked(False)
+    viewer._present_layout(data, context)
+    assert viewer.ax.get_xlim()[1] < 20
+    assert panel.connector.calculation_jobs._serial == 0
+
+
+def test_home_fits_retained_data_even_when_preserve_is_checked(scene):
+    panel, viewer, data, context = scene
+    panel.preserve_zoom_checkbox.setChecked(True)
+    set_automatic_limits(viewer)
+    viewer.reset_view()
+    assert viewer.ax.get_xlim()[1] < 20
+    assert panel.preserve_zoom_checkbox.isChecked()
+    assert viewer.preserve_zoom
+    assert panel.connector.calculation_jobs._serial == 0
+
+
+def test_explicit_preservation_and_new_document_fit_remain_distinct(scene):
+    panel, viewer, data, context = scene
+    set_automatic_limits(viewer)
+    viewer.plot_optic(preserve_zoom=True)
+    viewer._present_layout(data, context)
+    np.testing.assert_allclose(viewer.ax.get_xlim(), (20, 30))
+    panel.preserve_zoom_checkbox.setChecked(True)
+    viewer._present_layout(data, {**context, "document_id": "replacement"})
+    assert viewer.ax.get_xlim()[1] < 20
+    assert panel.connector.calculation_jobs._serial == 0

--- a/tests/gui/test_polarization_notifications.py
+++ b/tests/gui/test_polarization_notifications.py
@@ -1,0 +1,62 @@
+"""No-op polarization changes respect the active backend's scalar precision."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from optiland.rays import PolarizationState
+from optiland_gui.optiland_connector import OptilandConnector
+from optiland_gui.services.job_records import BackendConfig
+
+
+@pytest.mark.parametrize(
+    "backend,precision", [("numpy", 64), ("torch", 32), ("torch", 64)]
+)
+def test_scaled_full_turn_polarization_is_noop_but_real_change_is_edit(
+    qapp, backend, precision
+):
+    if backend == "torch":
+        pytest.importorskip("torch")
+    original = BackendConfig.capture()
+    try:
+        BackendConfig(backend, "cpu", precision).apply()
+        connector = OptilandConnector()
+        optic = connector.get_optic()
+        # Existing public states may contain unreduced phases from external code.
+        optic.polarization = PolarizationState(True, 1, 0, math.tau, 2.5 * math.pi)
+        before = connector.document_state.token, connector.document_state.edit_token
+        connector.set_polarization_state("polarized", 2, 0, 0, 90)
+        assert (
+            connector.document_state.token,
+            connector.document_state.edit_token,
+        ) == before
+        assert not connector._undo_redo_manager._undo_stack
+        assert not connector.is_modified()
+        connector.set_polarization_state("polarized", 2, 0, 360, 450)
+        assert connector.document_state.token == before[0]
+        connector.set_polarization_state("polarized", 1, 1, 0, 90)
+        assert connector.document_state.token.revision == before[0].revision + 1
+        assert len(connector._undo_redo_manager._undo_stack) == 1
+        connector.set_polarization_state("polarized", 1, 1, 0, 90.01)
+        assert connector.document_state.token.revision == before[0].revision + 2
+    finally:
+        original.apply()
+
+
+def test_explicit_setting_can_repair_an_unconfigured_incident_state(qapp):
+    connector = OptilandConnector()
+    connector.get_optic().polarization = None
+    connector.set_polarization_state("unpolarized")
+    assert not connector.get_optic().polarization.is_polarized
+
+
+@pytest.mark.parametrize("value", [math.inf, -math.inf, math.nan])
+def test_nonfinite_phase_does_not_create_edit(qapp, value):
+    connector = OptilandConnector()
+    before = connector.document_state.edit_token
+    with pytest.raises(ValueError, match="finite"):
+        connector.set_polarization_state("polarized", 1, 1, value, 90)
+    assert connector.document_state.edit_token == before
+    assert connector.get_optic().polarization == "ignore"

--- a/tests/gui/test_property_transactions.py
+++ b/tests/gui/test_property_transactions.py
@@ -21,6 +21,7 @@ def test_later_invalid_row_cannot_silently_mutate_earlier_rows(qapp, kind):
         editor = FieldsEditor(connector)
         table = editor.tableFields
         apply = editor.apply_table_field_changes
+
         def read():
             return [(f.x, f.y, f.vx, f.vy) for f in optic.fields]
 
@@ -30,6 +31,7 @@ def test_later_invalid_row_cannot_silently_mutate_earlier_rows(qapp, kind):
         editor = WavelengthsEditor(connector)
         table = editor.tableWavelengths
         apply = editor.apply_table_wavelength_changes
+
         def read():
             return [wave.value for wave in optic.wavelengths]
 

--- a/tests/gui/test_property_transactions.py
+++ b/tests/gui/test_property_transactions.py
@@ -1,0 +1,73 @@
+"""A whole property-table draft is validated before changing the live model."""
+
+from __future__ import annotations
+
+import pytest
+
+from optiland_gui.optiland_connector import OptilandConnector
+from optiland_gui.system_properties_panel import (
+    ApertureEditor,
+    FieldsEditor,
+    WavelengthsEditor,
+)
+
+
+@pytest.mark.parametrize("kind", ["fields", "wavelengths"])
+def test_later_invalid_row_cannot_silently_mutate_earlier_rows(qapp, kind):
+    connector = OptilandConnector()
+    optic = connector.get_optic()
+    if kind == "fields":
+        optic.fields.add(y=1)
+        editor = FieldsEditor(connector)
+        table = editor.tableFields
+        apply = editor.apply_table_field_changes
+        def read():
+            return [(f.x, f.y, f.vx, f.vy) for f in optic.fields]
+
+        valid = "2"
+    else:
+        optic.wavelengths.add(0.6328, is_primary=False)
+        editor = WavelengthsEditor(connector)
+        table = editor.tableWavelengths
+        apply = editor.apply_table_wavelength_changes
+        def read():
+            return [wave.value for wave in optic.wavelengths]
+
+        valid = "0.6000"
+    try:
+        editor.load_data()
+        before, token = read(), connector.document_state.edit_token
+        table.item(0, 0).setText(valid)
+        table.item(1, 0).setText("invalid")
+        apply()
+        assert read() == before
+        assert connector.document_state.edit_token == token
+        assert not connector.is_modified()
+        table.item(0, 0).setText(valid)
+        commits = []
+        connector.document_state.committed.connect(commits.append)
+        apply()
+        assert read() != before
+        assert connector.document_state.edit_token.revision == token.revision + 1
+        assert len(commits) == 1 and commits[0].affects_optics
+        assert connector.is_modified()
+        apply()
+        assert len(commits) == 1
+    finally:
+        editor.deleteLater()
+
+
+def test_aperture_and_primary_noop_do_not_create_document_edits(qapp):
+    connector = OptilandConnector()
+    aperture = ApertureEditor(connector)
+    wavelengths = WavelengthsEditor(connector)
+    aperture.load_data()
+    wavelengths.load_data()
+    wavelengths.tableWavelengths.setCurrentCell(0, 0)
+    token = connector.document_state.edit_token
+    aperture.apply_aperture_changes()
+    wavelengths.set_primary_wavelength()
+    assert connector.document_state.edit_token == token
+    assert not connector.is_modified()
+    aperture.deleteLater()
+    wavelengths.deleteLater()

--- a/tests/gui/test_surface_service.py
+++ b/tests/gui/test_surface_service.py
@@ -20,6 +20,7 @@ def mock_connector(minimal_optic):
     conn.set_modified.return_value = None
     conn.opticChanged = MagicMock()
     conn.opticChanged.emit.return_value = None
+    conn.notify_change.side_effect = lambda *args, **kwargs: conn.opticChanged.emit()
     # Column constants
     conn.COL_COMMENT = 1
     conn.COL_RADIUS = 2


### PR DESCRIPTION
Fixes #836.

Editing a surface comment or reapplying equivalent polarization settings currently triggers unnecessary optical invalidation and broad editor refreshes. This change classifies document edits, separates optical revisions from complete-document edit ownership, and publishes one canonical refresh for a transaction. External `opticChanged` and `opticLoaded` signals still invalidate conservatively, including reentrant changes from their listeners.

Local edits retain focused drafts, selected surfaces and expanded geometry editors. Field and wavelength Apply validate the entire draft before changing the model. Visible layouts refresh only when their optical revision changes; persistent zoom is honored when a pending scene is presented, while Home explicitly resets the view. Polarization no-op comparison also respects NumPy/Torch scalar precision.

Updated against master `1daf34ca`. The editor integration preserves #818's selection subscription alongside the canonical document-change subscription, replacing the two legacy full-refresh subscriptions. Regression tests cover selection identity after local edits, insertion and deletion, and confirm that selecting a surface does not invalidate optical results.

Validation at `ea259667`:

- 228 tests passed, 4 native-only checks skipped, across the GUI suite and 2D lens-ownership tests. This includes worker requests, stale results, transactions, atomic property updates and NumPy/Torch polarization cases.
- 20 native Windows Qt checks passed, including focused drafts, selection, zoom/Home and rectangle drag; these overlap the main suite.
- The unmodified CI coverage configuration passed the 218-test integration baseline, then 22 tests in the changed modules after the test-only follow-up. Local testing used Python 3.14 on Windows; the full Linux/Python CI matrix runs separately.
- Supplementary GUI patch coverage: 330/331 changed statements (99.70%) and 119/124 changed branch arcs (95.97%). The remaining statement is a scalar property-formatting alternative. Repository CI excludes GUI files, so these supplementary figures are not Codecov coverage claims. Coverage settings and thresholds are unchanged.
- Ruff check/format and full-delta whitespace checks passed. Additional tests verify non-finite and non-positive inputs, stale table drafts, no-op Apply and hidden Sag range updates.
