### PR TITLE
test: restore tests hidden by duplicate definitions

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -198,15 +198,6 @@ class TestCookeTripletEncircledEnergy:
         assert isinstance(ax, Axes)
         plt.close(fig)
 
-    def test_view_encircled_energy_larger_fig(self, set_test_backend, cooke_triplet):
-        encircled_energy = analysis.EncircledEnergy(cooke_triplet)
-        fig, ax = encircled_energy.view(figsize=(20, 10))
-        assert fig is not None
-        assert ax is not None
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
-        plt.close(fig)
-
 
 class TestCookeTripletRayFan:
     def test_ray_fan(self, set_test_backend, cooke_triplet):
@@ -484,24 +475,6 @@ class TestTelescopeTripletDistortion:
     def test_view_distortion(self, set_test_backend, telescope_objective):
         dist = analysis.Distortion(telescope_objective)
         fig, ax = dist.view()
-        assert fig is not None
-        assert ax is not None
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
-        plt.close(fig)
-
-    def test_view_distortion_larger_fig(self, set_test_backend, telescope_objective):
-        dist = analysis.Distortion(telescope_objective)
-        fig, ax = dist.view(figsize=(12.4, 10))
-        assert fig is not None
-        assert ax is not None
-        assert isinstance(fig, Figure)
-        assert isinstance(ax, Axes)
-        plt.close(fig)
-
-    def test_view_distortion_larger_fig(self, set_test_backend, telescope_objective):
-        dist = analysis.Distortion(telescope_objective)
-        fig, ax = dist.view(figsize=(12.4, 10))
         assert fig is not None
         assert ax is not None
         assert isinstance(fig, Figure)
