### PR TITLE
Fix IdealMaterial precision loss in mixed-precision object-NA calculations

### DIFF
--- a/docs/api/api_materials.rst
+++ b/docs/api/api_materials.rst
@@ -107,6 +107,13 @@ track their live parameter arrays; changing a parameter invalidates old results.
 Their calculations convert parameters for the active backend without replacing
 the original arrays, preserving existing Torch parameter identity and gradients.
 
+``IdealMaterial.n`` and ``IdealMaterial.k`` retain the dtype of their stored index
+and extinction coefficient, including for array-valued wavelength queries.
+Changing the default backend precision after creating the material does not
+recast these parameters or their returned values. Conversion still follows the
+active backend and device. This preserves mixed-precision calculations such as
+object-space NA with a float64 material and a Python scalar aperture value.
+
 Each concrete custom material opts into caching by implementing ``_cache_state``.
 An immutable model may return ``()``. A mutable model can use
 ``self._state_key((self.parameter, ...))`` for all numerical state used by its

--- a/optiland/materials/base.py
+++ b/optiland/materials/base.py
@@ -249,10 +249,16 @@ class BaseMaterial(ABC):
         return backend, be.get_precision(), device, gradients, inference
 
     @staticmethod
-    def _as_backend_array(value):
-        """Use live parameters in the active backend without replacing their storage."""
+    def _as_backend_array(value, *, preserve_dtype: bool = False):
+        """Use live parameters in the active backend without replacing their storage.
+
+        Typed parameters can opt out of conversion to the backend's default
+        precision. Untyped values still use that default.
+        """
         if be.get_backend() == "numpy" and hasattr(value, "detach"):
             value = value.detach().cpu().numpy()
+        if preserve_dtype and hasattr(value, "dtype"):
+            return be.asarray(value, dtype=None)
         return be.asarray(value)
 
     @staticmethod

--- a/optiland/materials/ideal.py
+++ b/optiland/materials/ideal.py
@@ -23,6 +23,9 @@ class IdealMaterial(BaseMaterial):
     """Represents an ideal material with a fixed refractive index and extinction
     coefficient for all wavelengths.
 
+    Evaluation preserves each stored parameter's dtype when the backend's default
+    precision changes, while converting to the active backend and device.
+
     Attributes:
         index (float): The refractive index of the material.
         absorp (float): The extinction coefficient of the material.
@@ -56,11 +59,12 @@ class IdealMaterial(BaseMaterial):
             scalar if wavelength is scalar, otherwise an array of the same shape
             as wavelength, filled with the constant refractive index.
         """
+        index = self._as_backend_array(self.index, preserve_dtype=True)[0]
         if be.is_array_like(wavelength) and be.size(wavelength) > 1:
-            # ``be.full_like(w, value)`` reads the value out as a scalar and
-            # detaches it; broadcasting keeps a trainable index attached.
-            return be.ones_like(wavelength) * self._as_backend_array(self.index)[0]
-        return self._as_backend_array(self.index)[0]
+            # Broadcast the parameter itself: multiplying by default-precision
+            # ones can downcast a scalar parameter and lose its precision.
+            return self._broadcast_like(index, wavelength)
+        return index
 
     def _calculate_k(self, wavelength, **kwargs):
         """Returns the extinction coefficient of the material.
@@ -75,11 +79,11 @@ class IdealMaterial(BaseMaterial):
             scalar if wavelength is scalar, otherwise an array of the same shape
             as wavelength, filled with the constant extinction coefficient.
         """
+        absorp = self._as_backend_array(self.absorp, preserve_dtype=True)[0]
         if be.is_array_like(wavelength) and be.size(wavelength) > 1:
