### PR TITLE
fix(geometries): drop nonexistent ForbesGeometry from __all__

### DIFF
--- a/optiland/geometries/__init__.py
+++ b/optiland/geometries/__init__.py
@@ -34,8 +34,6 @@ __all__ = [
     "BiconicGeometry",
     # From chebyshev.py
     "ChebyshevPolynomialGeometry",
-    # From forbes.py
-    "ForbesGeometry",
     # From even_asphere.py
     "EvenAsphere",
     # From newton_raphson.py


### PR DESCRIPTION
## Summary

`optiland/geometries/__init__.py` lists `"ForbesGeometry"` in `__all__`, but that name doesn't exist anywhere in the package. Because of that, star-importing the package fails:

```console
$ python -c "from optiland.geometries import *"
AttributeError: module 'optiland.geometries' has no attribute 'ForbesGeometry'. Did you mean: 'ForbesQ2dGeometry'?
```

This entry was added in #258 as a placeholder next to the real imports and never matched a class. The Forbes classes that do exist (`ForbesQ2dGeometry`, `ForbesQNormalSlopeGeometry`, `ForbesQbfsGeometry`, `ForbesSurfaceConfig`, `ForbesSolverConfig`) are already imported and listed under `# From forbes subpackage`, so this PR just removes the stale entry and its comment. That's `+0/−2`.

Linters don't flag this: ruff and pyflakes don't check that `__all__` entries resolve, and nothing in the test suite does a star-import.

## Verification

- Before: `from optiland.geometries import *` raises the `AttributeError` shown above.
- After: the star-import succeeds, and every remaining `__all__` entry resolves.
- `pytest tests/test_geometries.py -k "not torch"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