@@ -1561,160 +1534,6 @@ def test_cross_section_plot_helper_out_of_bounds(
 
 
 class TestThroughFocusSpotDiagram:
-    def test_init(self, set_test_backend, cooke_triplet):
-        optic = cooke_triplet
-        delta_focus = 0.05
-        num_steps = 3
-        num_rings = 4
-        distribution = "random"
-        coordinates = "global"
-
-        tf_spot = analysis.ThroughFocusSpotDiagram(
-            optic,
-            delta_focus=delta_focus,
-            num_steps=num_steps,
-            num_rings=num_rings,
-            distribution=distribution,
-            coordinates=coordinates,
-            fields="all",  # explicitly pass to ensure it's resolved
-            wavelengths="all",  # explicitly pass to ensure it's resolved
-        )
-
-        assert tf_spot.delta_focus == delta_focus
-        assert tf_spot.num_steps == num_steps
-        assert tf_spot.num_rings == num_rings
-        assert tf_spot.distribution == distribution
-        assert tf_spot.coordinates == coordinates
-
-        # Check that fields and wavelengths are resolved
-        assert isinstance(tf_spot.fields, list)
-        assert len(tf_spot.fields) > 0
-        assert tf_spot.fields != "all"
-        assert isinstance(tf_spot.wavelengths, list)
-        assert len(tf_spot.wavelengths) > 0
-        assert tf_spot.wavelengths != "all"
-
-        expected_results_len = 2 * num_steps + 1
-        assert len(tf_spot.results) == expected_results_len
-
-        # Check structure of one result item
-        result_item = tf_spot.results[0]  # First focal step
-        assert isinstance(result_item, dict)
-        assert len(result_item.keys()) == 1
-
-        # Key should be the delta_focus value for that step
-        focus_key = list(result_item.keys())[0]
-        expected_focus_key = -num_steps * delta_focus
-        assert_allclose(focus_key, expected_focus_key)
-
-        rms_values_list = list(result_item.values())[0]
-        assert isinstance(rms_values_list, list)
-        assert len(rms_values_list) == len(tf_spot.fields)
-        for rms_val in rms_values_list:
-            # RMS value should be a float or a backend scalar that can be converted
-            assert isinstance(be.to_numpy(rms_val).item(), float)
-
-    def test_image_surface_z_restoration(self, set_test_backend, cooke_triplet):
-        optic = cooke_triplet
-        original_z = optic.image_surface.geometry.cs.z
-
-        # Ensure original_z is a concrete value if it's a backend tensor
-        if hasattr(original_z, "item"):
-            original_z_val = original_z.item()
-        else:
-            original_z_val = float(original_z)
-
-        tf_spot = analysis.ThroughFocusSpotDiagram(optic, delta_focus=0.05, num_steps=1)
-
-        current_z = optic.image_surface.geometry.cs.z
-        if hasattr(current_z, "item"):
-            current_z_val = current_z.item()
-        else:
-            current_z_val = float(current_z)
-
-        assert_allclose(current_z_val, original_z_val)
-
-    def test_analysis_results_content(self, set_test_backend, cooke_triplet):
-        optic = cooke_triplet
-        delta_focus = 0.05
-        num_steps = 1  # Results for -0.05, 0, +0.05
-
-        tf_spot = analysis.ThroughFocusSpotDiagram(
-            optic, delta_focus=delta_focus, num_steps=num_steps
-        )
-
-        assert len(tf_spot.results) == 3
-
-        # Check results for nominal focus (delta_focus = 0)
-        nominal_results_dict = None
-        for res_dict in tf_spot.results:
-            if be.isclose(list(res_dict.keys())[0], 0.0):
-                nominal_results_dict = res_dict
-                break
-
-        assert nominal_results_dict is not None, "Nominal focus results not found."
-        rms_values_at_nominal = list(nominal_results_dict.values())[0]
-
-        # Compare with direct SpotDiagram calculation
-        spot_direct = analysis.SpotDiagram(optic)  # Optic z should be at nominal here
-        rms_direct_all_wl = spot_direct.rms_spot_radius()
-        primary_wl_idx = optic.wavelengths.primary_index
-
-        expected_rms_at_nominal = []
-        for field_idx in range(len(tf_spot.fields)):
-            expected_rms_at_nominal.append(rms_direct_all_wl[field_idx][primary_wl_idx])
-
-        for i in range(len(tf_spot.fields)):
-            assert_allclose(
-                be.to_numpy(rms_values_at_nominal[i]),
-                be.to_numpy(expected_rms_at_nominal[i]),
-            )
-
-        # Check other focal planes for plausibility (positive RMS)
-        for i, res_dict in enumerate(tf_spot.results):
-            # Skip nominal as it's already checked in detail
-            if be.isclose(list(res_dict.keys())[0], 0.0):
-                continue
-
-            rms_list = list(res_dict.values())[0]
-            current_df = list(res_dict.keys())[0]
-            # print(f"Checking delta_f: {current_df}, RMS list: {rms_list}") # For debugging if needed
-            for rms_val in rms_list:
-                rms_float = be.to_numpy(rms_val).item()
-                assert rms_float >= 0.0, (
-                    f"RMS value {rms_float} is negative for delta_focus {current_df}"
-                )
-                assert not be.isnan(rms_val), (
-                    f"RMS value is NaN for delta_focus {current_df}"
-                )
-
-    @patch("builtins.print")
-    def test_view_method(self, mock_print, set_test_backend, cooke_triplet):
-        optic = cooke_triplet
-        tf_spot = analysis.ThroughFocusSpotDiagram(optic, delta_focus=0.1, num_steps=2)
-        tf_spot.view()
-
-        mock_print.assert_called()
-
-        # Check for some expected output patterns
-        # Get all calls to print in a single list of strings
-        print_calls = [args[0] for args, kwargs in mock_print.call_args_list]
-
-        assert any("Through-Focus Spot Diagram Results" in call for call in print_calls)
-        assert any("Delta Focus:" in call for call in print_calls)
-        assert any("Field (" in call for call in print_calls)
-
-        # Check that the number of "Delta Focus:" lines matches num_steps
-        delta_focus_lines = [call for call in print_calls if "Delta Focus:" in call]
-        assert len(delta_focus_lines) == (2 * tf_spot.num_steps + 1)
-
-        # Check that the number of "Field (" lines matches num_fields * num_delta_focus_steps
-        field_lines = [call for call in print_calls if "Field (" in call]
-        expected_field_lines = len(tf_spot.fields) * (2 * tf_spot.num_steps + 1)
-        assert len(field_lines) == expected_field_lines
-
-
-class TestThroughFocusSpotDiagram:
     @pytest.fixture
     def tf_spot(self, set_test_backend):
         """Creates a ThroughFocusSpotDiagram instance after setting backend."""
@@ -1795,6 +1614,26 @@ class TestThroughFocusSpotDiagram:
         assert len(axes) > 0
         assert all(isinstance(ax, Axes) for ax in axes)
         plt.close(fig)
+
+    def test_image_surface_z_restoration(self, set_test_backend, cooke_triplet):
+        optic = cooke_triplet
+        original_z = optic.image_surface.geometry.cs.z
+
+        # Ensure original_z is a concrete value if it's a backend tensor
+        if hasattr(original_z, "item"):
+            original_z_val = original_z.item()
+        else:
+            original_z_val = float(original_z)
+
+        tf_spot = analysis.ThroughFocusSpotDiagram(optic, delta_focus=0.05, num_steps=1)
+
+        current_z = optic.image_surface.geometry.cs.z
+        if hasattr(current_z, "item"):
+            current_z_val = current_z.item()
+        else:
+            current_z_val = float(current_z)
+
+        assert_allclose(current_z_val, original_z_val)
 
 
 def read_zmx_file(file_path, skip_lines, cols=(0, 1)):

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -2920,26 +2920,6 @@ class TestForbesValidation:
                 pytest.skip("Skipping test at u=0 for m>0.")
 
     def test_qnm_values_against_analytical_formula(self, set_test_backend):
-        n, m = 1, 2
-        x = 0.4
-        P_n_m_canonical = 1.5 - x
-        from optiland.geometries.forbes.qpoly import f_q2d, g_q2d
-
-        P_0_m = 0.5
-        f0 = f_q2d(n=0, m=m)
-        Q_0_m_canonical = P_0_m / f0
-        g0 = g_q2d(n=0, m=m)
-        f1 = f_q2d(n=1, m=m)
-        Q_n_m_canonical = (P_n_m_canonical - g0 * Q_0_m_canonical) / f1
-        coeffs_to_test = [0.0] * (n + 1)
-        coeffs_to_test[n] = 1.0
-        from optiland.geometries.forbes.qpoly import clenshaw_q2d
-
-        alphas = clenshaw_q2d(coeffs_to_test, m=m, usq=x)
-        Q_n_m_optiland = 0.5 * alphas[0]
-        assert np.allclose(Q_n_m_optiland, Q_n_m_canonical, atol=1e-9)
-
-    def test_qnm_values_against_analytical_formula(self, set_test_backend):
         """
         Validates that a single Q polynomial from the qpoly implementation matches
         a value calculated directly from the analytical formula derived from the

--- a/tests/test_operand.py
+++ b/tests/test_operand.py
@@ -62,7 +62,7 @@ class TestParaxialOperand:
     def test_magnification(self, set_test_backend, hubble):
         assert_allclose(operand.ParaxialOperand.magnification(hubble), 0.0)
 
-    def test_magnification(self, set_test_backend, hubble):
+    def test_total_track(self, set_test_backend, hubble):
         assert_allclose(operand.ParaxialOperand.total_track(hubble), 6365.20955)
 
 


### PR DESCRIPTION
## Summary

A few test names in `tests/` are defined twice in the same scope. Python keeps only the last definition, so pytest never collects the earlier one. `pyflakes` reports these as `redefinition of unused ...`. They're hidden from lint here because `tests` is in ruff's `exclude`.

| File | Name | What was lost | Change |
|---|---|---|---|
| `test_operand.py` | `TestParaxialOperand.test_magnification` | The second copy asserts `total_track`, so the real magnification test never ran | Rename the second one to `test_total_track` |
| `test_analysis.py` | `class TestThroughFocusSpotDiagram` (x2) | The first class (older API) was never collected | Remove it, but move `test_image_surface_z_restoration` into the live class |
| `test_analysis.py` | `test_view_encircled_energy_larger_fig` (x2), `test_view_distortion_larger_fig` (x3) | Nothing (the copies are byte-identical) | Remove the extra copies |
| `test_geometries.py` | `TestForbesValidation.test_qnm_values_against_analytical_formula` (x2) | Nothing (same assertions, one copy has no comments) | Remove the comment-less copy |

### About the old `TestThroughFocusSpotDiagram`

I ran the shadowed class under a temporary name against current `master`:

- `test_init`, `test_analysis_results_content` and `test_view_method` **fail**. They expect the old API: dict-of-RMS results, a printed `view()`, and an even `num_steps=2`, which is now rejected with `'num_steps' must be an odd integer`. The live class already covers the current behaviour, so these three are dropped.
- `test_image_surface_z_restoration` **passes** and checks something the live class doesn't: the image surface `z` is restored after the through-focus sweep. I kept it and moved it verbatim into the live class.

## Verification

Run locally (numpy backend, `-k "not torch"`, since torch isn't installed in my env):

- `pytest --collect-only`: `test_analysis.py` 83 → 84, `test_operand.py` 86 → 87, `test_geometries.py` 127 → 127
- `pytest tests/test_analysis.py tests/test_operand.py tests/test_geometries.py -k "not torch"`: **286 passed** before, **288 passed** after. The two newly collected tests are `test_total_track` and `test_image_surface_z_restoration`, and both pass.
- `pyflakes` no longer reports any redefinitions in these three files.

The diff only touches tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