-            # Broadcast (rather than full_like) to keep a trainable extinction
-            # coefficient attached to the autograd graph.
-            return be.ones_like(wavelength) * self._as_backend_array(self.absorp)[0]
-        return self._as_backend_array(self.absorp)[0]
+            # A broadcast view preserves both parameter precision and gradients.
+            return self._broadcast_like(absorp, wavelength)
+        return absorp
 
     def to_dict(self):
         """Returns a dictionary representation of the material.

--- a/tests/test_ideal_material_precision.py
+++ b/tests/test_ideal_material_precision.py
@@ -1,0 +1,152 @@
+"""Ideal material parameters retain their precision across execution changes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+import optiland.backend as be
+from optiland.materials import IdealMaterial
+
+from .utils import assert_allclose
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def restore_context(set_test_backend: None) -> Iterator[None]:
+    """Restore each backend's precision and the Torch device after these tests."""
+    initial = be.get_backend()
+    precisions = {}
+    device = None
+    for backend in be.list_available_backends():
+        be.set_backend(backend)
+        precisions[backend] = f"float{be.get_precision()}"
+        if backend == "torch":
+            device = be.get_device()
+    be.set_backend(initial)
+    try:
+        yield
+    finally:
+        for backend, precision in precisions.items():
+            be.set_backend(backend)
+            be.set_precision(precision)
+            if backend == "torch":
+                be.set_device(device)
+        be.set_backend(initial)
+
+
+@pytest.mark.parametrize("property_name,attribute", [("n", "index"), ("k", "absorp")])
+@pytest.mark.parametrize("parameter_precision", ["float32", "float64"])
+@pytest.mark.parametrize(
+    "query_kind", ["scalar", "singleton", "matrix", "uniform", "list"]
+)
+def test_parameter_precision_survives_default_change(
+    restore_context: None,
+    property_name: str,
+    attribute: str,
+    parameter_precision: str,
+    query_kind: str,
+) -> None:
+    """Both n/k keep stored precision on fresh evaluation and on cache hits."""
+    be.set_precision(parameter_precision)
+    material = IdealMaterial(1.50000001, 0.100000001)
+    # Use constants here so repeat lookups exercise the property caches on Torch.
+    material.index = be.asarray([1.50000001])
+    material.absorp = be.asarray([0.100000001])
+    parameter = getattr(material, attribute)
+    expected = be.to_numpy(parameter).copy()[0]
+    evaluate = getattr(material, property_name)
+    evaluate(0.55)
+
+    other_precision = "float32" if parameter_precision == "float64" else "float64"
+    be.set_precision(other_precision)
+    if query_kind == "scalar":
+        query, shape = 0.55, ()
+    elif query_kind == "singleton":
+        query, shape = be.asarray([0.55]), ()
+    elif query_kind == "matrix":
+        query, shape = be.asarray([[0.4, 0.5], [0.6, 0.7]]), (2, 2)
+    elif query_kind == "uniform":
+        query, shape = be.asarray(np.full((32, 64), 0.55)), (32, 64)
+    else:
+        query, shape = [[0.4, 0.5], [0.6, 0.7]], (2, 2)
+
+    for _ in range(2):
+        result = evaluate(query)
+        assert tuple(result.shape) == shape
+        assert result.dtype == parameter.dtype
+        assert_allclose(result, np.full(shape, expected), rtol=0, atol=0)
+        assert getattr(material, attribute) is parameter
+
+
+@pytest.mark.parametrize("property_name,attribute", [("n", "index"), ("k", "absorp")])
+def test_precision_survives_backend_round_trip(
+    restore_context: None, property_name: str, attribute: str
+) -> None:
+    """Backend conversion preserves live storage, precision, and trainable leaves."""
+    if "torch" not in be.list_available_backends():
+        pytest.skip("requires both backends")
+    import torch
+
+    initial = be.get_backend()
+    be.set_precision("float64")
+    material = IdealMaterial(1.50000001, 0.100000001)
+    parameter = getattr(material, attribute)
+    expected = be.to_numpy(parameter).copy()[0]
+    evaluate = getattr(material, property_name)
+    other = "numpy" if initial == "torch" else "torch"
+    for backend in (other, initial):
+        be.set_backend(backend)
+        if backend == "torch":
+            be.set_device("cpu")
+        be.set_precision("float32")
+        for query in (0.55, be.asarray([0.4, 0.6])):
+            for _ in range(2):
+                result = evaluate(query)
+                assert isinstance(result, torch.Tensor) == (backend == "torch")
+                assert be.to_numpy(result).dtype == np.dtype("float64")
+                assert_allclose(result, expected, rtol=0, atol=0)
+                assert getattr(material, attribute) is parameter
+                if initial == backend == "torch":
+                    (gradient,) = torch.autograd.grad(result.sum(), parameter)
+                    assert_allclose(gradient, be.size(result), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("property_name,attribute", [("n", "index"), ("k", "absorp")])
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_trainable_parameter_precision_and_device(
+    restore_context: None, property_name: str, attribute: str, device: str
+) -> None:
+    """Default changes and device transfers keep fresh graphs to the original leaf."""
+    if be.get_backend() != "torch":
+        pytest.skip("Torch gradients")
+    import torch
+
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    be.set_precision("float64")
+    material = IdealMaterial(1.50000001, 0.100000001)
+    parameter = torch.nn.Parameter(getattr(material, attribute).detach().clone())
+    setattr(material, attribute, parameter)
+    expected = be.to_numpy(parameter).copy()[0]
+    evaluate = getattr(material, property_name)
+    be.set_precision("float32")
+    be.set_device(device)
+
+    # A graph-free first lookup must not poison subsequent gradient evaluations.
+    with torch.no_grad():
+        evaluate(0.55)
+    for query in (0.55, be.asarray([[0.4, 0.5], [0.6, 0.7]])):
+        for _ in range(2):
+            result = evaluate(query)
+            assert result.dtype == torch.float64
+            assert result.device.type == device
+            assert_allclose(result, expected, rtol=0, atol=0)
+            result.sum().backward()
+            assert_allclose(parameter.grad, be.size(result), rtol=0, atol=0)
+            parameter.grad = None
+            assert getattr(material, attribute) is parameter


### PR DESCRIPTION
Fixes #832.

Creating an `IdealMaterial` at float64 and then selecting float32 previously downcast its returned index. This rounded valid near-grazing object-NA cones into invalid grazing cones and broke six existing NumPy/Torch regression cases.

Preserve the stored index and extinction-coefficient dtype during IdealMaterial backend/device conversion and wavelength broadcasting. Keep the original parameter storage and Torch gradient graph, retain other material models' conversion policy, and document the precision contract. Add regressions for scalar and array wavelengths, cache hits, backend round trips, and repeated differentiation.

Validation:

- 755 tests passed, 21 skipped across focused materials, apertures, and backends; all six existing failures now pass.
- 86 tests passed, 24 skipped in a fresh process with Torch imports blocked.
- Local patch coverage: **100% (9/9 changed executable lines)** against `cbd5af71`, from 332 passing tests and 20 skips. Coverage configuration and exclusions are unchanged.
- Ruff check and formatting checks pass. CUDA regression cases are included but skipped in the local CPU-only environment.

This follows up on merged #805 and applies independently of #804. The open-PR overlap audit found no competing implementation.
